### PR TITLE
feat: add ix to close eata to idl

### DIFF
--- a/idl/ephemeral_spl_token.json
+++ b/idl/ephemeral_spl_token.json
@@ -512,6 +512,32 @@
       ]
     },
     {
+      "name": "closeEphemeralAta",
+      "discriminator": [10],
+      "docs": [
+        "Closes an empty ephemeral ATA and refunds its rent to a recipient account.",
+        "Only the owner of the ephemeral ATA can close it."
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "signer": true,
+          "docs": ["The owner of the ephemeral ATA (must sign)"]
+        },
+        {
+          "name": "ephemeralAta",
+          "writable": true,
+          "docs": ["The ephemeral ATA to close (must have amount = 0)"]
+        },
+        {
+          "name": "recipient",
+          "writable": true,
+          "docs": ["The recipient account for the reclaimed rent lamports"]
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "undelegationCallback",
       "discriminator": [196],
       "docs": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to close empty ephemeral token accounts and reclaim rent deposits. Account owners can now close zero-balance ephemeral accounts with rent refunds transferred to a designated recipient account. Owner authorization is required for all closures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->