### PR TITLE
fix: support legacy eata snapshots in shuttle cleanup

### DIFF
--- a/e-token-api/src/state/ephemeral_ata.rs
+++ b/e-token-api/src/state/ephemeral_ata.rs
@@ -1,6 +1,8 @@
-use pinocchio::Address;
+use pinocchio::{error::ProgramError, Address};
 
-use super::{Initializable, RawType};
+use super::{load, load_mut_unchecked, load_unchecked, Initializable, RawType};
+
+const LEGACY_EPHEMERAL_ATA_LEN: usize = 72;
 
 /// Internal representation of a token account data.
 #[repr(C)]
@@ -25,4 +27,108 @@ impl Initializable for EphemeralAta {
     fn is_initialized(&self) -> bool {
         self.mint != Address::default()
     }
+}
+
+// Temporary compatibility shim for legacy 72-byte EphemeralAta accounts.
+// Some undelegation flows can still restore old snapshots without the stored bump.
+// Keep it self-contained here so it can be removed cleanly once those snapshots are gone.
+#[repr(C)]
+struct LegacyEphemeralAta {
+    owner: Address,
+    mint: Address,
+    amount: u64,
+}
+
+impl RawType for LegacyEphemeralAta {
+    const LEN: usize = LEGACY_EPHEMERAL_ATA_LEN;
+}
+
+enum EphemeralAtaCompatMutInner<'a> {
+    Current(&'a mut EphemeralAta),
+    Legacy(&'a mut LegacyEphemeralAta),
+}
+
+pub struct EphemeralAtaCompatMut<'a>(EphemeralAtaCompatMutInner<'a>);
+
+impl EphemeralAtaCompatMut<'_> {
+    #[inline(always)]
+    pub fn owner(&self) -> &Address {
+        match &self.0 {
+            EphemeralAtaCompatMutInner::Current(ephemeral_ata) => &ephemeral_ata.owner,
+            EphemeralAtaCompatMutInner::Legacy(ephemeral_ata) => &ephemeral_ata.owner,
+        }
+    }
+
+    #[inline(always)]
+    pub fn mint(&self) -> &Address {
+        match &self.0 {
+            EphemeralAtaCompatMutInner::Current(ephemeral_ata) => &ephemeral_ata.mint,
+            EphemeralAtaCompatMutInner::Legacy(ephemeral_ata) => &ephemeral_ata.mint,
+        }
+    }
+
+    #[inline(always)]
+    pub fn amount(&self) -> u64 {
+        match &self.0 {
+            EphemeralAtaCompatMutInner::Current(ephemeral_ata) => ephemeral_ata.amount,
+            EphemeralAtaCompatMutInner::Legacy(ephemeral_ata) => ephemeral_ata.amount,
+        }
+    }
+
+    #[inline(always)]
+    pub fn set_amount(&mut self, amount: u64) {
+        match &mut self.0 {
+            EphemeralAtaCompatMutInner::Current(ephemeral_ata) => ephemeral_ata.amount = amount,
+            EphemeralAtaCompatMutInner::Legacy(ephemeral_ata) => ephemeral_ata.amount = amount,
+        }
+    }
+}
+
+#[inline(always)]
+pub fn read_ephemeral_ata_compat(bytes: &[u8]) -> Result<(Address, Address, u64), ProgramError> {
+    if bytes.len() == EphemeralAta::LEN {
+        let ephemeral_ata = unsafe { load::<EphemeralAta>(bytes)? };
+        #[allow(clippy::clone_on_copy)]
+        let owner = ephemeral_ata.owner.clone();
+        #[allow(clippy::clone_on_copy)]
+        let mint = ephemeral_ata.mint.clone();
+        return Ok((owner, mint, ephemeral_ata.amount));
+    }
+
+    if bytes.len() == LEGACY_EPHEMERAL_ATA_LEN {
+        let ephemeral_ata = unsafe { load_unchecked::<LegacyEphemeralAta>(bytes)? };
+        if ephemeral_ata.mint == Address::default() {
+            return Err(ProgramError::UninitializedAccount);
+        }
+        #[allow(clippy::clone_on_copy)]
+        let owner = ephemeral_ata.owner.clone();
+        #[allow(clippy::clone_on_copy)]
+        let mint = ephemeral_ata.mint.clone();
+        return Ok((owner, mint, ephemeral_ata.amount));
+    }
+
+    Err(ProgramError::InvalidAccountData)
+}
+
+#[inline(always)]
+pub fn load_ephemeral_ata_compat_mut(
+    bytes: &mut [u8],
+) -> Result<EphemeralAtaCompatMut<'_>, ProgramError> {
+    if bytes.len() == EphemeralAta::LEN {
+        return Ok(EphemeralAtaCompatMut(
+            EphemeralAtaCompatMutInner::Current(unsafe {
+                load_mut_unchecked::<EphemeralAta>(bytes)?
+            }),
+        ));
+    }
+
+    if bytes.len() == LEGACY_EPHEMERAL_ATA_LEN {
+        return Ok(EphemeralAtaCompatMut(
+            EphemeralAtaCompatMutInner::Legacy(unsafe {
+                load_mut_unchecked::<LegacyEphemeralAta>(bytes)?
+            }),
+        ));
+    }
+
+    Err(ProgramError::InvalidAccountData)
 }

--- a/e-token/src/processor/close_shuttle_ata_intent.rs
+++ b/e-token/src/processor/close_shuttle_ata_intent.rs
@@ -1,6 +1,7 @@
 use crate::processor::withdraw_spl_tokens::withdraw_ephemeral_ata_tokens;
 use ephemeral_spl_api::state::{
-    ephemeral_ata::EphemeralAta, load, shuttle_ephemeral_ata::ShuttleMetadata,
+    ephemeral_ata::read_ephemeral_ata_compat,
+    load, shuttle_ephemeral_ata::ShuttleMetadata,
 };
 use pinocchio::cpi::{Seed, Signer};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
@@ -171,20 +172,18 @@ pub fn process_close_shuttle_ata_intent(
             .ok_or(ProgramError::InvalidAccountData)?;
         let (mint, shuttle_ephemeral_amount) = {
             let shuttle_ephemeral_ata_data = shuttle_ephemeral_ata_info.try_borrow()?;
-            let shuttle_ephemeral_ata =
-                unsafe { load::<EphemeralAta>(&shuttle_ephemeral_ata_data) }.map_err(|err| {
+            let (ephemeral_owner, mint, amount) =
+                read_ephemeral_ata_compat(&shuttle_ephemeral_ata_data).map_err(|err| {
                     if err == ProgramError::UninitializedAccount {
                         ProgramError::InvalidAccountData
                     } else {
                         err
                     }
                 })?;
-            if shuttle_ephemeral_ata.owner != *shuttle_info.address() {
+            if ephemeral_owner != *shuttle_info.address() {
                 return Err(ProgramError::InvalidAccountData);
             }
-            #[allow(clippy::clone_on_copy)]
-            let mint = shuttle_ephemeral_ata.mint.clone();
-            (mint, shuttle_ephemeral_ata.amount)
+            (mint, amount)
         };
 
         if shuttle_ephemeral_amount != 0 {

--- a/e-token/src/processor/withdraw_spl_tokens.rs
+++ b/e-token/src/processor/withdraw_spl_tokens.rs
@@ -3,7 +3,8 @@ use ephemeral_spl_api::error::EphemeralSplError;
 use pinocchio::cpi::{Seed, Signer};
 use {
     ephemeral_spl_api::state::{
-        ephemeral_ata::EphemeralAta, global_vault::GlobalVault, load_mut_unchecked, load_unchecked,
+        ephemeral_ata::load_ephemeral_ata_compat_mut,
+        global_vault::GlobalVault, load_unchecked,
     },
     pinocchio::{error::ProgramError, AccountView, ProgramResult},
     pinocchio_token_2022::state::Mint,
@@ -70,8 +71,8 @@ pub(crate) fn withdraw_ephemeral_ata_tokens(
             return Err(ProgramError::IllegalOwner);
         }
     }
-    let ephemeral_ata =
-        unsafe { load_mut_unchecked::<EphemeralAta>(ephemeral_ata_info.borrow_unchecked_mut())? };
+    let mut ephemeral_ata =
+        load_ephemeral_ata_compat_mut(unsafe { ephemeral_ata_info.borrow_unchecked_mut() })?;
 
     // Validate vault ownership before reading raw data.
     unsafe {
@@ -87,9 +88,9 @@ pub(crate) fn withdraw_ephemeral_ata_tokens(
     let vault = unsafe { load_unchecked::<GlobalVault>(vault_info.borrow_unchecked())? };
 
     // Check eata consistency
-    if ephemeral_ata.mint != *mint_info.address()
+    if ephemeral_ata.mint() != mint_info.address()
         || vault.mint != *mint_info.address()
-        || ephemeral_ata.owner != *owner.address()
+        || ephemeral_ata.owner() != owner.address()
         || vault.token_account != *vault_source_token_acc.address()
     {
         return Err(EphemeralSplError::EphemeralAtaMismatch.into());
@@ -125,10 +126,11 @@ pub(crate) fn withdraw_ephemeral_ata_tokens(
     .invoke_signed(&[signer])?;
 
     // Safely decrease the amount in the EphemeralAta
-    ephemeral_ata.amount = ephemeral_ata
-        .amount
+    let updated_amount = ephemeral_ata
+        .amount()
         .checked_sub(amount)
         .ok_or(ProgramError::InvalidArgument)?;
+    ephemeral_ata.set_amount(updated_amount);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Temporary compatibility for legacy 72-byte EphemeralAta snapshots restored by undelegation.

## Release Notes

* **Bug Fixes**
  * Improved handling of legacy account formats to prevent processing errors and ensure compatibility with existing data structures.

* **Improvements**
  * Enhanced account compatibility layer to support both current and legacy account layouts seamlessly.
  * Refined account data operations for greater consistency and robustness across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->