### PR TITLE
feat: add ix to close eata

### DIFF
--- a/e-token-api/src/lib.rs
+++ b/e-token-api/src/lib.rs
@@ -49,4 +49,6 @@ pub mod instruction {
     ///     [0] bump
     ///     [1] MemberFlags bitfield encoded via MemberFlags::to_acl_flag_byte.
     pub const RESET_EPHEMERAL_ATA_PERMISSION: u8 = 9;
+    /// 10 - CloseEphemeralAta: close an empty ephemeral ATA and refund rent to recipient
+    pub const CLOSE_EPHEMERAL_ATA: u8 = 10;
 }

--- a/e-token/src/entrypoint.rs
+++ b/e-token/src/entrypoint.rs
@@ -114,6 +114,12 @@ pub(crate) fn inner_process_instruction(
 
             process_reset_ephemeral_ata_permission(accounts, instruction_data)
         }
+        10 => {
+            #[cfg(feature = "logging")]
+            pinocchio_log::log!("Instruction: CloseEphemeralAta");
+
+            process_close_ephemeral_ata(accounts, instruction_data)
+        }
         196 => {
             #[cfg(feature = "logging")]
             pinocchio_log::log!("Instruction: UndelegationCallback");

--- a/e-token/src/processor/close_ephemeral_ata.rs
+++ b/e-token/src/processor/close_ephemeral_ata.rs
@@ -1,0 +1,72 @@
+use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_unchecked, Initializable};
+use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+
+#[inline(always)]
+pub fn process_close_ephemeral_ata(
+    accounts: &[AccountView],
+    _instruction_data: &[u8],
+) -> ProgramResult {
+    // Expected accounts:
+    // 0. [signer]   Owner of the ephemeral ATA
+    // 1. [writable] Ephemeral ATA account (PDA [owner, mint])
+    // 2. [writable] Recipient account for rent refund
+    let [owner_info, ephemeral_ata_info, recipient_info, ..] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    if !owner_info.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    unsafe {
+        if ephemeral_ata_info
+            .owner()
+            .ne(&ephemeral_spl_api::program::id_address())
+        {
+            return Err(ProgramError::IllegalOwner);
+        }
+    }
+
+    let (mint, lamports_to_refund) = {
+        let ephemeral_ata =
+            unsafe { load_unchecked::<EphemeralAta>(ephemeral_ata_info.borrow_unchecked())? };
+
+        if !ephemeral_ata.is_initialized() {
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        if ephemeral_ata.owner != *owner_info.address() {
+            return Err(ProgramError::IncorrectAuthority);
+        }
+
+        if ephemeral_ata.amount != 0 {
+            return Err(ProgramError::InvalidArgument);
+        }
+
+        #[allow(clippy::clone_on_copy)]
+        let mint = ephemeral_ata.mint.clone();
+        (mint, ephemeral_ata_info.lamports())
+    };
+
+    let (derived_pda, _) = ephemeral_spl_api::Address::find_program_address(
+        &[owner_info.address().as_ref(), mint.as_ref()],
+        &ephemeral_spl_api::program::id_address(),
+    );
+    if derived_pda != *ephemeral_ata_info.address() {
+        return Err(ProgramError::InvalidSeeds);
+    }
+
+    if *recipient_info.address() == *ephemeral_ata_info.address() {
+        return Err(ProgramError::InvalidArgument);
+    }
+
+    let updated_recipient_lamports = recipient_info
+        .lamports()
+        .checked_add(lamports_to_refund)
+        .ok_or(ProgramError::InvalidArgument)?;
+    recipient_info.set_lamports(updated_recipient_lamports);
+    ephemeral_ata_info.set_lamports(0);
+    ephemeral_ata_info.close()?;
+
+    Ok(())
+}

--- a/e-token/src/processor/mod.rs
+++ b/e-token/src/processor/mod.rs
@@ -1,3 +1,4 @@
+pub mod close_ephemeral_ata;
 pub mod create_ephemeral_ata_permission;
 pub mod delegate_ephemeral_ata;
 pub mod delegate_ephemeral_ata_permission;
@@ -10,6 +11,7 @@ pub mod undelegate_ephemeral_ata_permission;
 pub mod undelegation_callback;
 pub mod withdraw_spl_tokens;
 
+pub use close_ephemeral_ata::process_close_ephemeral_ata;
 pub use create_ephemeral_ata_permission::process_create_ephemeral_ata_permission;
 pub use delegate_ephemeral_ata::process_delegate_ephemeral_ata;
 pub use delegate_ephemeral_ata_permission::process_delegate_ephemeral_ata_permission;

--- a/e-token/tests/close_ephemeral_ata.rs
+++ b/e-token/tests/close_ephemeral_ata.rs
@@ -1,0 +1,120 @@
+use ephemeral_spl_api::instruction;
+use ephemeral_spl_api::program::ID;
+use solana_instruction::{AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use {
+    solana_program_test::{tokio, ProgramTest},
+    solana_pubkey::Pubkey,
+    solana_signer::Signer,
+    solana_system_interface::instruction::create_account,
+    solana_transaction::Transaction,
+};
+
+pub const PROGRAM: Pubkey = Pubkey::new_from_array(ID);
+
+#[tokio::test]
+async fn close_ephemeral_ata_refunds_rent_and_closes_account() {
+    let context = ProgramTest::new("ephemeral_token_program", PROGRAM, None)
+        .start_with_context()
+        .await;
+
+    let payer = context.payer.pubkey();
+    let user = payer;
+    let mint = Pubkey::new_unique();
+
+    let (ephemeral_ata, bump) =
+        Pubkey::find_program_address(&[user.as_ref(), mint.as_ref()], &PROGRAM);
+
+    let recipient_kp = Keypair::new();
+    let recipient = recipient_kp.pubkey();
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let ix_create_recipient = create_account(
+        &payer,
+        &recipient,
+        rent.minimum_balance(0).max(1),
+        0,
+        &solana_system_interface::program::ID,
+    );
+
+    let ix_init = Instruction {
+        program_id: PROGRAM,
+        accounts: vec![
+            AccountMeta::new(ephemeral_ata, false),
+            AccountMeta::new_readonly(payer, false),
+            AccountMeta::new_readonly(user, false),
+            AccountMeta::new_readonly(mint, false),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+        ],
+        data: vec![instruction::INITIALIZE_EPHEMERAL_ATA, bump],
+    };
+
+    let tx_init = Transaction::new_signed_with_payer(
+        &[ix_create_recipient, ix_init],
+        Some(&payer),
+        &[&context.payer, &recipient_kp],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(tx_init)
+        .await
+        .unwrap();
+
+    let recipient_before = context
+        .banks_client
+        .get_account(recipient)
+        .await
+        .unwrap()
+        .expect("recipient account should exist");
+    let recipient_before_lamports = recipient_before.lamports;
+
+    let ephemeral_ata_before = context
+        .banks_client
+        .get_account(ephemeral_ata)
+        .await
+        .unwrap()
+        .expect("ephemeral ATA should exist");
+    let ephemeral_ata_lamports = ephemeral_ata_before.lamports;
+    assert!(ephemeral_ata_lamports > 0);
+
+    let ix_close = Instruction {
+        program_id: PROGRAM,
+        accounts: vec![
+            AccountMeta::new_readonly(payer, true),
+            AccountMeta::new(ephemeral_ata, false),
+            AccountMeta::new(recipient, false),
+        ],
+        data: vec![instruction::CLOSE_EPHEMERAL_ATA],
+    };
+
+    let tx_close = Transaction::new_signed_with_payer(
+        &[ix_close],
+        Some(&payer),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(tx_close)
+        .await
+        .unwrap();
+
+    let recipient_after = context
+        .banks_client
+        .get_account(recipient)
+        .await
+        .unwrap()
+        .expect("recipient account should still exist");
+    assert_eq!(
+        recipient_after.lamports,
+        recipient_before_lamports + ephemeral_ata_lamports
+    );
+
+    let ephemeral_ata_after = context
+        .banks_client
+        .get_account(ephemeral_ata)
+        .await
+        .unwrap();
+    assert!(ephemeral_ata_after.is_none());
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for closing ephemeral token accounts with lamport refunds to designated recipients. Includes validation for account ownership, signer authorization, and address verification.

* **Tests**
  * Added comprehensive test suite for ephemeral token account closure functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->