### PR TITLE
feat: homogenize checks

### DIFF
--- a/e-token-api/src/lib.rs
+++ b/e-token-api/src/lib.rs
@@ -12,7 +12,7 @@ pub mod program {
 
     /// Returns the program ID as an Address
     #[inline(always)]
-    pub fn id_address() -> pinocchio::Address {
+    pub const fn id_address() -> pinocchio::Address {
         pinocchio::Address::new_from_array(ID)
     }
 }

--- a/e-token-api/src/state/ephemeral_ata.rs
+++ b/e-token-api/src/state/ephemeral_ata.rs
@@ -1,6 +1,8 @@
 use pinocchio::{error::ProgramError, Address};
 
-use super::{load, load_mut_unchecked, load_unchecked, Initializable, RawType};
+use crate::state::load_mut;
+
+use super::{load, load_initialized, Initializable, RawType};
 
 const LEGACY_EPHEMERAL_ATA_LEN: usize = 72;
 
@@ -87,7 +89,7 @@ impl EphemeralAtaCompatMut<'_> {
 #[inline(always)]
 pub fn read_ephemeral_ata_compat(bytes: &[u8]) -> Result<(Address, Address, u64), ProgramError> {
     if bytes.len() == EphemeralAta::LEN {
-        let ephemeral_ata = unsafe { load::<EphemeralAta>(bytes)? };
+        let ephemeral_ata = load_initialized::<EphemeralAta>(bytes)?;
         #[allow(clippy::clone_on_copy)]
         let owner = ephemeral_ata.owner.clone();
         #[allow(clippy::clone_on_copy)]
@@ -96,7 +98,7 @@ pub fn read_ephemeral_ata_compat(bytes: &[u8]) -> Result<(Address, Address, u64)
     }
 
     if bytes.len() == LEGACY_EPHEMERAL_ATA_LEN {
-        let ephemeral_ata = unsafe { load_unchecked::<LegacyEphemeralAta>(bytes)? };
+        let ephemeral_ata = load::<LegacyEphemeralAta>(bytes)?;
         if ephemeral_ata.mint == Address::default() {
             return Err(ProgramError::UninitializedAccount);
         }
@@ -116,13 +118,13 @@ pub fn load_ephemeral_ata_compat_mut(
 ) -> Result<EphemeralAtaCompatMut<'_>, ProgramError> {
     if bytes.len() == EphemeralAta::LEN {
         return Ok(EphemeralAtaCompatMut(EphemeralAtaCompatMutInner::Current(
-            unsafe { load_mut_unchecked::<EphemeralAta>(bytes)? },
+            load_mut::<EphemeralAta>(bytes)?,
         )));
     }
 
     if bytes.len() == LEGACY_EPHEMERAL_ATA_LEN {
         return Ok(EphemeralAtaCompatMut(EphemeralAtaCompatMutInner::Legacy(
-            unsafe { load_mut_unchecked::<LegacyEphemeralAta>(bytes)? },
+            load_mut::<LegacyEphemeralAta>(bytes)?,
         )));
     }
 

--- a/e-token-api/src/state/mod.rs
+++ b/e-token-api/src/state/mod.rs
@@ -20,8 +20,8 @@ pub trait Initializable {
 /// a valid representation of `T`. The length and initialization checks below do
 /// not prove either property.
 #[inline(always)]
-pub unsafe fn load<T: Initializable + RawType>(bytes: &[u8]) -> Result<&T, ProgramError> {
-    load_unchecked(bytes).and_then(|t: &T| {
+pub fn load_initialized<T: Initializable + RawType>(bytes: &[u8]) -> Result<&T, ProgramError> {
+    load(bytes).and_then(|t: &T| {
         // checks if the data is initialized
         if t.is_initialized() {
             Ok(t)
@@ -41,11 +41,11 @@ pub unsafe fn load<T: Initializable + RawType>(bytes: &[u8]) -> Result<&T, Progr
 /// a valid representation of `T`. The length check below does not prove either
 /// property.
 #[inline(always)]
-pub unsafe fn load_unchecked<T: RawType>(bytes: &[u8]) -> Result<&T, ProgramError> {
+pub fn load<T: RawType>(bytes: &[u8]) -> Result<&T, ProgramError> {
     if bytes.len() != T::LEN {
         return Err(ProgramError::InvalidAccountData);
     }
-    Ok(&*(bytes.as_ptr() as *const T))
+    Ok(unsafe { &*(bytes.as_ptr() as *const T) })
 }
 
 /// Return a mutable reference for an initialized `T` from the given bytes.
@@ -56,10 +56,10 @@ pub unsafe fn load_unchecked<T: RawType>(bytes: &[u8]) -> Result<&T, ProgramErro
 /// a valid representation of `T`. The length and initialization checks below do
 /// not prove either property.
 #[inline(always)]
-pub unsafe fn load_mut<T: Initializable + RawType>(
+pub fn load_mut_initialized<T: Initializable + RawType>(
     bytes: &mut [u8],
 ) -> Result<&mut T, ProgramError> {
-    load_mut_unchecked(bytes).and_then(|t: &mut T| {
+    load_mut(bytes).and_then(|t: &mut T| {
         // checks if the data is initialized
         if t.is_initialized() {
             Ok(t)
@@ -67,6 +67,23 @@ pub unsafe fn load_mut<T: Initializable + RawType>(
             Err(ProgramError::UninitializedAccount)
         }
     })
+}
+
+/// Return a mutable `T` reference from the given bytes.
+///
+/// This function does not check if the data is initialized.
+///
+/// # Safety
+///
+/// The caller must ensure that `bytes` is properly aligned for `T` and contains
+/// a valid representation of `T`. The length check below does not prove either
+/// property.
+#[inline(always)]
+pub fn load_mut<T: RawType>(bytes: &mut [u8]) -> Result<&mut T, ProgramError> {
+    if bytes.len() != T::LEN {
+        return Err(ProgramError::InvalidAccountData);
+    }
+    Ok(unsafe { &mut *(bytes.as_mut_ptr() as *mut T) })
 }
 
 /// Type alias for fields represented as `COption`.
@@ -81,21 +98,4 @@ pub trait RawType {
     ///
     /// This must be equal to the size of each individual field in the type.
     const LEN: usize;
-}
-
-/// Return a mutable `T` reference from the given bytes.
-///
-/// This function does not check if the data is initialized.
-///
-/// # Safety
-///
-/// The caller must ensure that `bytes` is properly aligned for `T` and contains
-/// a valid representation of `T`. The length check below does not prove either
-/// property.
-#[inline(always)]
-pub unsafe fn load_mut_unchecked<T: RawType>(bytes: &mut [u8]) -> Result<&mut T, ProgramError> {
-    if bytes.len() != T::LEN {
-        return Err(ProgramError::InvalidAccountData);
-    }
-    Ok(&mut *(bytes.as_mut_ptr() as *mut T))
 }

--- a/e-token/src/processor/close_ephemeral_ata.rs
+++ b/e-token/src/processor/close_ephemeral_ata.rs
@@ -1,5 +1,7 @@
-use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_unchecked, Initializable};
+use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+
+use crate::{assert_owner, assert_signer};
 
 #[inline(always)]
 pub fn process_close_ephemeral_ata(
@@ -14,31 +16,18 @@ pub fn process_close_ephemeral_ata(
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    if !owner_info.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
-
-    unsafe {
-        if ephemeral_ata_info
-            .owner()
-            .ne(&ephemeral_spl_api::program::id_address())
-        {
-            return Err(ProgramError::IllegalOwner);
-        }
-    }
+    assert_signer!(owner_info);
+    assert_owner!(
+        ephemeral_ata_info,
+        &ephemeral_spl_api::program::id_address()
+    );
 
     let (mint, lamports_to_refund) = {
         let ephemeral_ata =
-            unsafe { load_unchecked::<EphemeralAta>(ephemeral_ata_info.borrow_unchecked())? };
-
-        if !ephemeral_ata.is_initialized() {
-            return Err(ProgramError::InvalidAccountData);
-        }
-
+            load_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked() })?;
         if ephemeral_ata.owner != *owner_info.address() {
             return Err(ProgramError::IncorrectAuthority);
         }
-
         if ephemeral_ata.amount != 0 {
             return Err(ProgramError::InvalidArgument);
         }

--- a/e-token/src/processor/close_shuttle_ata_intent.rs
+++ b/e-token/src/processor/close_shuttle_ata_intent.rs
@@ -1,3 +1,4 @@
+use crate::processor::utils::validate_token_account;
 use crate::processor::withdraw_spl_tokens::withdraw_ephemeral_ata_tokens;
 use crate::{assert_owner, assert_signer};
 use ephemeral_spl_api::state::{
@@ -7,7 +8,6 @@ use ephemeral_spl_api::state::{
 use pinocchio::cpi::{Seed, Signer};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 use pinocchio_token_2022::instructions::CloseAccount;
-use pinocchio_token_2022::state::TokenAccount;
 const DLP_EPHEMERAL_BALANCE_TAG: &[u8] = b"balance";
 
 /// Post-undelegate handler that first withdraws any remaining shuttle EATA
@@ -98,16 +98,13 @@ pub fn process_close_shuttle_ata_intent(
             .as_ref()
             .ok_or(ProgramError::InvalidAccountData)?;
         let (mint, shuttle_wallet_amount) = {
-            let shuttle_wallet =
-                unsafe { TokenAccount::from_account_view_unchecked(shuttle_wallet_ata_info)? };
-            if !shuttle_wallet.is_initialized() {
-                return Err(ProgramError::UninitializedAccount);
-            }
-            if shuttle_wallet.owner() != shuttle_info.address() {
-                return Err(ProgramError::InvalidAccountData);
-            }
-            let mint = *shuttle_wallet.mint();
-            (mint, shuttle_wallet.amount())
+            let token_account = validate_token_account(
+                shuttle_wallet_ata_info,
+                &mint_info.address(),
+                Some(shuttle_info.address()),
+                Some(token_program_info.address()),
+            )?;
+            (token_account.mint(), token_account.amount())
         };
 
         if shuttle_wallet_amount != 0 {

--- a/e-token/src/processor/close_shuttle_ata_intent.rs
+++ b/e-token/src/processor/close_shuttle_ata_intent.rs
@@ -1,6 +1,8 @@
 use crate::processor::withdraw_spl_tokens::withdraw_ephemeral_ata_tokens;
+use crate::{assert_owner, assert_signer};
 use ephemeral_spl_api::state::{
-    ephemeral_ata::read_ephemeral_ata_compat, load, shuttle_ephemeral_ata::ShuttleMetadata,
+    ephemeral_ata::read_ephemeral_ata_compat, load_initialized,
+    shuttle_ephemeral_ata::ShuttleMetadata,
 };
 use pinocchio::cpi::{Seed, Signer};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
@@ -52,9 +54,7 @@ pub fn process_close_shuttle_ata_intent(
     let escrow_authority = &accounts[accounts.len() - 2];
     let escrow_signer = &accounts[accounts.len() - 1];
 
-    if !escrow_signer.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
+    assert_signer!(escrow_signer);
 
     let escrow_index_seed = [*escrow_index];
     let (expected_escrow, _) = ephemeral_spl_api::Address::find_program_address(
@@ -76,17 +76,10 @@ pub fn process_close_shuttle_ata_intent(
     let mut shuttle_id = 0u32;
     let mut shuttle_owner_opt = None;
     if shuttle_present {
-        if !shuttle_info.owned_by(&ephemeral_spl_api::program::id_address()) {
-            return Err(ProgramError::IllegalOwner);
-        }
-        let shuttle_data = shuttle_info.try_borrow()?;
-        let shuttle = unsafe { load::<ShuttleMetadata>(&shuttle_data) }.map_err(|err| {
-            if err == ProgramError::UninitializedAccount {
-                ProgramError::InvalidAccountData
-            } else {
-                err
-            }
-        })?;
+        assert_owner!(shuttle_info, &ephemeral_spl_api::program::id_address());
+
+        let shuttle =
+            load_initialized::<ShuttleMetadata>(unsafe { shuttle_info.borrow_unchecked() })?;
         if shuttle.payer != *rent_reimbursement_info.address() {
             return Err(ProgramError::IncorrectAuthority);
         }
@@ -96,9 +89,7 @@ pub fn process_close_shuttle_ata_intent(
     }
 
     if shuttle_wallet_present {
-        if !shuttle_wallet_ata_info.owned_by(token_program_info.address()) {
-            return Err(ProgramError::IllegalOwner);
-        }
+        assert_owner!(shuttle_wallet_ata_info, token_program_info.address());
         if !shuttle_present {
             return Err(ProgramError::InvalidAccountData);
         }
@@ -107,12 +98,8 @@ pub fn process_close_shuttle_ata_intent(
             .as_ref()
             .ok_or(ProgramError::InvalidAccountData)?;
         let (mint, shuttle_wallet_amount) = {
-            let shuttle_wallet_data = shuttle_wallet_ata_info.try_borrow()?;
-            if shuttle_wallet_data.len() < TokenAccount::BASE_LEN {
-                return Err(ProgramError::InvalidAccountData);
-            }
             let shuttle_wallet =
-                unsafe { TokenAccount::from_bytes_unchecked(&shuttle_wallet_data) };
+                unsafe { TokenAccount::from_account_view_unchecked(shuttle_wallet_ata_info)? };
             if !shuttle_wallet.is_initialized() {
                 return Err(ProgramError::UninitializedAccount);
             }
@@ -159,9 +146,10 @@ pub fn process_close_shuttle_ata_intent(
     }
 
     if shuttle_ephemeral_present {
-        if !shuttle_ephemeral_ata_info.owned_by(&ephemeral_spl_api::program::id_address()) {
-            return Err(ProgramError::IllegalOwner);
-        }
+        assert_owner!(
+            shuttle_ephemeral_ata_info,
+            &ephemeral_spl_api::program::id_address()
+        );
         if !shuttle_present {
             return Err(ProgramError::InvalidAccountData);
         }

--- a/e-token/src/processor/create_ephemeral_ata_permission.rs
+++ b/e-token/src/processor/create_ephemeral_ata_permission.rs
@@ -5,8 +5,10 @@ use ephemeral_rollups_pinocchio::acl::{
     pda::permission_pda_from_permissioned_account,
     types::{Member, MemberFlags, MembersArgs},
 };
-use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_unchecked, Initializable};
+use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+
+use crate::assert_signer;
 
 #[inline(always)]
 pub fn process_create_ephemeral_ata_permission(
@@ -31,20 +33,15 @@ pub fn process_create_ephemeral_ata_permission(
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    if !payer_info.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
+    assert_signer!(payer_info);
 
     if *permission_program.address() != PERMISSION_PROGRAM_ID {
         return Err(ProgramError::InvalidAccountData);
     }
 
     let ephemeral_ata =
-        unsafe { load_unchecked::<EphemeralAta>(ephemeral_ata_info.borrow_unchecked())? };
+        load_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked() })?;
 
-    if !ephemeral_ata.is_initialized() {
-        return Err(ProgramError::InvalidAccountData);
-    }
     let flag_byte = args.flag_byte();
 
     // Valid in 2 cases:

--- a/e-token/src/processor/delegate_ephemeral_ata.rs
+++ b/e-token/src/processor/delegate_ephemeral_ata.rs
@@ -32,7 +32,7 @@ pub fn process_delegate_ephemeral_ata(
 
     // Load Ephemeral ATA account
     let ephemeral_ata =
-        load_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked_mut() })?;
+        load_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked() })?;
 
     let config = DelegateConfig {
         validator: args.validator().map(Address::new_from_array),

--- a/e-token/src/processor/delegate_ephemeral_ata.rs
+++ b/e-token/src/processor/delegate_ephemeral_ata.rs
@@ -1,7 +1,6 @@
 use ephemeral_rollups_pinocchio::instruction::DelegateAccountCpiBuilder;
 use ephemeral_rollups_pinocchio::types::DelegateConfig;
-use ephemeral_spl_api::state::ephemeral_ata::EphemeralAta;
-use ephemeral_spl_api::state::load_mut_unchecked;
+use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
 
 pub fn process_delegate_ephemeral_ata(
@@ -33,7 +32,7 @@ pub fn process_delegate_ephemeral_ata(
 
     // Load Ephemeral ATA account
     let ephemeral_ata =
-        unsafe { load_mut_unchecked::<EphemeralAta>(ephemeral_ata_info.borrow_unchecked_mut())? };
+        load_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked_mut() })?;
 
     let config = DelegateConfig {
         validator: args.validator().map(Address::new_from_array),

--- a/e-token/src/processor/delegate_ephemeral_ata_permission.rs
+++ b/e-token/src/processor/delegate_ephemeral_ata_permission.rs
@@ -2,12 +2,14 @@ use ephemeral_rollups_pinocchio::acl::{
     consts::PERMISSION_PROGRAM_ID, instruction::DelegatePermissionCpiBuilder,
     pda::permission_pda_from_permissioned_account,
 };
-use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_unchecked, Initializable};
+use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
 use pinocchio::{
     cpi::{Seed, Signer},
     error::ProgramError,
     AccountView, ProgramResult,
 };
+
+use crate::assert_signer;
 
 #[inline(always)]
 pub fn process_delegate_ephemeral_ata_permission(
@@ -32,9 +34,7 @@ pub fn process_delegate_ephemeral_ata_permission(
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    if !payer_info.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
+    assert_signer!(payer_info);
 
     if *permission_program.address() != PERMISSION_PROGRAM_ID {
         return Err(ProgramError::InvalidAccountData);
@@ -47,11 +47,7 @@ pub fn process_delegate_ephemeral_ata_permission(
     }
 
     let ephemeral_ata =
-        unsafe { load_unchecked::<EphemeralAta>(ephemeral_ata_info.borrow_unchecked())? };
-
-    if !ephemeral_ata.is_initialized() {
-        return Err(ProgramError::InvalidAccountData);
-    }
+        load_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked() })?;
 
     let expected_permission =
         permission_pda_from_permissioned_account(ephemeral_ata_info.address());

--- a/e-token/src/processor/delegate_shuttle_ephemeral_ata.rs
+++ b/e-token/src/processor/delegate_shuttle_ephemeral_ata.rs
@@ -36,7 +36,7 @@ pub fn process_delegate_shuttle_ephemeral_ata(
 
     assert_owner!(shuttle_info, &ephemeral_spl_api::program::id_address());
 
-    // Check initialization
+    // Loading the account to check if the shuttle is correctly initialized
     load_initialized::<ShuttleMetadata>(unsafe { shuttle_info.borrow_unchecked() })?;
 
     assert_owner!(

--- a/e-token/src/processor/delegate_shuttle_ephemeral_ata.rs
+++ b/e-token/src/processor/delegate_shuttle_ephemeral_ata.rs
@@ -1,10 +1,11 @@
 use ephemeral_rollups_pinocchio::instruction::DelegateAccountCpiBuilder;
 use ephemeral_rollups_pinocchio::types::DelegateConfig;
 use ephemeral_spl_api::state::{
-    ephemeral_ata::EphemeralAta, load_unchecked, shuttle_ephemeral_ata::ShuttleMetadata,
-    Initializable,
+    ephemeral_ata::EphemeralAta, load_initialized, shuttle_ephemeral_ata::ShuttleMetadata,
 };
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
+
+use crate::assert_owner;
 
 pub fn process_delegate_shuttle_ephemeral_ata(
     accounts: &[AccountView],
@@ -33,35 +34,19 @@ pub fn process_delegate_shuttle_ephemeral_ata(
         return Ok(());
     }
 
-    unsafe {
-        if shuttle_info
-            .owner()
-            .ne(&ephemeral_spl_api::program::id_address())
-        {
-            return Err(ProgramError::IllegalOwner);
-        }
-    }
+    assert_owner!(shuttle_info, &ephemeral_spl_api::program::id_address());
 
-    let shuttle = unsafe { load_unchecked::<ShuttleMetadata>(shuttle_info.borrow_unchecked())? };
-    if !shuttle.is_initialized() {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    // Check initialization
+    load_initialized::<ShuttleMetadata>(unsafe { shuttle_info.borrow_unchecked() })?;
 
-    unsafe {
-        if ephemeral_ata_info
-            .owner()
-            .ne(&ephemeral_spl_api::program::id_address())
-        {
-            return Err(ProgramError::IllegalOwner);
-        }
-    }
+    assert_owner!(
+        ephemeral_ata_info,
+        &ephemeral_spl_api::program::id_address()
+    );
 
     let (mint, eata_bump) = {
         let ephemeral_ata =
-            unsafe { load_unchecked::<EphemeralAta>(ephemeral_ata_info.borrow_unchecked())? };
-        if !ephemeral_ata.is_initialized() {
-            return Err(ProgramError::UninitializedAccount);
-        }
+            load_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked() })?;
         if ephemeral_ata.owner != *shuttle_info.address() {
             return Err(ProgramError::InvalidAccountData);
         }

--- a/e-token/src/processor/delegate_transfer_queue.rs
+++ b/e-token/src/processor/delegate_transfer_queue.rs
@@ -3,6 +3,8 @@ use ephemeral_rollups_pinocchio::types::DelegateConfig;
 use ephemeral_spl_api::state::transfer_queue::{queue_views_checked, QUEUE_SEED};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
+use crate::assert_signer;
+
 pub fn process_delegate_transfer_queue(
     accounts: &[AccountView],
     instruction_data: &[u8],
@@ -27,9 +29,7 @@ pub fn process_delegate_transfer_queue(
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    if !payer_info.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
+    assert_signer!(payer_info);
 
     let program_id = ephemeral_spl_api::program::id_address();
     let delegation_program = ephemeral_spl_api::program::DELEGATION_PROGRAM_ID;

--- a/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge.rs
+++ b/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge.rs
@@ -14,8 +14,8 @@ use ephemeral_rollups_pinocchio::{
     utils::{close_pda_acc, make_seed_buf},
 };
 use ephemeral_spl_api::state::{
-    ephemeral_ata::EphemeralAta, load_mut_unchecked, load_unchecked,
-    shuttle_ephemeral_ata::ShuttleMetadata, Initializable,
+    ephemeral_ata::EphemeralAta, load_initialized, load_mut_initialized,
+    shuttle_ephemeral_ata::ShuttleMetadata,
 };
 use pinocchio::{
     cpi::{invoke_signed_with_bounds, Seed, Signer},
@@ -24,14 +24,16 @@ use pinocchio::{
     AccountView, Address, ProgramResult,
 };
 use pinocchio_system::instructions::{Assign, CreateAccount, Transfer};
-use pinocchio_token_2022::state::Mint;
 use solana_instruction::{AccountMeta, Instruction};
 use solana_pubkey::Pubkey;
 
-use crate::processor::{
-    deposit_spl_tokens::transfer_to_vault_for_mint,
-    initialize_shuttle_ephemeral_ata::initialize_shuttle_ephemeral_ata_with_sponsor,
-    rent_pda::derive_rent_pda,
+use crate::{
+    assert_owner,
+    processor::{
+        deposit_spl_tokens::transfer_to_vault_for_mint,
+        initialize_shuttle_ephemeral_ata::initialize_shuttle_ephemeral_ata_with_sponsor,
+        rent_pda::derive_rent_pda,
+    },
 };
 
 pub(crate) struct DepositAndDelegateShuttleAccounts<'a> {
@@ -221,9 +223,9 @@ pub(crate) fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_post_actio
         args.amount,
     )?;
 
-    let shuttle_eata = unsafe {
-        load_mut_unchecked::<EphemeralAta>(accounts.shuttle_eata_info.borrow_unchecked_mut())?
-    };
+    let shuttle_eata = load_mut_initialized::<EphemeralAta>(unsafe {
+        accounts.shuttle_eata_info.borrow_unchecked_mut()
+    })?;
     shuttle_eata.amount = shuttle_eata
         .amount
         .checked_add(args.amount)
@@ -265,6 +267,8 @@ pub(crate) fn prepare_sponsored_shuttle_delegation(
         return Err(ProgramError::MissingRequiredSignature);
     }
 
+    assert_owner!(rent_pda_info, &pinocchio_system::ID);
+
     #[cfg(feature = "logging")]
     {
         let shuttle = shuttle_info.address().to_string();
@@ -289,7 +293,7 @@ pub(crate) fn prepare_sponsored_shuttle_delegation(
     if derived_rent_pda != *rent_pda_info.address() {
         return Err(ProgramError::InvalidSeeds);
     }
-    if !rent_pda_info.owned_by(&pinocchio_system::ID) || rent_pda_info.data_len() != 0 {
+    if rent_pda_info.data_len() != 0 {
         return Err(ProgramError::InvalidAccountData);
     }
 
@@ -330,38 +334,17 @@ pub(crate) fn prepare_sponsored_shuttle_delegation(
         });
     }
 
-    unsafe {
-        if shuttle_info
-            .owner()
-            .ne(&ephemeral_spl_api::program::id_address())
-        {
-            return Err(ProgramError::IllegalOwner);
-        }
-    }
+    assert_owner!(shuttle_info, &ephemeral_spl_api::program::id_address());
+    assert_owner!(shuttle_eata_info, &ephemeral_spl_api::program::id_address());
 
-    let shuttle = unsafe { load_unchecked::<ShuttleMetadata>(shuttle_info.borrow_unchecked())? };
-    if !shuttle.is_initialized() {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    let shuttle = load_initialized::<ShuttleMetadata>(unsafe { shuttle_info.borrow_unchecked() })?;
     if shuttle.owner != *owner_info.address() || shuttle.payer != *rent_pda_info.address() {
         return Err(ProgramError::IncorrectAuthority);
     }
 
-    unsafe {
-        if shuttle_eata_info
-            .owner()
-            .ne(&ephemeral_spl_api::program::id_address())
-        {
-            return Err(ProgramError::IllegalOwner);
-        }
-    }
-
     let (mint, bump) = {
         let shuttle_eata =
-            unsafe { load_unchecked::<EphemeralAta>(shuttle_eata_info.borrow_unchecked())? };
-        if !shuttle_eata.is_initialized() {
-            return Err(ProgramError::UninitializedAccount);
-        }
+            load_initialized::<EphemeralAta>(unsafe { shuttle_eata_info.borrow_unchecked() })?;
         if shuttle_eata.owner != *shuttle_info.address() {
             return Err(ProgramError::InvalidAccountData);
         }
@@ -488,21 +471,6 @@ pub(crate) fn delegate_sponsored_shuttle_with_post_actions(
     )
 }
 
-#[inline(always)]
-pub(crate) fn read_mint_decimals(mint_info: &AccountView) -> Result<u8, ProgramError> {
-    let mint_data = unsafe { mint_info.borrow_unchecked() };
-    if mint_data.len() < Mint::BASE_LEN {
-        return Err(ProgramError::InvalidAccountData);
-    }
-
-    let mint = unsafe { Mint::from_bytes_unchecked(mint_data) };
-    if !mint.is_initialized() {
-        return Err(ProgramError::UninitializedAccount);
-    }
-
-    Ok(mint.decimals())
-}
-
 fn merge_shuttle_into_destination_action(
     accounts: &DepositAndDelegateShuttleWithMergeAccounts<'_>,
 ) -> Instruction {
@@ -516,12 +484,12 @@ pub(crate) fn merge_shuttle_into_token_account_action(
     Instruction {
         program_id: Pubkey::from(ephemeral_spl_api::program::ID),
         accounts: alloc::vec![
-            AccountMeta::new_readonly(pubkey(accounts.owner_info.address()), true),
-            AccountMeta::new(pubkey(destination_token_info.address()), false),
-            AccountMeta::new_readonly(pubkey(accounts.shuttle_info.address()), false),
-            AccountMeta::new(pubkey(accounts.shuttle_wallet_ata_info.address()), false),
-            AccountMeta::new_readonly(pubkey(accounts.mint_info.address()), false),
-            AccountMeta::new_readonly(pubkey(accounts.token_program_info.address()), false),
+            AccountMeta::new_readonly(*accounts.owner_info.address(), true),
+            AccountMeta::new(*destination_token_info.address(), false),
+            AccountMeta::new_readonly(*accounts.shuttle_info.address(), false),
+            AccountMeta::new(*accounts.shuttle_wallet_ata_info.address(), false),
+            AccountMeta::new_readonly(*accounts.mint_info.address(), false),
+            AccountMeta::new_readonly(*accounts.token_program_info.address(), false),
         ],
         data: alloc::vec![ephemeral_spl_api::instruction::MERGE_SHUTTLE_INTO_EPHEMERAL_ATA],
     }
@@ -533,12 +501,12 @@ pub(crate) fn undelegate_and_close_shuttle_action(
     Instruction {
         program_id: Pubkey::from(ephemeral_spl_api::program::ID),
         accounts: alloc::vec![
-            AccountMeta::new(pubkey(accounts.payer_info.address()), true),
-            AccountMeta::new(pubkey(accounts.rent_pda_info.address()), false),
-            AccountMeta::new_readonly(pubkey(accounts.shuttle_info.address()), false),
-            AccountMeta::new_readonly(pubkey(accounts.shuttle_eata_info.address()), false),
-            AccountMeta::new(pubkey(accounts.shuttle_wallet_ata_info.address()), false),
-            AccountMeta::new_readonly(pubkey(accounts.token_program_info.address()), false),
+            AccountMeta::new(*accounts.payer_info.address(), true),
+            AccountMeta::new(*accounts.rent_pda_info.address(), false),
+            AccountMeta::new_readonly(*accounts.shuttle_info.address(), false),
+            AccountMeta::new_readonly(*accounts.shuttle_eata_info.address(), false),
+            AccountMeta::new(*accounts.shuttle_wallet_ata_info.address(), false),
+            AccountMeta::new_readonly(*accounts.token_program_info.address(), false),
             AccountMeta::new(Pubkey::from(MAGIC_CONTEXT_ID.to_bytes()), false),
             AccountMeta::new_readonly(Pubkey::from(MAGIC_PROGRAM_ID.to_bytes()), false),
         ],
@@ -758,8 +726,4 @@ fn cpi_delegate_with_actions_from_sponsor(
     )?;
 
     Ok(())
-}
-#[inline]
-pub(crate) fn pubkey(address: &Address) -> Pubkey {
-    Pubkey::from(address.to_bytes())
 }

--- a/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
+++ b/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
@@ -15,6 +15,7 @@ use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
 use dlp_api::{args::PostDelegationActions, compact::ClearTextWithInsertable};
 
+use crate::assert_owner;
 use crate::processor::deposit_and_delegate_shuttle_ephemeral_ata_with_merge::undelegate_and_close_shuttle_action;
 use crate::processor::deposit_and_delegate_shuttle_ephemeral_ata_with_merge::{
     merge_shuttle_into_token_account_action,
@@ -39,6 +40,11 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private
 
     let (common_accounts, queue_info) =
         parse_deposit_and_delegate_shuttle_private_transfer_accounts(accounts)?;
+
+    assert_owner!(
+        queue_info,
+        &ephemeral_spl_api::program::DELEGATION_PROGRAM_ID
+    );
 
     #[cfg(feature = "logging")]
     {
@@ -85,9 +91,6 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private
             );
         }
         return Err(ProgramError::InvalidSeeds);
-    }
-    if !queue_info.owned_by(&ephemeral_spl_api::program::DELEGATION_PROGRAM_ID) {
-        return Err(ProgramError::IllegalOwner);
     }
 
     let actions = {

--- a/e-token/src/processor/deposit_and_queue_transfer.rs
+++ b/e-token/src/processor/deposit_and_queue_transfer.rs
@@ -81,7 +81,7 @@ pub fn process_deposit_and_queue_transfer(
     let destination_owner = if args.should_create_destination_ata_idempotent() {
         *destination_token_acc.address()
     } else {
-        let (_, owner, _) = validate_token_account(
+        let token = validate_token_account(
             destination_token_acc,
             mint_info.address(),
             None,
@@ -90,10 +90,10 @@ pub fn process_deposit_and_queue_transfer(
         assert_associated_token_address!(
             destination_token_acc.address(),
             mint_info.address(),
-            &owner,
+            token.owner(),
             token_program_info.address()
         );
-        owner
+        *token.owner()
     };
     let split_plan = build_split_plan(amount, split, decimals)?;
 

--- a/e-token/src/processor/deposit_and_queue_transfer.rs
+++ b/e-token/src/processor/deposit_and_queue_transfer.rs
@@ -1,6 +1,8 @@
 use core::{convert::TryFrom, marker::PhantomData};
 
 use crate::processor::deposit_spl_tokens::transfer_to_vault_for_mint;
+use crate::processor::utils::{read_mint_decimals, validate_token_account};
+use crate::{assert_associated_token_address, assert_owner, assert_signer};
 use ephemeral_spl_api::state::transfer_queue::{
     queue_len_for_mint_with_capacity, queue_push_from_data, QueuedTransfer,
     QUEUED_TRANSFER_FLAG_CREATE_IDEMPOTENT_ATA, QUEUE_SEED,
@@ -8,7 +10,6 @@ use ephemeral_spl_api::state::transfer_queue::{
 use pinocchio::sysvars::clock::Clock;
 use pinocchio::sysvars::Sysvar;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
-use pinocchio_token_2022::state::{Mint, TokenAccount};
 
 const MILLIS_PER_SECOND: u64 = 1_000;
 
@@ -34,9 +35,8 @@ pub fn process_deposit_and_queue_transfer(
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    if !user_authority.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
+    assert_signer!(user_authority);
+    assert_owner!(queue_info, &ephemeral_spl_api::program::id_address());
 
     let amount = args.amount();
     validate_deposit_and_queue_transfer_params(
@@ -55,9 +55,6 @@ pub fn process_deposit_and_queue_transfer(
     if derived_queue != *queue_info.address() {
         return Err(ProgramError::InvalidSeeds);
     }
-    if !queue_info.owned_by(&program_id) {
-        return Err(ProgramError::IllegalOwner);
-    }
 
     let queue_len_before = {
         let data = unsafe { queue_info.borrow_unchecked() };
@@ -66,7 +63,7 @@ pub fn process_deposit_and_queue_transfer(
     #[cfg(not(feature = "logging"))]
     let _ = queue_len_before;
 
-    let decimals = read_mint_decimals(mint_info)?;
+    let decimals = read_mint_decimals(mint_info, token_program_info)?;
     let inserted_at = queue_timestamp_now()?;
 
     transfer_to_vault_for_mint(
@@ -84,11 +81,19 @@ pub fn process_deposit_and_queue_transfer(
     let destination_owner = if args.should_create_destination_ata_idempotent() {
         *destination_token_acc.address()
     } else {
-        resolve_destination_owner_from_token_account(
+        let (_, owner, _) = validate_token_account(
             destination_token_acc,
-            token_program_info,
-            mint_info,
-        )?
+            mint_info.address(),
+            None,
+            Some(token_program_info.address()),
+        )?;
+        assert_associated_token_address!(
+            destination_token_acc.address(),
+            mint_info.address(),
+            &owner,
+            token_program_info.address()
+        );
+        owner
     };
     let split_plan = build_split_plan(amount, split, decimals)?;
 
@@ -144,54 +149,6 @@ pub fn process_deposit_and_queue_transfer(
     );
 
     Ok(())
-}
-
-#[inline(always)]
-fn resolve_destination_owner_from_token_account(
-    destination_token_acc: &AccountView,
-    token_program_info: &AccountView,
-    mint_info: &AccountView,
-) -> Result<ephemeral_spl_api::Address, ProgramError> {
-    if !destination_token_acc.owned_by(token_program_info.address()) {
-        return Err(ProgramError::IllegalOwner);
-    }
-
-    let destination_token_data = unsafe { destination_token_acc.borrow_unchecked() };
-    if destination_token_data.len() < TokenAccount::BASE_LEN {
-        return Err(ProgramError::InvalidAccountData);
-    }
-
-    let destination_token = unsafe { TokenAccount::from_bytes_unchecked(destination_token_data) };
-    if !destination_token.is_initialized() || destination_token.mint() != mint_info.address() {
-        return Err(ProgramError::InvalidAccountData);
-    }
-
-    let destination_owner = *destination_token.owner();
-    let expected_destination = derive_associated_token_address(
-        &destination_owner,
-        token_program_info.address(),
-        mint_info.address(),
-    );
-    if expected_destination != *destination_token_acc.address() {
-        return Err(ProgramError::InvalidAccountData);
-    }
-
-    Ok(destination_owner)
-}
-
-#[inline(always)]
-fn read_mint_decimals(mint_info: &AccountView) -> Result<u8, ProgramError> {
-    let mint_data = unsafe { mint_info.borrow_unchecked() };
-    if mint_data.len() < Mint::BASE_LEN {
-        return Err(ProgramError::InvalidAccountData);
-    }
-
-    let mint = unsafe { Mint::from_bytes_unchecked(mint_data) };
-    if !mint.is_initialized() {
-        return Err(ProgramError::UninitializedAccount);
-    }
-
-    Ok(mint.decimals())
 }
 
 pub struct DepositAndQueueTransferArgs<'a> {
@@ -456,17 +413,4 @@ fn hash_delay_seed(destination: &ephemeral_spl_api::Address, queue_position: u64
     hash ^= queue_position;
     hash = hash.wrapping_mul(0x100_0000_01b3);
     hash ^ (hash >> 32)
-}
-
-#[inline(always)]
-fn derive_associated_token_address(
-    wallet: &ephemeral_spl_api::Address,
-    token_program: &ephemeral_spl_api::Address,
-    mint: &ephemeral_spl_api::Address,
-) -> ephemeral_spl_api::Address {
-    ephemeral_spl_api::Address::find_program_address(
-        &[wallet.as_ref(), token_program.as_ref(), mint.as_ref()],
-        &pinocchio_associated_token_account::ID,
-    )
-    .0
 }

--- a/e-token/src/processor/deposit_spl_tokens.rs
+++ b/e-token/src/processor/deposit_spl_tokens.rs
@@ -1,4 +1,4 @@
-use ephemeral_spl_api::state::{load, load_initialized, load_mut_initialized};
+use ephemeral_spl_api::state::{load_initialized, load_mut_initialized};
 
 use core::marker::PhantomData;
 
@@ -78,7 +78,7 @@ pub(crate) fn transfer_to_vault_for_mint(
 ) -> ProgramResult {
     assert_owner!(vault_info, &ephemeral_spl_api::program::id_address());
 
-    let vault = load::<GlobalVault>(unsafe { vault_info.borrow_unchecked() })?;
+    let vault = load_initialized::<GlobalVault>(unsafe { vault_info.borrow_unchecked() })?;
     if vault.mint != *mint_info.address()
         || vault.token_account != *vault_token_acc.address()
         || vault.mint != *expected_mint

--- a/e-token/src/processor/deposit_spl_tokens.rs
+++ b/e-token/src/processor/deposit_spl_tokens.rs
@@ -1,10 +1,12 @@
+use ephemeral_spl_api::state::{load, load_initialized, load_mut_initialized};
+
 use core::marker::PhantomData;
+
+use crate::{assert_owner, processor::utils::read_mint_decimals};
+
 use {
-    ephemeral_spl_api::state::{
-        ephemeral_ata::EphemeralAta, global_vault::GlobalVault, load_mut_unchecked, load_unchecked,
-    },
+    ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, global_vault::GlobalVault},
     pinocchio::{error::ProgramError, AccountView, Address, ProgramResult},
-    pinocchio_token_2022::state::Mint,
 };
 
 #[inline(always)]
@@ -30,21 +32,15 @@ pub fn process_deposit_spl_tokens(
     };
 
     // Validate EphemeralAta ownership first, before reading raw data.
-    unsafe {
-        if ephemeral_ata_info
-            .owner()
-            .ne(&ephemeral_spl_api::program::id_address())
-        {
-            return Err(ProgramError::IllegalOwner);
-        }
-    }
+    assert_owner!(
+        ephemeral_ata_info,
+        &ephemeral_spl_api::program::id_address()
+    );
 
     let ephemeral_ata_mint = {
         let ephemeral_ata =
-            unsafe { load_unchecked::<EphemeralAta>(ephemeral_ata_info.borrow_unchecked())? };
-        #[allow(clippy::clone_on_copy)]
-        let mint = ephemeral_ata.mint.clone();
-        mint
+            load_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked() })?;
+        ephemeral_ata.mint
     };
 
     transfer_to_vault_for_mint(
@@ -59,7 +55,7 @@ pub fn process_deposit_spl_tokens(
     )?;
 
     let ephemeral_ata =
-        unsafe { load_mut_unchecked::<EphemeralAta>(ephemeral_ata_info.borrow_unchecked_mut())? };
+        load_mut_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked_mut() })?;
     ephemeral_ata.amount = ephemeral_ata
         .amount
         .checked_add(args.amount())
@@ -80,16 +76,9 @@ pub(crate) fn transfer_to_vault_for_mint(
     expected_mint: &Address,
     amount: u64,
 ) -> ProgramResult {
-    unsafe {
-        if vault_info
-            .owner()
-            .ne(&ephemeral_spl_api::program::id_address())
-        {
-            return Err(ProgramError::IllegalOwner);
-        }
-    }
+    assert_owner!(vault_info, &ephemeral_spl_api::program::id_address());
 
-    let vault = unsafe { load_unchecked::<GlobalVault>(vault_info.borrow_unchecked())? };
+    let vault = load::<GlobalVault>(unsafe { vault_info.borrow_unchecked() })?;
     if vault.mint != *mint_info.address()
         || vault.token_account != *vault_token_acc.address()
         || vault.mint != *expected_mint
@@ -97,17 +86,7 @@ pub(crate) fn transfer_to_vault_for_mint(
         return Err(ProgramError::InvalidAccountData);
     }
 
-    let decimals = {
-        let mint_data = unsafe { mint_info.borrow_unchecked() };
-        if mint_data.len() < Mint::BASE_LEN {
-            return Err(ProgramError::InvalidAccountData);
-        }
-        let mint = unsafe { Mint::from_bytes_unchecked(mint_data) };
-        if !mint.is_initialized() {
-            return Err(ProgramError::UninitializedAccount);
-        }
-        mint.decimals()
-    };
+    let decimals = read_mint_decimals(mint_info, token_program_info)?;
 
     pinocchio_token_2022::instructions::TransferChecked {
         mint: mint_info,

--- a/e-token/src/processor/ensure_transfer_queue_crank.rs
+++ b/e-token/src/processor/ensure_transfer_queue_crank.rs
@@ -10,6 +10,8 @@ use pinocchio::cpi::invoke_with_bounds;
 use pinocchio::instruction::{InstructionAccount, InstructionView};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
+use crate::{assert_owner, assert_signer};
+
 pub const CRANK_EXECUTION_INTERVAL_MILLIS: i64 = 500;
 
 const PROCESS_QUEUE_TICK_CRANK_ACCOUNTS: usize = 3;
@@ -35,14 +37,14 @@ pub fn process_ensure_transfer_queue_crank(
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    if !payer_info.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
+    let program_id = ephemeral_spl_api::program::id_address();
+    assert_signer!(payer_info);
+    assert_owner!(queue_info, &program_id);
+
     if magic_program_info.address() != &ephemeral_rollups_pinocchio::consts::MAGIC_PROGRAM_ID {
         return Err(ProgramError::IncorrectProgramId);
     }
 
-    let program_id = ephemeral_spl_api::program::id_address();
     let (mint, bump) = {
         let data = unsafe { queue_info.borrow_unchecked() };
         let (header, _) = queue_views_checked(data)?;
@@ -57,9 +59,6 @@ pub fn process_ensure_transfer_queue_crank(
     .map_err(|_| ProgramError::InvalidAccountData)?;
     if derived_queue != *queue_info.address() {
         return Err(ProgramError::InvalidSeeds);
-    }
-    if !queue_info.owned_by(&program_id) {
-        return Err(ProgramError::IllegalOwner);
     }
 
     let crank_task_id = derive_queue_crank_task_id(queue_info.address());

--- a/e-token/src/processor/execute_ready_queued_transfer.rs
+++ b/e-token/src/processor/execute_ready_queued_transfer.rs
@@ -3,17 +3,20 @@ use core::marker::PhantomData;
 use {
     ephemeral_rollups_pinocchio::pda::ephemeral_balance_pda_from_payer,
     ephemeral_spl_api::state::{
-        global_vault::GlobalVault, load_unchecked,
-        transfer_queue::QUEUED_TRANSFER_FLAG_CREATE_IDEMPOTENT_ATA,
+        global_vault::GlobalVault, transfer_queue::QUEUED_TRANSFER_FLAG_CREATE_IDEMPOTENT_ATA,
     },
     pinocchio::{error::ProgramError, AccountView, ProgramResult},
     pinocchio_token_2022::state::Mint,
 };
 
+use ephemeral_spl_api::state::load_initialized;
 use pinocchio::cpi::{Seed, Signer};
 use pinocchio_system::ID as SYSTEM_PROGRAM_ID;
 
-use crate::processor::rent_pda::{derive_rent_pda, RENT_PDA_SEED};
+use crate::{
+    assert_owner,
+    processor::rent_pda::{derive_rent_pda, RENT_PDA_SEED},
+};
 
 #[inline(always)]
 pub fn process_execute_ready_queued_transfer(
@@ -67,7 +70,8 @@ pub fn process_execute_ready_queued_transfer(
         if derived_rent_pda != *rent_pda_info.address() {
             return Err(ProgramError::InvalidSeeds);
         }
-        if !rent_pda_info.owned_by(&SYSTEM_PROGRAM_ID) || rent_pda_info.data_len() != 0 {
+        assert_owner!(rent_pda_info, &SYSTEM_PROGRAM_ID);
+        if rent_pda_info.data_len() != 0 {
             return Err(ProgramError::InvalidAccountData);
         }
         if associated_token_program_info.address() != &pinocchio_associated_token_account::ID
@@ -131,16 +135,9 @@ pub(crate) fn validate_vault_for_mint(
     mint_info: &AccountView,
     vault_token_acc_info: &AccountView,
 ) -> Result<u8, ProgramError> {
-    unsafe {
-        if vault_info
-            .owner()
-            .ne(&ephemeral_spl_api::program::id_address())
-        {
-            return Err(ProgramError::IllegalOwner);
-        }
-    }
+    assert_owner!(vault_info, &ephemeral_spl_api::program::id_address());
 
-    let vault = unsafe { load_unchecked::<GlobalVault>(vault_info.borrow_unchecked())? };
+    let vault = load_initialized::<GlobalVault>(unsafe { vault_info.borrow_unchecked() })?;
     let (derived_vault, bump) = ephemeral_spl_api::Address::find_program_address(
         &[mint_info.address().as_ref()],
         &ephemeral_spl_api::program::id_address(),

--- a/e-token/src/processor/execute_ready_queued_transfer.rs
+++ b/e-token/src/processor/execute_ready_queued_transfer.rs
@@ -6,7 +6,6 @@ use {
         global_vault::GlobalVault, transfer_queue::QUEUED_TRANSFER_FLAG_CREATE_IDEMPOTENT_ATA,
     },
     pinocchio::{error::ProgramError, AccountView, ProgramResult},
-    pinocchio_token_2022::state::Mint,
 };
 
 use ephemeral_spl_api::state::load_initialized;
@@ -15,7 +14,10 @@ use pinocchio_system::ID as SYSTEM_PROGRAM_ID;
 
 use crate::{
     assert_owner,
-    processor::rent_pda::{derive_rent_pda, RENT_PDA_SEED},
+    processor::{
+        rent_pda::{derive_rent_pda, RENT_PDA_SEED},
+        utils::read_mint_decimals,
+    },
 };
 
 #[inline(always)]
@@ -66,11 +68,11 @@ pub fn process_execute_ready_queued_transfer(
     }
 
     if args.should_create_destination_ata_idempotent() {
+        assert_owner!(rent_pda_info, &SYSTEM_PROGRAM_ID);
         let (derived_rent_pda, rent_bump) = derive_rent_pda();
         if derived_rent_pda != *rent_pda_info.address() {
             return Err(ProgramError::InvalidSeeds);
         }
-        assert_owner!(rent_pda_info, &SYSTEM_PROGRAM_ID);
         if rent_pda_info.data_len() != 0 {
             return Err(ProgramError::InvalidAccountData);
         }
@@ -96,17 +98,7 @@ pub fn process_execute_ready_queued_transfer(
     }
 
     let vault_bump = validate_vault_for_mint(vault_info, mint_info, vault_token_acc_info)?;
-    let decimals = {
-        let mint_data = unsafe { mint_info.borrow_unchecked() };
-        if mint_data.len() < Mint::BASE_LEN {
-            return Err(ProgramError::InvalidAccountData);
-        }
-        let mint = unsafe { Mint::from_bytes_unchecked(mint_data) };
-        if !mint.is_initialized() {
-            return Err(ProgramError::UninitializedAccount);
-        }
-        mint.decimals()
-    };
+    let decimals = read_mint_decimals(mint_info, token_program_info)?;
 
     let vault_bump = [vault_bump];
     let signer_seeds = [
@@ -142,9 +134,10 @@ pub(crate) fn validate_vault_for_mint(
         &[mint_info.address().as_ref()],
         &ephemeral_spl_api::program::id_address(),
     );
-    if derived_vault != *vault_info.address()
-        || vault.mint != *mint_info.address()
-        || vault.token_account != *vault_token_acc_info.address()
+    if derived_vault != *vault_info.address() {
+        return Err(ProgramError::InvalidSeeds);
+    }
+    if vault.mint != *mint_info.address() || vault.token_account != *vault_token_acc_info.address()
     {
         return Err(ProgramError::InvalidAccountData);
     }

--- a/e-token/src/processor/fees_pda.rs
+++ b/e-token/src/processor/fees_pda.rs
@@ -1,12 +1,14 @@
 use ephemeral_rollups_pinocchio::instruction::{commit_accounts, DelegateAccountCpiBuilder};
 use ephemeral_rollups_pinocchio::types::DelegateConfig;
 use ephemeral_spl_api::state::fees_pda::{FeesPda, FEES_PDA_SEED, FEES_PDA_TAG};
-use ephemeral_spl_api::state::{load_mut_unchecked, load_unchecked, Initializable, RawType};
+use ephemeral_spl_api::state::{load_initialized, load_mut, RawType};
 use pinocchio::cpi::{Seed, Signer};
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 use pinocchio_system::instructions::CreateAccount;
+
+use crate::assert_signer;
 
 #[inline(always)]
 pub fn process_initialize_fees_pda(
@@ -59,7 +61,7 @@ pub fn process_initialize_fees_pda(
     }
     .invoke_signed(&[signer])?;
 
-    let fees_pda = unsafe { load_mut_unchecked::<FeesPda>(fees_pda_info.borrow_unchecked_mut())? };
+    let fees_pda = load_mut::<FeesPda>(unsafe { fees_pda_info.borrow_unchecked_mut() })?;
     fees_pda.tag = FEES_PDA_TAG;
     fees_pda.validator = *validator_info.address();
     fees_pda.bump = bump;
@@ -92,9 +94,7 @@ pub fn process_delegate_fees_pda(
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    if !payer_info.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
+    assert_signer!(payer_info);
 
     let program_id = ephemeral_spl_api::program::id_address();
     let delegation_program = ephemeral_spl_api::program::DELEGATION_PROGRAM_ID;
@@ -201,14 +201,12 @@ fn is_valid_initialized_fees_pda(
         return false;
     }
 
-    let fees_pda = match unsafe { load_unchecked::<FeesPda>(fees_pda_info.borrow_unchecked()) } {
+    let fees_pda = match load_initialized::<FeesPda>(unsafe { fees_pda_info.borrow_unchecked() }) {
         Ok(fees_pda) => fees_pda,
         Err(_) => return false,
     };
 
-    fees_pda.is_initialized()
-        && fees_pda.validator == *validator_info.address()
-        && fees_pda.bump == bump
+    fees_pda.validator == *validator_info.address() && fees_pda.bump == bump
 }
 
 #[inline(always)]
@@ -217,11 +215,8 @@ fn validate_fees_pda(
     validator_info: &AccountView,
     bump: u8,
 ) -> ProgramResult {
-    let fees_pda = unsafe { load_unchecked::<FeesPda>(fees_pda_info.borrow_unchecked())? };
-    if !fees_pda.is_initialized()
-        || fees_pda.validator != *validator_info.address()
-        || fees_pda.bump != bump
-    {
+    let fees_pda = load_initialized::<FeesPda>(unsafe { fees_pda_info.borrow_unchecked() })?;
+    if fees_pda.validator != *validator_info.address() || fees_pda.bump != bump {
         return Err(ProgramError::InvalidAccountData);
     }
     Ok(())

--- a/e-token/src/processor/initialize_ephemeral_ata.rs
+++ b/e-token/src/processor/initialize_ephemeral_ata.rs
@@ -1,11 +1,10 @@
-use ephemeral_spl_api::state::{Initializable, RawType};
+use ephemeral_spl_api::state::{load_initialized, load_mut, RawType};
 use pinocchio::cpi::{Seed, Signer};
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
 use pinocchio_system::instructions::{CreateAccount, Transfer};
 use {
     ephemeral_spl_api::state::ephemeral_ata::EphemeralAta,
-    ephemeral_spl_api::state::{load_mut_unchecked, load_unchecked},
     pinocchio::{error::ProgramError, AccountView, ProgramResult},
 };
 
@@ -54,11 +53,9 @@ pub(crate) fn initialize_ephemeral_ata_with_sponsor(
 
     // Make init idempotent even if the account is currently delegated (owner changed).
     if let Ok(ephemeral_ata) =
-        unsafe { load_unchecked::<EphemeralAta>(ephemeral_ata_info.borrow_unchecked()) }
+        load_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked() })
     {
-        if ephemeral_ata.is_initialized()
-            && ephemeral_ata.owner == *user_info.address()
-            && ephemeral_ata.mint == *mint_info.address()
+        if ephemeral_ata.owner == *user_info.address() && ephemeral_ata.mint == *mint_info.address()
         {
             return Ok(());
         }
@@ -92,9 +89,8 @@ pub(crate) fn initialize_ephemeral_ata_with_sponsor(
 
         ephemeral_ata_info.resize(EphemeralAta::LEN)?;
 
-        let ephemeral_ata = unsafe {
-            load_mut_unchecked::<EphemeralAta>(ephemeral_ata_info.borrow_unchecked_mut())?
-        };
+        let ephemeral_ata =
+            load_mut::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked_mut() })?;
 
         // Set the missing bump
         ephemeral_ata.bump = eata_bump;
@@ -132,7 +128,7 @@ pub(crate) fn initialize_ephemeral_ata_with_sponsor(
 
     // Ensure account data has the expected size
     let ephemeral_ata =
-        unsafe { load_mut_unchecked::<EphemeralAta>(ephemeral_ata_info.borrow_unchecked_mut())? };
+        load_mut::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked_mut() })?;
 
     // Initialize the ephemeral ATA
     // Set the owner to the provided user; payer only funds account creation

--- a/e-token/src/processor/initialize_global_vault.rs
+++ b/e-token/src/processor/initialize_global_vault.rs
@@ -6,7 +6,7 @@ use pinocchio::sysvars::Sysvar;
 use pinocchio_system::instructions::{CreateAccount, Transfer};
 use {
     ephemeral_spl_api::state::global_vault::GlobalVault,
-    ephemeral_spl_api::state::load_mut_unchecked,
+    ephemeral_spl_api::state::load_mut,
     pinocchio::{error::ProgramError, AccountView, ProgramResult},
 };
 
@@ -122,7 +122,7 @@ pub fn process_initialize_global_vault(
     .invoke()?;
 
     // Ensure account data has the expected size.
-    let vault = unsafe { load_mut_unchecked::<GlobalVault>(vault_info.borrow_unchecked_mut())? };
+    let vault = load_mut::<GlobalVault>(unsafe { vault_info.borrow_unchecked_mut() })?;
 
     // Initialize the vault
     vault.mint = *mint_info.address();

--- a/e-token/src/processor/initialize_shuttle_ephemeral_ata.rs
+++ b/e-token/src/processor/initialize_shuttle_ephemeral_ata.rs
@@ -1,6 +1,6 @@
 use crate::processor::initialize_ephemeral_ata::initialize_ephemeral_ata_with_sponsor;
 use core::marker::PhantomData;
-use ephemeral_spl_api::state::{load_mut_unchecked, load_unchecked, Initializable, RawType};
+use ephemeral_spl_api::state::{load_initialized, load_mut, RawType};
 use pinocchio::cpi::{Seed, Signer};
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
@@ -115,8 +115,7 @@ pub(crate) fn initialize_shuttle_ephemeral_ata_with_sponsor(
             create_shuttle.invoke_signed(&signers)?;
         }
 
-        let shuttle =
-            unsafe { load_mut_unchecked::<ShuttleMetadata>(shuttle_info.borrow_unchecked_mut())? };
+        let shuttle = unsafe { load_mut::<ShuttleMetadata>(shuttle_info.borrow_unchecked_mut())? };
 
         shuttle.owner = *owner_info.address();
         shuttle.payer = *refund_recipient_info.address();
@@ -146,16 +145,14 @@ pub(crate) fn initialize_shuttle_ephemeral_ata_with_sponsor(
                 }
             }
             shuttle_info.resize(ShuttleMetadata::LEN)?;
-            let shuttle = unsafe {
-                load_mut_unchecked::<ShuttleMetadata>(shuttle_info.borrow_unchecked_mut())?
-            };
+            let shuttle =
+                load_mut::<ShuttleMetadata>(unsafe { shuttle_info.borrow_unchecked_mut() })?;
             shuttle.bump = shuttle_bump;
         }
 
         let shuttle =
-            unsafe { load_unchecked::<ShuttleMetadata>(shuttle_info.borrow_unchecked())? };
-        if !shuttle.is_initialized()
-            || shuttle.id != shuttle_id
+            load_initialized::<ShuttleMetadata>(unsafe { shuttle_info.borrow_unchecked() })?;
+        if shuttle.id != shuttle_id
             || shuttle.owner != *owner_info.address()
             || shuttle.payer != *refund_recipient_info.address()
         {

--- a/e-token/src/processor/merge_shuttle_into_ephemeral_ata.rs
+++ b/e-token/src/processor/merge_shuttle_into_ephemeral_ata.rs
@@ -57,23 +57,28 @@ pub fn process_merge_shuttle_into_ephemeral_ata(
         return Err(ProgramError::InvalidSeeds);
     }
 
-    let (_, _, shuttle_amount) = validate_token_account(
-        shuttle_wallet_ata_info,
-        mint_info.address(),
-        Some(shuttle_info.address()),
-        Some(token_program_info.address()),
-    )?;
+    let shuttle_amount = {
+        let shuttle_ata = validate_token_account(
+            shuttle_wallet_ata_info,
+            mint_info.address(),
+            Some(shuttle_info.address()),
+            Some(token_program_info.address()),
+        )?;
 
-    if shuttle_amount == 0 {
-        return Ok(());
-    }
+        let amount = shuttle_ata.amount();
+        if amount == 0 {
+            return Ok(());
+        }
 
-    validate_token_account(
-        destination_token_info,
-        mint_info.address(),
-        None,
-        Some(token_program_info.address()),
-    )?;
+        validate_token_account(
+            destination_token_info,
+            mint_info.address(),
+            None,
+            Some(token_program_info.address()),
+        )?;
+
+        amount
+    };
 
     let decimals = read_mint_decimals(mint_info, token_program_info)?;
 

--- a/e-token/src/processor/merge_shuttle_into_ephemeral_ata.rs
+++ b/e-token/src/processor/merge_shuttle_into_ephemeral_ata.rs
@@ -59,8 +59,8 @@ pub fn process_merge_shuttle_into_ephemeral_ata(
 
     let (_, _, shuttle_amount) = validate_token_account(
         shuttle_wallet_ata_info,
-        &mint_info.address(),
-        Some(&shuttle_info.address()),
+        mint_info.address(),
+        Some(shuttle_info.address()),
         Some(token_program_info.address()),
     )?;
 
@@ -70,7 +70,7 @@ pub fn process_merge_shuttle_into_ephemeral_ata(
 
     validate_token_account(
         destination_token_info,
-        &mint_info.address(),
+        mint_info.address(),
         None,
         Some(token_program_info.address()),
     )?;

--- a/e-token/src/processor/merge_shuttle_into_ephemeral_ata.rs
+++ b/e-token/src/processor/merge_shuttle_into_ephemeral_ata.rs
@@ -1,9 +1,10 @@
-use ephemeral_spl_api::state::{
-    load_unchecked, shuttle_ephemeral_ata::ShuttleMetadata, Initializable,
-};
+use ephemeral_spl_api::state::load_initialized;
+use ephemeral_spl_api::state::shuttle_ephemeral_ata::ShuttleMetadata;
 use pinocchio::cpi::{Seed, Signer};
-use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
-use pinocchio_token_2022::state::{Mint, TokenAccount};
+use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+
+use crate::assert_owner;
+use crate::processor::utils::{read_mint_decimals, validate_token_account};
 
 #[inline(always)]
 pub fn process_merge_shuttle_into_ephemeral_ata(
@@ -27,16 +28,13 @@ pub fn process_merge_shuttle_into_ephemeral_ata(
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    assert_owner(shuttle_info, &ephemeral_spl_api::program::id_address())?;
-    assert_owner(shuttle_wallet_ata_info, token_program_info.address())?;
-    assert_owner(destination_token_info, token_program_info.address())?;
+    assert_owner!(shuttle_info, &ephemeral_spl_api::program::id_address());
+    assert_owner!(shuttle_wallet_ata_info, token_program_info.address());
+    assert_owner!(destination_token_info, token_program_info.address());
 
     let (shuttle_owner, shuttle_id, bump) = {
         let shuttle =
-            unsafe { load_unchecked::<ShuttleMetadata>(shuttle_info.borrow_unchecked())? };
-        if !shuttle.is_initialized() {
-            return Err(ProgramError::InvalidAccountData);
-        }
+            load_initialized::<ShuttleMetadata>(unsafe { shuttle_info.borrow_unchecked() })?;
         if shuttle.owner != *owner_info.address() {
             return Err(ProgramError::IncorrectAuthority);
         }
@@ -59,23 +57,25 @@ pub fn process_merge_shuttle_into_ephemeral_ata(
         return Err(ProgramError::InvalidSeeds);
     }
 
-    let (shuttle_mint, shuttle_wallet_owner, shuttle_amount) =
-        read_token_account(shuttle_wallet_ata_info)?;
-    if shuttle_wallet_owner != *shuttle_info.address() || shuttle_mint != *mint_info.address() {
-        return Err(ProgramError::InvalidAccountData);
-    }
-
-    let (destination_mint, _destination_owner, _destination_amount) =
-        read_token_account(destination_token_info)?;
-    if destination_mint != *mint_info.address() {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    let (_, _, shuttle_amount) = validate_token_account(
+        shuttle_wallet_ata_info,
+        &mint_info.address(),
+        Some(&shuttle_info.address()),
+        Some(token_program_info.address()),
+    )?;
 
     if shuttle_amount == 0 {
         return Ok(());
     }
 
-    let decimals = read_mint_decimals(mint_info)?;
+    validate_token_account(
+        destination_token_info,
+        &mint_info.address(),
+        None,
+        Some(token_program_info.address()),
+    )?;
+
+    let decimals = read_mint_decimals(mint_info, token_program_info)?;
 
     let seeds = [
         Seed::from(shuttle_owner.as_ref()),
@@ -97,48 +97,4 @@ pub fn process_merge_shuttle_into_ephemeral_ata(
     .invoke_signed(&[signer])?;
 
     Ok(())
-}
-
-#[inline(always)]
-fn assert_owner(account: &AccountView, expected_owner: &Address) -> ProgramResult {
-    unsafe {
-        if account.owner().ne(expected_owner) {
-            return Err(ProgramError::IllegalOwner);
-        }
-    }
-    Ok(())
-}
-
-#[inline(always)]
-fn read_token_account(account: &AccountView) -> Result<(Address, Address, u64), ProgramError> {
-    let token_data = unsafe { account.borrow_unchecked() };
-    if token_data.len() < TokenAccount::BASE_LEN {
-        return Err(ProgramError::InvalidAccountData);
-    }
-
-    let token = unsafe { TokenAccount::from_bytes_unchecked(token_data) };
-    if !token.is_initialized() {
-        return Err(ProgramError::UninitializedAccount);
-    }
-
-    #[allow(clippy::clone_on_copy)]
-    let mint = token.mint().clone();
-    #[allow(clippy::clone_on_copy)]
-    let owner = token.owner().clone();
-    Ok((mint, owner, token.amount()))
-}
-
-#[inline(always)]
-fn read_mint_decimals(mint_info: &AccountView) -> Result<u8, ProgramError> {
-    let mint_data = unsafe { mint_info.borrow_unchecked() };
-    if mint_data.len() < Mint::BASE_LEN {
-        return Err(ProgramError::InvalidAccountData);
-    }
-
-    let mint = unsafe { Mint::from_bytes_unchecked(mint_data) };
-    if !mint.is_initialized() {
-        return Err(ProgramError::UninitializedAccount);
-    }
-
-    Ok(mint.decimals())
 }

--- a/e-token/src/processor/mod.rs
+++ b/e-token/src/processor/mod.rs
@@ -25,6 +25,7 @@ pub mod undelegate_ephemeral_ata;
 pub mod undelegate_ephemeral_ata_permission;
 pub mod undelegate_withdraw_and_close_shuttle_ephemeral_ata;
 pub mod undelegation_callback;
+pub(crate) mod utils;
 pub mod withdraw_spl_tokens;
 pub mod withdraw_through_delegated_shuttle_with_merge;
 

--- a/e-token/src/processor/reset_ephemeral_ata_permission.rs
+++ b/e-token/src/processor/reset_ephemeral_ata_permission.rs
@@ -5,7 +5,7 @@ use ephemeral_rollups_pinocchio::acl::{
     pda::permission_pda_from_permissioned_account,
     types::{Member, MemberFlags, MembersArgs},
 };
-use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_unchecked, Initializable};
+use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
 #[inline(always)]
@@ -36,11 +36,7 @@ pub fn process_reset_ephemeral_ata_permission(
     }
 
     let ephemeral_ata =
-        unsafe { load_unchecked::<EphemeralAta>(ephemeral_ata_info.borrow_unchecked())? };
-
-    if !ephemeral_ata.is_initialized() {
-        return Err(ProgramError::InvalidAccountData);
-    }
+        load_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked() })?;
 
     if ephemeral_ata.owner != *owner_info.address() {
         return Err(ProgramError::IncorrectAuthority);

--- a/e-token/src/processor/undelegate_and_close_shuttle_ephemeral_ata.rs
+++ b/e-token/src/processor/undelegate_and_close_shuttle_ephemeral_ata.rs
@@ -6,9 +6,8 @@ use ephemeral_spl_api::state::{
     ephemeral_ata::EphemeralAta, load_initialized, shuttle_ephemeral_ata::ShuttleMetadata,
 };
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
-use pinocchio_token_2022::state::TokenAccount;
 
-use crate::processor::utils::get_associated_token_address;
+use crate::processor::utils::{get_associated_token_address, validate_token_account};
 
 const DEFAULT_ESCROW_INDEX: u8 = u8::MAX;
 const INTENT_BUNDLE_DATA_BUF_SIZE: usize = 1280;
@@ -83,28 +82,12 @@ pub fn process_undelegate_and_close_shuttle_ephemeral_ata(
         return Err(ProgramError::InvalidAccountData);
     }
 
-    {
-        let shuttle_wallet_data = unsafe { shuttle_wallet_ata_info.borrow_unchecked() };
-        if shuttle_wallet_data.len() < TokenAccount::BASE_LEN {
-            return Err(ProgramError::InvalidAccountData);
-        }
-        let shuttle_wallet = unsafe { TokenAccount::from_bytes_unchecked(shuttle_wallet_data) };
-        if !shuttle_wallet.is_initialized() {
-            return Err(ProgramError::UninitializedAccount);
-        }
-        if shuttle_wallet.owner() != shuttle_info.address() || shuttle_wallet.mint() != &mint {
-            return Err(ProgramError::InvalidAccountData);
-        }
-    }
-
-    unsafe {
-        if shuttle_wallet_ata_info
-            .owner()
-            .ne(token_program_info.address())
-        {
-            return Err(ProgramError::IllegalOwner);
-        }
-    }
+    validate_token_account(
+        shuttle_wallet_ata_info,
+        &mint,
+        Some(shuttle_info.address()),
+        Some(token_program_info.address()),
+    )?;
 
     undelegate_and_close_shuttle_ephemeral_ata(
         executor,

--- a/e-token/src/processor/undelegate_and_close_shuttle_ephemeral_ata.rs
+++ b/e-token/src/processor/undelegate_and_close_shuttle_ephemeral_ata.rs
@@ -3,11 +3,12 @@ use ephemeral_rollups_pinocchio::intent_bundle::{
 };
 use ephemeral_spl_api::instruction::internal::CLOSE_SHUTTLE_ATA_INTENT;
 use ephemeral_spl_api::state::{
-    ephemeral_ata::EphemeralAta, load_unchecked, shuttle_ephemeral_ata::ShuttleMetadata,
-    Initializable,
+    ephemeral_ata::EphemeralAta, load_initialized, shuttle_ephemeral_ata::ShuttleMetadata,
 };
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
 use pinocchio_token_2022::state::TokenAccount;
+
+use crate::processor::utils::get_associated_token_address;
 
 const DEFAULT_ESCROW_INDEX: u8 = u8::MAX;
 const INTENT_BUNDLE_DATA_BUF_SIZE: usize = 1280;
@@ -51,18 +52,15 @@ pub fn process_undelegate_and_close_shuttle_ephemeral_ata(
         }
     }
 
-    let shuttle = unsafe { load_unchecked::<ShuttleMetadata>(shuttle_info.borrow_unchecked())? };
-    if !shuttle.is_initialized() {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    let shuttle = load_initialized::<ShuttleMetadata>(unsafe { shuttle_info.borrow_unchecked() })?;
     if shuttle.payer != *rent_reimbursement.address() {
         return Err(ProgramError::IncorrectAuthority);
     }
 
     let mint = {
-        let shuttle_ephemeral_ata = unsafe {
-            load_unchecked::<EphemeralAta>(shuttle_ephemeral_ata_info.borrow_unchecked())?
-        };
+        let shuttle_ephemeral_ata = load_initialized::<EphemeralAta>(unsafe {
+            shuttle_ephemeral_ata_info.borrow_unchecked()
+        })?;
         if shuttle_ephemeral_ata.owner != *shuttle_info.address() {
             return Err(ProgramError::InvalidAccountData);
         }
@@ -131,19 +129,6 @@ fn parse_escrow_index(instruction_data: &[u8]) -> Result<u8, ProgramError> {
         return Err(ProgramError::InvalidInstructionData);
     }
     Ok(instruction_data[0])
-}
-
-#[inline(always)]
-fn get_associated_token_address(
-    wallet: &Address,
-    mint: &Address,
-    token_program: &Address,
-) -> Address {
-    ephemeral_spl_api::Address::find_program_address(
-        &[wallet.as_ref(), token_program.as_ref(), mint.as_ref()],
-        &pinocchio_associated_token_account::id(),
-    )
-    .0
 }
 
 #[inline(never)]

--- a/e-token/src/processor/undelegate_ephemeral_ata.rs
+++ b/e-token/src/processor/undelegate_ephemeral_ata.rs
@@ -1,6 +1,7 @@
-use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_unchecked};
+use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
-use pinocchio_token_2022::state::TokenAccount;
+
+use crate::processor::utils::validate_token_account;
 
 fn commit_and_undelegate_accounts(
     payer: &AccountView,
@@ -44,7 +45,7 @@ pub fn process_undelegate_ephemeral_ata(
     // Scope the borrow so it's released before any CPI.
     let mint = {
         let eata_data =
-            unsafe { load_unchecked::<EphemeralAta>(ephemeral_ata_info.borrow_unchecked())? };
+            load_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked() })?;
         #[allow(clippy::clone_on_copy)]
         let mint = eata_data.mint.clone();
         mint
@@ -61,20 +62,7 @@ pub fn process_undelegate_ephemeral_ata(
     }
 
     // Validate that the provided ATA account is a valid SPL token account for [payer, mint].
-    {
-        let token_data = unsafe { ata_info.borrow_unchecked() };
-        if token_data.len() < TokenAccount::BASE_LEN {
-            return Err(ProgramError::InvalidAccountData);
-        }
-        let token_acc = unsafe { TokenAccount::from_bytes_unchecked(token_data) };
-        if !token_acc.is_initialized() {
-            return Err(ProgramError::UninitializedAccount);
-        }
-
-        if token_acc.mint() != &mint || token_acc.owner() != payer.address() {
-            return Err(ProgramError::InvalidAccountData);
-        }
-    }
+    validate_token_account(ata_info, &mint, Some(payer.address()), None)?;
 
     // Commit and undelegate with the user's ATA and the ephemeral ATA as the account set
     commit_and_undelegate_accounts(payer, &[ata_info.clone()], magic_context, magic_program)

--- a/e-token/src/processor/undelegate_ephemeral_ata_permission.rs
+++ b/e-token/src/processor/undelegate_ephemeral_ata_permission.rs
@@ -2,8 +2,10 @@ use ephemeral_rollups_pinocchio::acl::{
     consts::PERMISSION_PROGRAM_ID, instruction::commit_and_undelegate_permission,
     pda::permission_pda_from_permissioned_account,
 };
-use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_unchecked, Initializable};
+use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+
+use crate::assert_signer;
 
 /// Commit and undelegate the permission PDA associated with an Ephemeral ATA.
 ///
@@ -24,20 +26,14 @@ pub fn process_undelegate_ephemeral_ata_permission(
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    if !payer_info.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
+    assert_signer!(payer_info);
 
     if *permission_program.address() != PERMISSION_PROGRAM_ID {
         return Err(ProgramError::InvalidAccountData);
     }
 
     let ephemeral_ata =
-        unsafe { load_unchecked::<EphemeralAta>(ephemeral_ata_info.borrow_unchecked())? };
-
-    if !ephemeral_ata.is_initialized() {
-        return Err(ProgramError::InvalidAccountData);
-    }
+        load_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked() })?;
 
     if ephemeral_ata.owner != *payer_info.address() {
         return Err(ProgramError::InvalidAccountData);

--- a/e-token/src/processor/undelegate_withdraw_and_close_shuttle_ephemeral_ata.rs
+++ b/e-token/src/processor/undelegate_withdraw_and_close_shuttle_ephemeral_ata.rs
@@ -66,7 +66,7 @@ pub fn process_undelegate_withdraw_and_close_shuttle_ephemeral_ata(
 
     validate_token_account(
         shuttle_wallet_ata_info,
-        &mint_info.address(),
+        mint_info.address(),
         Some(shuttle_info.address()),
         Some(token_program_info.address()),
     )?;

--- a/e-token/src/processor/undelegate_withdraw_and_close_shuttle_ephemeral_ata.rs
+++ b/e-token/src/processor/undelegate_withdraw_and_close_shuttle_ephemeral_ata.rs
@@ -2,12 +2,14 @@ use ephemeral_rollups_pinocchio::intent_bundle::{
     ActionArgs, CallHandler, MagicIntentBundleBuilder, ShortAccountMeta,
 };
 use ephemeral_spl_api::instruction::internal::CLOSE_SHUTTLE_ATA_INTENT;
+use ephemeral_spl_api::state::load_initialized;
 use ephemeral_spl_api::state::{
-    ephemeral_ata::EphemeralAta, load_unchecked, shuttle_ephemeral_ata::ShuttleMetadata,
-    Initializable,
+    ephemeral_ata::EphemeralAta, shuttle_ephemeral_ata::ShuttleMetadata,
 };
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
-use pinocchio_token_2022::state::TokenAccount;
+
+use crate::processor::utils::{get_associated_token_address, validate_token_account};
+use crate::{assert_associated_token_address, assert_owner, assert_signer};
 
 const DEFAULT_ESCROW_INDEX: u8 = u8::MAX;
 const INTENT_BUNDLE_DATA_BUF_SIZE: usize = 1536;
@@ -39,52 +41,41 @@ pub fn process_undelegate_withdraw_and_close_shuttle_ephemeral_ata(
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    if !executor.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
+    assert_signer!(executor);
+    assert_owner!(shuttle_info, &ephemeral_spl_api::program::id_address());
 
-    unsafe {
-        if shuttle_info
-            .owner()
-            .ne(&ephemeral_spl_api::program::id_address())
-        {
-            return Err(ProgramError::IllegalOwner);
-        }
-    }
-
-    let shuttle = unsafe { load_unchecked::<ShuttleMetadata>(shuttle_info.borrow_unchecked())? };
-    if !shuttle.is_initialized() {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    let shuttle = load_initialized::<ShuttleMetadata>(unsafe { shuttle_info.borrow_unchecked() })?;
     if shuttle.payer != *rent_reimbursement.address() {
         return Err(ProgramError::IncorrectAuthority);
     }
 
     let shuttle_ephemeral_ata =
-        unsafe { load_unchecked::<EphemeralAta>(shuttle_ephemeral_ata_info.borrow_unchecked())? };
-    if !shuttle_ephemeral_ata.is_initialized()
-        || shuttle_ephemeral_ata.owner != *shuttle_info.address()
+        load_initialized::<EphemeralAta>(unsafe { shuttle_ephemeral_ata_info.borrow_unchecked() })?;
+    if shuttle_ephemeral_ata.owner != *shuttle_info.address()
         || shuttle_ephemeral_ata.mint != *mint_info.address()
     {
         return Err(ProgramError::InvalidAccountData);
     }
 
-    let expected_shuttle_wallet_ata = get_associated_token_address(
-        shuttle_info.address(),
+    assert_associated_token_address!(
+        shuttle_wallet_ata_info.address(),
         mint_info.address(),
-        token_program_info.address(),
+        shuttle_info.address(),
+        token_program_info.address()
     );
-    if expected_shuttle_wallet_ata != *shuttle_wallet_ata_info.address() {
-        return Err(ProgramError::InvalidSeeds);
-    }
 
     validate_token_account(
         shuttle_wallet_ata_info,
-        token_program_info,
-        mint_info,
-        shuttle_info,
+        &mint_info.address(),
+        Some(shuttle_info.address()),
+        Some(token_program_info.address()),
     )?;
-    validate_destination_token_account(destination_token_info, token_program_info, mint_info)?;
+    validate_token_account(
+        destination_token_info,
+        mint_info.address(),
+        None,
+        Some(token_program_info.address()),
+    )?;
 
     undelegate_withdraw_and_close_shuttle_ephemeral_ata(
         executor,
@@ -110,67 +101,6 @@ fn parse_escrow_index(instruction_data: &[u8]) -> Result<u8, ProgramError> {
         return Err(ProgramError::InvalidInstructionData);
     }
     Ok(instruction_data[0])
-}
-
-#[inline(always)]
-fn get_associated_token_address(
-    wallet: &Address,
-    mint: &Address,
-    token_program: &Address,
-) -> Address {
-    ephemeral_spl_api::Address::find_program_address(
-        &[wallet.as_ref(), token_program.as_ref(), mint.as_ref()],
-        &pinocchio_associated_token_account::id(),
-    )
-    .0
-}
-
-#[inline(always)]
-fn validate_token_account(
-    account_info: &AccountView,
-    token_program_info: &AccountView,
-    mint_info: &AccountView,
-    owner_info: &AccountView,
-) -> ProgramResult {
-    if !account_info.owned_by(token_program_info.address()) {
-        return Err(ProgramError::IllegalOwner);
-    }
-
-    let account_data = unsafe { account_info.borrow_unchecked() };
-    if account_data.len() < TokenAccount::BASE_LEN {
-        return Err(ProgramError::InvalidAccountData);
-    }
-    let token = unsafe { TokenAccount::from_bytes_unchecked(account_data) };
-    if !token.is_initialized()
-        || token.owner() != owner_info.address()
-        || token.mint() != mint_info.address()
-    {
-        return Err(ProgramError::InvalidAccountData);
-    }
-
-    Ok(())
-}
-
-#[inline(always)]
-fn validate_destination_token_account(
-    destination_token_info: &AccountView,
-    token_program_info: &AccountView,
-    mint_info: &AccountView,
-) -> ProgramResult {
-    if !destination_token_info.owned_by(token_program_info.address()) {
-        return Err(ProgramError::IllegalOwner);
-    }
-
-    let destination_data = unsafe { destination_token_info.borrow_unchecked() };
-    if destination_data.len() < TokenAccount::BASE_LEN {
-        return Err(ProgramError::InvalidAccountData);
-    }
-    let destination = unsafe { TokenAccount::from_bytes_unchecked(destination_data) };
-    if !destination.is_initialized() || destination.mint() != mint_info.address() {
-        return Err(ProgramError::InvalidAccountData);
-    }
-
-    Ok(())
 }
 
 #[inline(never)]

--- a/e-token/src/processor/utils/asserts.rs
+++ b/e-token/src/processor/utils/asserts.rs
@@ -1,0 +1,34 @@
+#[macro_export]
+macro_rules! assert_owner {
+    ($account:expr, $expected_owner:expr) => {
+        unsafe {
+            if !pinocchio::address::address_eq($account.owner(), $expected_owner) {
+                return Err(pinocchio::error::ProgramError::InvalidAccountOwner);
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! assert_signer {
+    ($account:expr) => {
+        if !$account.is_signer() {
+            return Err(pinocchio::error::ProgramError::MissingRequiredSignature);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! assert_associated_token_address {
+    ($ata:expr, $mint:expr, $wallet:expr, $token_program:expr) => {
+        if $ata
+            != &crate::processor::utils::get_associated_token_address(
+                $wallet,
+                $mint,
+                $token_program,
+            )
+        {
+            return Err(ProgramError::InvalidAccountData);
+        }
+    };
+}

--- a/e-token/src/processor/utils/asserts.rs
+++ b/e-token/src/processor/utils/asserts.rs
@@ -26,7 +26,7 @@ macro_rules! assert_associated_token_address {
             $ata,
             &$crate::processor::utils::get_associated_token_address($wallet, $mint, $token_program),
         ) {
-            return Err(ProgramError::InvalidAccountData);
+            return Err(pinocchio::error::ProgramError::InvalidAccountData);
         }
     };
 }

--- a/e-token/src/processor/utils/asserts.rs
+++ b/e-token/src/processor/utils/asserts.rs
@@ -1,6 +1,7 @@
 #[macro_export]
 macro_rules! assert_owner {
     ($account:expr, $expected_owner:expr) => {
+        #[allow(clippy::macro_metavars_in_unsafe)]
         unsafe {
             if !pinocchio::address::address_eq($account.owner(), $expected_owner) {
                 return Err(pinocchio::error::ProgramError::InvalidAccountOwner);
@@ -21,13 +22,10 @@ macro_rules! assert_signer {
 #[macro_export]
 macro_rules! assert_associated_token_address {
     ($ata:expr, $mint:expr, $wallet:expr, $token_program:expr) => {
-        if $ata
-            != &crate::processor::utils::get_associated_token_address(
-                $wallet,
-                $mint,
-                $token_program,
-            )
-        {
+        if !pinocchio::address::address_eq(
+            $ata,
+            &$crate::processor::utils::get_associated_token_address($wallet, $mint, $token_program),
+        ) {
             return Err(ProgramError::InvalidAccountData);
         }
     };

--- a/e-token/src/processor/utils/asserts.rs
+++ b/e-token/src/processor/utils/asserts.rs
@@ -1,11 +1,8 @@
 #[macro_export]
 macro_rules! assert_owner {
     ($account:expr, $expected_owner:expr) => {
-        #[allow(clippy::macro_metavars_in_unsafe)]
-        unsafe {
-            if !pinocchio::address::address_eq($account.owner(), $expected_owner) {
-                return Err(pinocchio::error::ProgramError::InvalidAccountOwner);
-            }
+        if !pinocchio::address::address_eq(unsafe { $account.owner() }, $expected_owner) {
+            return Err(pinocchio::error::ProgramError::InvalidAccountOwner);
         }
     };
 }

--- a/e-token/src/processor/utils/mod.rs
+++ b/e-token/src/processor/utils/mod.rs
@@ -1,0 +1,4 @@
+mod asserts;
+mod token;
+
+pub use token::*;

--- a/e-token/src/processor/utils/token.rs
+++ b/e-token/src/processor/utils/token.rs
@@ -1,0 +1,77 @@
+use pinocchio::{address::address_eq, error::ProgramError, AccountView, Address};
+use pinocchio_token_2022::state::{Mint, TokenAccount};
+
+use crate::assert_owner;
+
+pub type ReadTokenAccount = (Address, Address, u64);
+
+#[inline(always)]
+pub(crate) fn read_mint_decimals(
+    mint_info: &AccountView,
+    token_program_info: &AccountView,
+) -> Result<u8, ProgramError> {
+    let mint_data = unsafe { mint_info.borrow_unchecked() };
+    if mint_data.len() < Mint::BASE_LEN {
+        return Err(ProgramError::InvalidAccountData);
+    }
+    if !mint_info.owned_by(token_program_info.address()) {
+        return Err(ProgramError::InvalidAccountOwner);
+    }
+    let mint = unsafe { Mint::from_bytes_unchecked(mint_data) };
+    if !mint.is_initialized() {
+        return Err(ProgramError::UninitializedAccount);
+    }
+    Ok(mint.decimals())
+}
+
+#[inline(always)]
+pub fn read_token_account(account: &AccountView) -> Result<ReadTokenAccount, ProgramError> {
+    let token_data = unsafe { account.borrow_unchecked() };
+    if token_data.len() < TokenAccount::BASE_LEN {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    let token = unsafe { TokenAccount::from_bytes_unchecked(token_data) };
+    if !token.is_initialized() {
+        return Err(ProgramError::UninitializedAccount);
+    }
+
+    Ok((*token.mint(), *token.owner(), token.amount()))
+}
+
+#[inline(always)]
+pub(crate) fn validate_token_account(
+    ata_info: &AccountView,
+    expected_mint: &Address,
+    expected_owner: Option<&Address>,
+    expected_token_program: Option<&Address>,
+) -> Result<ReadTokenAccount, ProgramError> {
+    if let Some(token_program) = expected_token_program {
+        assert_owner!(ata_info, token_program);
+    }
+
+    let (mint, owner, amount) = read_token_account(ata_info)?;
+    if !address_eq(&mint, expected_mint) {
+        return Err(ProgramError::InvalidAccountData);
+    }
+    if let Some(expected_owner) = expected_owner {
+        if !address_eq(&owner, expected_owner) {
+            return Err(ProgramError::IllegalOwner);
+        }
+    }
+
+    Ok((mint, owner, amount))
+}
+
+#[inline(always)]
+pub fn get_associated_token_address(
+    wallet: &Address,
+    mint: &Address,
+    token_program: &Address,
+) -> Address {
+    ephemeral_spl_api::Address::find_program_address(
+        &[wallet.as_ref(), token_program.as_ref(), mint.as_ref()],
+        &pinocchio_associated_token_account::ID,
+    )
+    .0
+}

--- a/e-token/src/processor/utils/token.rs
+++ b/e-token/src/processor/utils/token.rs
@@ -3,8 +3,6 @@ use pinocchio_token_2022::state::{Mint, TokenAccount};
 
 use crate::assert_owner;
 
-pub type ReadTokenAccount = (Address, Address, u64);
-
 #[inline(always)]
 pub(crate) fn read_mint_decimals(
     mint_info: &AccountView,
@@ -25,7 +23,7 @@ pub(crate) fn read_mint_decimals(
 }
 
 #[inline(always)]
-pub fn read_token_account(account: &AccountView) -> Result<ReadTokenAccount, ProgramError> {
+pub fn read_token_account(account: &AccountView) -> Result<&TokenAccount, ProgramError> {
     let token_data = unsafe { account.borrow_unchecked() };
     if token_data.len() < TokenAccount::BASE_LEN {
         return Err(ProgramError::InvalidAccountData);
@@ -36,31 +34,31 @@ pub fn read_token_account(account: &AccountView) -> Result<ReadTokenAccount, Pro
         return Err(ProgramError::UninitializedAccount);
     }
 
-    Ok((*token.mint(), *token.owner(), token.amount()))
+    Ok(token)
 }
 
 #[inline(always)]
-pub(crate) fn validate_token_account(
-    ata_info: &AccountView,
+pub(crate) fn validate_token_account<'a>(
+    ata_info: &'a AccountView,
     expected_mint: &Address,
     expected_owner: Option<&Address>,
     expected_token_program: Option<&Address>,
-) -> Result<ReadTokenAccount, ProgramError> {
+) -> Result<&'a TokenAccount, ProgramError> {
     if let Some(token_program) = expected_token_program {
         assert_owner!(ata_info, token_program);
     }
 
-    let (mint, owner, amount) = read_token_account(ata_info)?;
-    if !address_eq(&mint, expected_mint) {
+    let token = read_token_account(ata_info)?;
+    if !address_eq(token.mint(), expected_mint) {
         return Err(ProgramError::InvalidAccountData);
     }
     if let Some(expected_owner) = expected_owner {
-        if !address_eq(&owner, expected_owner) {
+        if !address_eq(token.owner(), expected_owner) {
             return Err(ProgramError::IllegalOwner);
         }
     }
 
-    Ok((mint, owner, amount))
+    Ok(token)
 }
 
 #[inline(always)]

--- a/e-token/src/processor/withdraw_spl_tokens.rs
+++ b/e-token/src/processor/withdraw_spl_tokens.rs
@@ -1,12 +1,13 @@
+use crate::{assert_owner, assert_signer, processor::utils::read_mint_decimals};
 use core::marker::PhantomData;
-use ephemeral_spl_api::error::EphemeralSplError;
+use ephemeral_spl_api::{error::EphemeralSplError, state::load_initialized};
 use pinocchio::cpi::{Seed, Signer};
+
 use {
     ephemeral_spl_api::state::{
-        ephemeral_ata::load_ephemeral_ata_compat_mut, global_vault::GlobalVault, load_unchecked,
+        ephemeral_ata::load_ephemeral_ata_compat_mut, global_vault::GlobalVault,
     },
     pinocchio::{error::ProgramError, AccountView, ProgramResult},
-    pinocchio_token_2022::state::Mint,
 };
 
 #[inline(always)]
@@ -57,34 +58,23 @@ pub(crate) fn withdraw_ephemeral_ata_tokens(
     token_program_info: &AccountView,
     amount: u64,
 ) -> ProgramResult {
-    if require_owner_signature && !owner.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
+    if require_owner_signature {
+        assert_signer!(owner);
     }
 
     // Validate EphemeralAta account (writable)
-    unsafe {
-        if ephemeral_ata_info
-            .owner()
-            .ne(&ephemeral_spl_api::program::id_address())
-        {
-            return Err(ProgramError::IllegalOwner);
-        }
-    }
+    assert_owner!(
+        ephemeral_ata_info,
+        &ephemeral_spl_api::program::id_address()
+    );
     let mut ephemeral_ata =
         load_ephemeral_ata_compat_mut(unsafe { ephemeral_ata_info.borrow_unchecked_mut() })?;
 
     // Validate vault ownership before reading raw data.
-    unsafe {
-        if vault_info
-            .owner()
-            .ne(&ephemeral_spl_api::program::id_address())
-        {
-            return Err(ProgramError::IllegalOwner);
-        }
-    }
+    assert_owner!(vault_info, &ephemeral_spl_api::program::id_address());
 
     // Validate Vault data account
-    let vault = unsafe { load_unchecked::<GlobalVault>(vault_info.borrow_unchecked())? };
+    let vault = load_initialized::<GlobalVault>(unsafe { vault_info.borrow_unchecked() })?;
 
     // Check eata consistency
     if ephemeral_ata.mint() != mint_info.address()
@@ -96,17 +86,7 @@ pub(crate) fn withdraw_ephemeral_ata_tokens(
     }
 
     // Parse the base mint layout shared by both legacy SPL Token and Token-2022.
-    let decimals = {
-        let mint_data = unsafe { mint_info.borrow_unchecked() };
-        if mint_data.len() < Mint::BASE_LEN {
-            return Err(ProgramError::InvalidAccountData);
-        }
-        let mint = unsafe { Mint::from_bytes_unchecked(mint_data) };
-        if !mint.is_initialized() {
-            return Err(ProgramError::UninitializedAccount);
-        }
-        mint.decimals()
-    };
+    let decimals = read_mint_decimals(mint_info, token_program_info)?;
 
     // Perform transfer from vault token account to user destination, signed by vault PDA
     let bump = [vault.bump];

--- a/e-token/src/processor/withdraw_through_delegated_shuttle_with_merge.rs
+++ b/e-token/src/processor/withdraw_through_delegated_shuttle_with_merge.rs
@@ -73,15 +73,15 @@ pub fn process_withdraw_through_delegated_shuttle_with_merge(
     }
 
     validate_token_account(
-        &accounts.owner_token_info,
+        accounts.owner_token_info,
         &prepared.mint,
-        Some(&accounts.owner_info.address()),
+        Some(accounts.owner_info.address()),
         Some(accounts.token_program_info.address()),
     )?;
     validate_token_account(
-        &accounts.shuttle_wallet_ata_info,
+        accounts.shuttle_wallet_ata_info,
         &prepared.mint,
-        Some(&accounts.shuttle_info.address()),
+        Some(accounts.shuttle_info.address()),
         Some(accounts.token_program_info.address()),
     )?;
 

--- a/e-token/src/processor/withdraw_through_delegated_shuttle_with_merge.rs
+++ b/e-token/src/processor/withdraw_through_delegated_shuttle_with_merge.rs
@@ -2,10 +2,9 @@ use dlp_api::compact::ClearText;
 use ephemeral_rollups_pinocchio::consts::{MAGIC_CONTEXT_ID, MAGIC_PROGRAM_ID};
 use ephemeral_spl_api::{
     instruction::internal,
-    state::{ephemeral_ata::EphemeralAta, load_unchecked},
+    state::{ephemeral_ata::EphemeralAta, load},
 };
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
-use pinocchio_token_2022::state::TokenAccount;
 use solana_instruction::{AccountMeta, Instruction};
 use solana_pubkey::Pubkey;
 
@@ -14,9 +13,12 @@ const TRANSFER_CHECKED_DISCRIMINATOR: u8 = 12;
 #[cfg(feature = "logging")]
 use crate::alloc::string::ToString;
 
-use crate::processor::deposit_and_delegate_shuttle_ephemeral_ata_with_merge::{
-    delegate_sponsored_shuttle_with_post_actions, prepare_sponsored_shuttle_delegation,
-    read_mint_decimals, DepositAndDelegateShuttleArgs,
+use crate::processor::{
+    deposit_and_delegate_shuttle_ephemeral_ata_with_merge::{
+        delegate_sponsored_shuttle_with_post_actions, prepare_sponsored_shuttle_delegation,
+        DepositAndDelegateShuttleArgs,
+    },
+    utils::{read_mint_decimals, validate_token_account},
 };
 
 pub(crate) struct WithdrawThroughDelegatedShuttleAccounts<'a> {
@@ -70,16 +72,28 @@ pub fn process_withdraw_through_delegated_shuttle_with_merge(
         return Ok(());
     }
 
-    validate_token_accounts(&accounts, &prepared.mint)?;
+    validate_token_account(
+        &accounts.owner_token_info,
+        &prepared.mint,
+        Some(&accounts.owner_info.address()),
+        Some(accounts.token_program_info.address()),
+    )?;
+    validate_token_account(
+        &accounts.shuttle_wallet_ata_info,
+        &prepared.mint,
+        Some(&accounts.shuttle_info.address()),
+        Some(accounts.token_program_info.address()),
+    )?;
 
-    let decimals = read_mint_decimals(accounts.mint_info)?;
+    let decimals = read_mint_decimals(accounts.mint_info, accounts.token_program_info)?;
     let post_actions = alloc::vec![
         transfer_owner_tokens_into_shuttle_action(&accounts, args.amount(), decimals)?,
         undelegate_withdraw_and_close_shuttle_action(&accounts),
     ];
 
+    // Shuttle has been initialized above
     let shuttle_eata =
-        unsafe { load_unchecked::<EphemeralAta>(accounts.shuttle_eata_info.borrow_unchecked())? };
+        load::<EphemeralAta>(unsafe { accounts.shuttle_eata_info.borrow_unchecked() })?;
 
     delegate_sponsored_shuttle_with_post_actions(
         accounts.payer_info,
@@ -127,47 +141,6 @@ fn parse_withdraw_through_delegated_shuttle_accounts(
     })
 }
 
-fn validate_token_accounts(
-    accounts: &WithdrawThroughDelegatedShuttleAccounts<'_>,
-    expected_mint: &ephemeral_spl_api::Address,
-) -> ProgramResult {
-    if !accounts
-        .owner_token_info
-        .owned_by(accounts.token_program_info.address())
-        || !accounts
-            .shuttle_wallet_ata_info
-            .owned_by(accounts.token_program_info.address())
-    {
-        return Err(ProgramError::IllegalOwner);
-    }
-
-    let owner_token_data = unsafe { accounts.owner_token_info.borrow_unchecked() };
-    if owner_token_data.len() < TokenAccount::BASE_LEN {
-        return Err(ProgramError::InvalidAccountData);
-    }
-    let owner_token = unsafe { TokenAccount::from_bytes_unchecked(owner_token_data) };
-    if !owner_token.is_initialized()
-        || owner_token.owner() != accounts.owner_info.address()
-        || owner_token.mint() != expected_mint
-    {
-        return Err(ProgramError::InvalidAccountData);
-    }
-
-    let shuttle_wallet_data = unsafe { accounts.shuttle_wallet_ata_info.borrow_unchecked() };
-    if shuttle_wallet_data.len() < TokenAccount::BASE_LEN {
-        return Err(ProgramError::InvalidAccountData);
-    }
-    let shuttle_wallet = unsafe { TokenAccount::from_bytes_unchecked(shuttle_wallet_data) };
-    if !shuttle_wallet.is_initialized()
-        || shuttle_wallet.owner() != accounts.shuttle_info.address()
-        || shuttle_wallet.mint() != expected_mint
-    {
-        return Err(ProgramError::InvalidAccountData);
-    }
-
-    Ok(())
-}
-
 fn transfer_owner_tokens_into_shuttle_action(
     accounts: &WithdrawThroughDelegatedShuttleAccounts<'_>,
     amount: u64,
@@ -180,10 +153,10 @@ fn transfer_owner_tokens_into_shuttle_action(
     Ok(Instruction {
         program_id: *accounts.token_program_info.address(),
         accounts: alloc::vec![
-            AccountMeta::new(pubkey(accounts.owner_token_info.address()), false),
-            AccountMeta::new_readonly(pubkey(accounts.mint_info.address()), false),
-            AccountMeta::new(pubkey(accounts.shuttle_wallet_ata_info.address()), false),
-            AccountMeta::new_readonly(pubkey(accounts.owner_info.address()), true),
+            AccountMeta::new(*accounts.owner_token_info.address(), false),
+            AccountMeta::new_readonly(*accounts.mint_info.address(), false),
+            AccountMeta::new(*accounts.shuttle_wallet_ata_info.address(), false),
+            AccountMeta::new_readonly(*accounts.owner_info.address(), true),
         ],
         data,
     })
@@ -195,22 +168,17 @@ fn undelegate_withdraw_and_close_shuttle_action(
     Instruction {
         program_id: Pubkey::from(ephemeral_spl_api::program::ID),
         accounts: alloc::vec![
-            AccountMeta::new(pubkey(accounts.payer_info.address()), true),
-            AccountMeta::new(pubkey(accounts.rent_pda_info.address()), false),
-            AccountMeta::new_readonly(pubkey(accounts.shuttle_info.address()), false),
-            AccountMeta::new_readonly(pubkey(accounts.shuttle_eata_info.address()), false),
-            AccountMeta::new(pubkey(accounts.shuttle_wallet_ata_info.address()), false),
-            AccountMeta::new(pubkey(accounts.owner_token_info.address()), false),
-            AccountMeta::new_readonly(pubkey(accounts.mint_info.address()), false),
-            AccountMeta::new_readonly(pubkey(accounts.token_program_info.address()), false),
+            AccountMeta::new(*accounts.payer_info.address(), true),
+            AccountMeta::new(*accounts.rent_pda_info.address(), false),
+            AccountMeta::new_readonly(*accounts.shuttle_info.address(), false),
+            AccountMeta::new_readonly(*accounts.shuttle_eata_info.address(), false),
+            AccountMeta::new(*accounts.shuttle_wallet_ata_info.address(), false),
+            AccountMeta::new(*accounts.owner_token_info.address(), false),
+            AccountMeta::new_readonly(*accounts.mint_info.address(), false),
+            AccountMeta::new_readonly(*accounts.token_program_info.address(), false),
             AccountMeta::new(Pubkey::from(MAGIC_CONTEXT_ID.to_bytes()), false),
             AccountMeta::new_readonly(Pubkey::from(MAGIC_PROGRAM_ID.to_bytes()), false),
         ],
         data: alloc::vec![internal::UNDELEGATE_WITHDRAW_AND_CLOSE_SHUTTLE_EPHEMERAL_ATA],
     }
-}
-
-#[inline(always)]
-fn pubkey(address: &ephemeral_spl_api::Address) -> Pubkey {
-    *address
 }

--- a/e-token/tests/deposit_and_delegate_shuttle_ephemeral_ata_with_merge.rs
+++ b/e-token/tests/deposit_and_delegate_shuttle_ephemeral_ata_with_merge.rs
@@ -2,8 +2,8 @@ use dlp_api::state::DelegationRecord;
 use ephemeral_spl_api::instruction;
 use ephemeral_spl_api::program::ID;
 use ephemeral_spl_api::state::ephemeral_ata::EphemeralAta;
+use ephemeral_spl_api::state::load_initialized;
 use ephemeral_spl_api::state::shuttle_ephemeral_ata::ShuttleMetadata;
-use ephemeral_spl_api::state::{load, Initializable};
 use solana_account::Account;
 use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
@@ -220,8 +220,7 @@ async fn deposit_and_delegate_shuttle_ephemeral_ata_with_merge_deposits_and_stor
         .expect("shuttle metadata must exist");
     assert_eq!(shuttle_account.owner, PROGRAM);
     let mut shuttle_data = shuttle_account.data.clone();
-    let shuttle = load::<ShuttleMetadata>(shuttle_data.as_mut_slice()).unwrap();
-    assert!(shuttle.is_initialized());
+    let shuttle = load_initialized::<ShuttleMetadata>(shuttle_data.as_mut_slice()).unwrap();
     assert_eq!(shuttle.owner.as_array(), &owner.pubkey().to_bytes());
     assert_eq!(shuttle.payer.as_array(), &rent_pda.to_bytes());
     assert_eq!(shuttle.id, shuttle_id);
@@ -237,7 +236,8 @@ async fn deposit_and_delegate_shuttle_ephemeral_ata_with_merge_deposits_and_stor
         ephemeral_spl_api::program::DELEGATION_PROGRAM_ID
     );
     let mut shuttle_eata_data = shuttle_eata_account.data.clone();
-    let shuttle_eata_state = load::<EphemeralAta>(shuttle_eata_data.as_mut_slice()).unwrap();
+    let shuttle_eata_state =
+        load_initialized::<EphemeralAta>(shuttle_eata_data.as_mut_slice()).unwrap();
     assert_eq!(shuttle_eata_state.amount, DEPOSIT_AMOUNT);
 
     let shuttle_wallet_account = context

--- a/e-token/tests/deposit_and_delegate_shuttle_ephemeral_ata_with_merge.rs
+++ b/e-token/tests/deposit_and_delegate_shuttle_ephemeral_ata_with_merge.rs
@@ -3,7 +3,7 @@ use ephemeral_spl_api::instruction;
 use ephemeral_spl_api::program::ID;
 use ephemeral_spl_api::state::ephemeral_ata::EphemeralAta;
 use ephemeral_spl_api::state::shuttle_ephemeral_ata::ShuttleMetadata;
-use ephemeral_spl_api::state::{load_mut_unchecked, Initializable};
+use ephemeral_spl_api::state::{load, Initializable};
 use solana_account::Account;
 use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
@@ -220,8 +220,7 @@ async fn deposit_and_delegate_shuttle_ephemeral_ata_with_merge_deposits_and_stor
         .expect("shuttle metadata must exist");
     assert_eq!(shuttle_account.owner, PROGRAM);
     let mut shuttle_data = shuttle_account.data.clone();
-    let shuttle =
-        unsafe { load_mut_unchecked::<ShuttleMetadata>(shuttle_data.as_mut_slice()).unwrap() };
+    let shuttle = load::<ShuttleMetadata>(shuttle_data.as_mut_slice()).unwrap();
     assert!(shuttle.is_initialized());
     assert_eq!(shuttle.owner.as_array(), &owner.pubkey().to_bytes());
     assert_eq!(shuttle.payer.as_array(), &rent_pda.to_bytes());
@@ -238,8 +237,7 @@ async fn deposit_and_delegate_shuttle_ephemeral_ata_with_merge_deposits_and_stor
         ephemeral_spl_api::program::DELEGATION_PROGRAM_ID
     );
     let mut shuttle_eata_data = shuttle_eata_account.data.clone();
-    let shuttle_eata_state =
-        unsafe { load_mut_unchecked::<EphemeralAta>(shuttle_eata_data.as_mut_slice()).unwrap() };
+    let shuttle_eata_state = load::<EphemeralAta>(shuttle_eata_data.as_mut_slice()).unwrap();
     assert_eq!(shuttle_eata_state.amount, DEPOSIT_AMOUNT);
 
     let shuttle_wallet_account = context

--- a/e-token/tests/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
+++ b/e-token/tests/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
@@ -4,7 +4,7 @@ use ephemeral_spl_api::program::ID;
 use ephemeral_spl_api::state::ephemeral_ata::EphemeralAta;
 use ephemeral_spl_api::state::shuttle_ephemeral_ata::ShuttleMetadata;
 use ephemeral_spl_api::state::transfer_queue::{header_len, TransferQueueHeader, QUEUE_SEED};
-use ephemeral_spl_api::state::{load_mut_unchecked, Initializable};
+use ephemeral_spl_api::state::{load, Initializable};
 use solana_account::Account;
 use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
@@ -320,8 +320,7 @@ async fn deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_trans
         .expect("shuttle metadata must exist");
     assert_eq!(shuttle_account.owner, PROGRAM);
     let mut shuttle_data = shuttle_account.data.clone();
-    let shuttle =
-        unsafe { load_mut_unchecked::<ShuttleMetadata>(shuttle_data.as_mut_slice()).unwrap() };
+    let shuttle = load::<ShuttleMetadata>(shuttle_data.as_mut_slice()).unwrap();
     assert!(shuttle.is_initialized());
     assert_eq!(shuttle.owner.as_array(), &owner.pubkey().to_bytes());
     assert_eq!(shuttle.payer.as_array(), &rent_pda.to_bytes());
@@ -338,8 +337,7 @@ async fn deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_trans
         ephemeral_spl_api::program::DELEGATION_PROGRAM_ID
     );
     let mut shuttle_eata_data = shuttle_eata_account.data.clone();
-    let shuttle_eata_state =
-        unsafe { load_mut_unchecked::<EphemeralAta>(shuttle_eata_data.as_mut_slice()).unwrap() };
+    let shuttle_eata_state = load::<EphemeralAta>(shuttle_eata_data.as_mut_slice()).unwrap();
     assert_eq!(shuttle_eata_state.amount, DEPOSIT_AMOUNT);
 
     let owner_source_account = context

--- a/e-token/tests/deposit_shuttle_spl_tokens.rs
+++ b/e-token/tests/deposit_shuttle_spl_tokens.rs
@@ -2,7 +2,7 @@ use ephemeral_spl_api::instruction;
 use ephemeral_spl_api::program::ID;
 use ephemeral_spl_api::state::ephemeral_ata::EphemeralAta;
 use ephemeral_spl_api::state::shuttle_ephemeral_ata::ShuttleMetadata;
-use ephemeral_spl_api::state::{load_mut_unchecked, RawType};
+use ephemeral_spl_api::state::{load, RawType};
 use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
 use solana_program_pack::Pack;
@@ -155,7 +155,7 @@ async fn deposit_spl_tokens_increments_shuttle_amount() {
     assert_eq!(account.data.len(), ShuttleMetadata::LEN);
 
     let mut mut_acc = account.data.clone();
-    let shuttle = unsafe { load_mut_unchecked::<ShuttleMetadata>(mut_acc.as_mut_slice()).unwrap() };
+    let shuttle = load::<ShuttleMetadata>(mut_acc.as_mut_slice()).unwrap();
     assert_eq!(shuttle.id, shuttle_id);
     assert_eq!(shuttle.owner.as_array(), &owner.to_bytes());
     assert_eq!(shuttle.payer.as_array(), &payer.to_bytes());
@@ -168,8 +168,7 @@ async fn deposit_spl_tokens_increments_shuttle_amount() {
         .expect("shuttle eata must exist");
     assert_eq!(shuttle_eata_account.data.len(), EphemeralAta::LEN);
     let mut mut_shuttle_eata = shuttle_eata_account.data.clone();
-    let shuttle_eata_data =
-        unsafe { load_mut_unchecked::<EphemeralAta>(mut_shuttle_eata.as_mut_slice()).unwrap() };
+    let shuttle_eata_data = load::<EphemeralAta>(mut_shuttle_eata.as_mut_slice()).unwrap();
     assert_eq!(shuttle_eata_data.amount, amount);
     assert_eq!(
         shuttle_eata_data.owner.as_array(),

--- a/e-token/tests/deposit_shuttle_spl_tokens.rs
+++ b/e-token/tests/deposit_shuttle_spl_tokens.rs
@@ -2,7 +2,7 @@ use ephemeral_spl_api::instruction;
 use ephemeral_spl_api::program::ID;
 use ephemeral_spl_api::state::ephemeral_ata::EphemeralAta;
 use ephemeral_spl_api::state::shuttle_ephemeral_ata::ShuttleMetadata;
-use ephemeral_spl_api::state::{load, RawType};
+use ephemeral_spl_api::state::{load_initialized, RawType};
 use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
 use solana_program_pack::Pack;
@@ -155,7 +155,7 @@ async fn deposit_spl_tokens_increments_shuttle_amount() {
     assert_eq!(account.data.len(), ShuttleMetadata::LEN);
 
     let mut mut_acc = account.data.clone();
-    let shuttle = load::<ShuttleMetadata>(mut_acc.as_mut_slice()).unwrap();
+    let shuttle = load_initialized::<ShuttleMetadata>(mut_acc.as_mut_slice()).unwrap();
     assert_eq!(shuttle.id, shuttle_id);
     assert_eq!(shuttle.owner.as_array(), &owner.to_bytes());
     assert_eq!(shuttle.payer.as_array(), &payer.to_bytes());
@@ -168,7 +168,8 @@ async fn deposit_spl_tokens_increments_shuttle_amount() {
         .expect("shuttle eata must exist");
     assert_eq!(shuttle_eata_account.data.len(), EphemeralAta::LEN);
     let mut mut_shuttle_eata = shuttle_eata_account.data.clone();
-    let shuttle_eata_data = load::<EphemeralAta>(mut_shuttle_eata.as_mut_slice()).unwrap();
+    let shuttle_eata_data =
+        load_initialized::<EphemeralAta>(mut_shuttle_eata.as_mut_slice()).unwrap();
     assert_eq!(shuttle_eata_data.amount, amount);
     assert_eq!(
         shuttle_eata_data.owner.as_array(),

--- a/e-token/tests/deposit_spl_tokens.rs
+++ b/e-token/tests/deposit_spl_tokens.rs
@@ -168,7 +168,7 @@ async fn deposit_spl_tokens_increments_ephemeral_amount() {
     assert_eq!(account.owner, PROGRAM);
     assert_eq!(account.data.len(), EphemeralAta::LEN);
 
-    let mut mut_acc = account.data.clone();
-    let ata_data = load::<EphemeralAta>(mut_acc.as_mut_slice()).unwrap();
+    let mut_acc = account.data.clone();
+    let ata_data = load::<EphemeralAta>(mut_acc.as_slice()).unwrap();
     assert_eq!(ata_data.amount, amount);
 }

--- a/e-token/tests/deposit_spl_tokens.rs
+++ b/e-token/tests/deposit_spl_tokens.rs
@@ -1,7 +1,7 @@
 use ephemeral_spl_api::instruction;
 use ephemeral_spl_api::program::ID;
 use ephemeral_spl_api::state::ephemeral_ata::EphemeralAta;
-use ephemeral_spl_api::state::{load_mut_unchecked, RawType};
+use ephemeral_spl_api::state::{load, RawType};
 use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
 use solana_program_pack::Pack;
@@ -169,6 +169,6 @@ async fn deposit_spl_tokens_increments_ephemeral_amount() {
     assert_eq!(account.data.len(), EphemeralAta::LEN);
 
     let mut mut_acc = account.data.clone();
-    let ata_data = unsafe { load_mut_unchecked::<EphemeralAta>(mut_acc.as_mut_slice()).unwrap() };
+    let ata_data = load::<EphemeralAta>(mut_acc.as_mut_slice()).unwrap();
     assert_eq!(ata_data.amount, amount);
 }

--- a/e-token/tests/deposit_spl_tokens.rs
+++ b/e-token/tests/deposit_spl_tokens.rs
@@ -1,7 +1,7 @@
 use ephemeral_spl_api::instruction;
 use ephemeral_spl_api::program::ID;
 use ephemeral_spl_api::state::ephemeral_ata::EphemeralAta;
-use ephemeral_spl_api::state::{load, RawType};
+use ephemeral_spl_api::state::{load_initialized, RawType};
 use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
 use solana_program_pack::Pack;
@@ -169,6 +169,6 @@ async fn deposit_spl_tokens_increments_ephemeral_amount() {
     assert_eq!(account.data.len(), EphemeralAta::LEN);
 
     let mut_acc = account.data.clone();
-    let ata_data = load::<EphemeralAta>(mut_acc.as_slice()).unwrap();
+    let ata_data = load_initialized::<EphemeralAta>(mut_acc.as_slice()).unwrap();
     assert_eq!(ata_data.amount, amount);
 }

--- a/e-token/tests/initialize_ephemeral_ata.rs
+++ b/e-token/tests/initialize_ephemeral_ata.rs
@@ -1,6 +1,6 @@
 use ephemeral_spl_api::program::ID;
 use ephemeral_spl_api::state::ephemeral_ata::EphemeralAta;
-use ephemeral_spl_api::state::{load_mut_unchecked, Initializable, RawType};
+use ephemeral_spl_api::state::{load, Initializable, RawType};
 use solana_instruction::Instruction;
 use {
     ephemeral_spl_api::instruction,
@@ -63,8 +63,7 @@ async fn initialize_ephemeral_ata() {
     assert_eq!(account.data.len(), EphemeralAta::LEN);
 
     let mut mut_acc = account.data.clone();
-    let ephemeral_ata =
-        unsafe { load_mut_unchecked::<EphemeralAta>(mut_acc.as_mut_slice()).unwrap() };
+    let ephemeral_ata = load::<EphemeralAta>(mut_acc.as_mut_slice()).unwrap();
     assert!(ephemeral_ata.is_initialized());
     assert_eq!(ephemeral_ata.amount, 0);
     assert_eq!(ephemeral_ata.owner.as_array(), &user.to_bytes());

--- a/e-token/tests/initialize_ephemeral_ata.rs
+++ b/e-token/tests/initialize_ephemeral_ata.rs
@@ -1,6 +1,6 @@
 use ephemeral_spl_api::program::ID;
 use ephemeral_spl_api::state::ephemeral_ata::EphemeralAta;
-use ephemeral_spl_api::state::{load, Initializable, RawType};
+use ephemeral_spl_api::state::{load_initialized, Initializable, RawType};
 use solana_instruction::Instruction;
 use {
     ephemeral_spl_api::instruction,
@@ -63,7 +63,7 @@ async fn initialize_ephemeral_ata() {
     assert_eq!(account.data.len(), EphemeralAta::LEN);
 
     let mut mut_acc = account.data.clone();
-    let ephemeral_ata = load::<EphemeralAta>(mut_acc.as_mut_slice()).unwrap();
+    let ephemeral_ata = load_initialized::<EphemeralAta>(mut_acc.as_mut_slice()).unwrap();
     assert!(ephemeral_ata.is_initialized());
     assert_eq!(ephemeral_ata.amount, 0);
     assert_eq!(ephemeral_ata.owner.as_array(), &user.to_bytes());

--- a/e-token/tests/initialize_global_vault.rs
+++ b/e-token/tests/initialize_global_vault.rs
@@ -1,7 +1,7 @@
 use ephemeral_spl_api::program::ID;
 use ephemeral_spl_api::state::ephemeral_ata::EphemeralAta;
 use ephemeral_spl_api::state::global_vault::GlobalVault;
-use ephemeral_spl_api::state::{load_mut_unchecked, Initializable, RawType};
+use ephemeral_spl_api::state::{load, Initializable, RawType};
 use solana_account::Account as SolanaAccount;
 use solana_instruction::Instruction;
 use solana_keypair::Keypair;
@@ -82,7 +82,7 @@ async fn initialize_global_vault() {
     assert_eq!(account.data.len(), GlobalVault::LEN);
 
     let mut mut_acc = account.data.clone();
-    let vault_data = unsafe { load_mut_unchecked::<GlobalVault>(mut_acc.as_mut_slice()).unwrap() };
+    let vault_data = load::<GlobalVault>(mut_acc.as_mut_slice()).unwrap();
     assert!(vault_data.is_initialized());
 
     let vault_token_acc_state = context
@@ -176,7 +176,7 @@ async fn initialize_global_vault_migrates_legacy_layout() {
     assert!(account.lamports >= rent.minimum_balance(GlobalVault::LEN));
 
     let mut mut_acc = account.data.clone();
-    let vault_data = unsafe { load_mut_unchecked::<GlobalVault>(mut_acc.as_mut_slice()).unwrap() };
+    let vault_data = load::<GlobalVault>(mut_acc.as_mut_slice()).unwrap();
     assert_eq!(
         vault_data.mint,
         ephemeral_spl_api::Address::new_from_array(mint.to_bytes())

--- a/e-token/tests/initialize_global_vault.rs
+++ b/e-token/tests/initialize_global_vault.rs
@@ -1,7 +1,7 @@
 use ephemeral_spl_api::program::ID;
 use ephemeral_spl_api::state::ephemeral_ata::EphemeralAta;
 use ephemeral_spl_api::state::global_vault::GlobalVault;
-use ephemeral_spl_api::state::{load, Initializable, RawType};
+use ephemeral_spl_api::state::{load_initialized, RawType};
 use solana_account::Account as SolanaAccount;
 use solana_instruction::Instruction;
 use solana_keypair::Keypair;
@@ -82,8 +82,8 @@ async fn initialize_global_vault() {
     assert_eq!(account.data.len(), GlobalVault::LEN);
 
     let mut mut_acc = account.data.clone();
-    let vault_data = load::<GlobalVault>(mut_acc.as_mut_slice()).unwrap();
-    assert!(vault_data.is_initialized());
+    let vault_data = load_initialized::<GlobalVault>(mut_acc.as_mut_slice()).unwrap();
+    assert_eq!(vault_data.mint, mint);
 
     let vault_token_acc_state = context
         .banks_client
@@ -176,7 +176,7 @@ async fn initialize_global_vault_migrates_legacy_layout() {
     assert!(account.lamports >= rent.minimum_balance(GlobalVault::LEN));
 
     let mut mut_acc = account.data.clone();
-    let vault_data = load::<GlobalVault>(mut_acc.as_mut_slice()).unwrap();
+    let vault_data = load_initialized::<GlobalVault>(mut_acc.as_mut_slice()).unwrap();
     assert_eq!(
         vault_data.mint,
         ephemeral_spl_api::Address::new_from_array(mint.to_bytes())

--- a/e-token/tests/initialize_shuttle_ephemeral_ata.rs
+++ b/e-token/tests/initialize_shuttle_ephemeral_ata.rs
@@ -2,7 +2,7 @@ use ephemeral_spl_api::instruction;
 use ephemeral_spl_api::program::ID;
 use ephemeral_spl_api::state::ephemeral_ata::EphemeralAta;
 use ephemeral_spl_api::state::shuttle_ephemeral_ata::ShuttleMetadata;
-use ephemeral_spl_api::state::{load, Initializable, RawType};
+use ephemeral_spl_api::state::{load_initialized, RawType};
 use solana_instruction::Instruction;
 use solana_keypair::Keypair;
 use solana_program_pack::Pack;
@@ -77,8 +77,7 @@ async fn initialize_shuttle_ephemeral_ata() {
     assert_eq!(account.data.len(), ShuttleMetadata::LEN);
 
     let mut mut_acc = account.data.clone();
-    let shuttle = load::<ShuttleMetadata>(mut_acc.as_mut_slice()).unwrap();
-    assert!(shuttle.is_initialized());
+    let shuttle = load_initialized::<ShuttleMetadata>(mut_acc.as_mut_slice()).unwrap();
     assert_eq!(shuttle.owner.as_array(), &owner.to_bytes());
     assert_eq!(shuttle.payer.as_array(), &payer.to_bytes());
     assert_eq!(shuttle.id, shuttle_id);
@@ -93,7 +92,7 @@ async fn initialize_shuttle_ephemeral_ata() {
     assert_eq!(shuttle_eata_account.data.len(), EphemeralAta::LEN);
 
     let mut mut_eata_acc = shuttle_eata_account.data.clone();
-    let shuttle_eata_data = load::<EphemeralAta>(mut_eata_acc.as_mut_slice()).unwrap();
+    let shuttle_eata_data = load_initialized::<EphemeralAta>(mut_eata_acc.as_mut_slice()).unwrap();
     assert_eq!(
         shuttle_eata_data.owner.as_array(),
         &shuttle_ephemeral_ata.to_bytes()

--- a/e-token/tests/initialize_shuttle_ephemeral_ata.rs
+++ b/e-token/tests/initialize_shuttle_ephemeral_ata.rs
@@ -2,7 +2,7 @@ use ephemeral_spl_api::instruction;
 use ephemeral_spl_api::program::ID;
 use ephemeral_spl_api::state::ephemeral_ata::EphemeralAta;
 use ephemeral_spl_api::state::shuttle_ephemeral_ata::ShuttleMetadata;
-use ephemeral_spl_api::state::{load_mut_unchecked, Initializable, RawType};
+use ephemeral_spl_api::state::{load, Initializable, RawType};
 use solana_instruction::Instruction;
 use solana_keypair::Keypair;
 use solana_program_pack::Pack;
@@ -77,7 +77,7 @@ async fn initialize_shuttle_ephemeral_ata() {
     assert_eq!(account.data.len(), ShuttleMetadata::LEN);
 
     let mut mut_acc = account.data.clone();
-    let shuttle = unsafe { load_mut_unchecked::<ShuttleMetadata>(mut_acc.as_mut_slice()).unwrap() };
+    let shuttle = load::<ShuttleMetadata>(mut_acc.as_mut_slice()).unwrap();
     assert!(shuttle.is_initialized());
     assert_eq!(shuttle.owner.as_array(), &owner.to_bytes());
     assert_eq!(shuttle.payer.as_array(), &payer.to_bytes());
@@ -93,8 +93,7 @@ async fn initialize_shuttle_ephemeral_ata() {
     assert_eq!(shuttle_eata_account.data.len(), EphemeralAta::LEN);
 
     let mut mut_eata_acc = shuttle_eata_account.data.clone();
-    let shuttle_eata_data =
-        unsafe { load_mut_unchecked::<EphemeralAta>(mut_eata_acc.as_mut_slice()).unwrap() };
+    let shuttle_eata_data = load::<EphemeralAta>(mut_eata_acc.as_mut_slice()).unwrap();
     assert_eq!(
         shuttle_eata_data.owner.as_array(),
         &shuttle_ephemeral_ata.to_bytes()

--- a/e-token/tests/merge_shuttle_into_ephemeral_ata.rs
+++ b/e-token/tests/merge_shuttle_into_ephemeral_ata.rs
@@ -1,7 +1,7 @@
 use ephemeral_spl_api::instruction;
 use ephemeral_spl_api::program::ID;
 use ephemeral_spl_api::state::shuttle_ephemeral_ata::ShuttleMetadata;
-use ephemeral_spl_api::state::{load_mut_unchecked, RawType};
+use ephemeral_spl_api::state::{load, RawType};
 use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
 use solana_program_pack::Pack;
@@ -176,8 +176,7 @@ async fn merge_shuttle_into_ephemeral_ata_transfers_from_shuttle_ata_to_destinat
     assert_eq!(shuttle_account.owner, PROGRAM);
     assert_eq!(shuttle_account.data.len(), ShuttleMetadata::LEN);
     let mut shuttle_data = shuttle_account.data.clone();
-    let shuttle =
-        unsafe { load_mut_unchecked::<ShuttleMetadata>(shuttle_data.as_mut_slice()).unwrap() };
+    let shuttle = load::<ShuttleMetadata>(shuttle_data.as_mut_slice()).unwrap();
     assert_eq!(shuttle.id, shuttle_id);
     assert_eq!(shuttle.owner.as_array(), &owner.to_bytes());
     assert_eq!(shuttle.payer.as_array(), &payer.to_bytes());

--- a/e-token/tests/merge_shuttle_into_ephemeral_ata.rs
+++ b/e-token/tests/merge_shuttle_into_ephemeral_ata.rs
@@ -1,7 +1,7 @@
 use ephemeral_spl_api::instruction;
 use ephemeral_spl_api::program::ID;
 use ephemeral_spl_api::state::shuttle_ephemeral_ata::ShuttleMetadata;
-use ephemeral_spl_api::state::{load, RawType};
+use ephemeral_spl_api::state::{load_initialized, RawType};
 use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
 use solana_program_pack::Pack;
@@ -176,7 +176,7 @@ async fn merge_shuttle_into_ephemeral_ata_transfers_from_shuttle_ata_to_destinat
     assert_eq!(shuttle_account.owner, PROGRAM);
     assert_eq!(shuttle_account.data.len(), ShuttleMetadata::LEN);
     let mut shuttle_data = shuttle_account.data.clone();
-    let shuttle = load::<ShuttleMetadata>(shuttle_data.as_mut_slice()).unwrap();
+    let shuttle = load_initialized::<ShuttleMetadata>(shuttle_data.as_mut_slice()).unwrap();
     assert_eq!(shuttle.id, shuttle_id);
     assert_eq!(shuttle.owner.as_array(), &owner.to_bytes());
     assert_eq!(shuttle.payer.as_array(), &payer.to_bytes());

--- a/e-token/tests/undelegation_ephemeral_ata_callback.rs
+++ b/e-token/tests/undelegation_ephemeral_ata_callback.rs
@@ -2,7 +2,7 @@ use dlp_api::pda::{fees_vault_pda, validator_fees_vault_pda_from_validator};
 use ephemeral_rollups_pinocchio::consts::DELEGATION_PROGRAM_ID;
 use ephemeral_spl_api::program::ID;
 use ephemeral_spl_api::state::ephemeral_ata::EphemeralAta;
-use ephemeral_spl_api::state::{load_mut_unchecked, RawType};
+use ephemeral_spl_api::state::{load_mut, RawType};
 use solana_account::Account;
 use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
@@ -62,7 +62,7 @@ async fn undelegation_callback_restores_ephemeral_ata() {
 
     // Setup the delegated PDA
     let mut data = vec![0u8; EphemeralAta::LEN];
-    let ephemeral_ata = unsafe { load_mut_unchecked::<EphemeralAta>(data.as_mut_slice()).unwrap() };
+    let ephemeral_ata = load_mut::<EphemeralAta>(data.as_mut_slice()).unwrap();
     ephemeral_ata.mint = pinocchio::Address::new_from_array(mint.to_bytes());
     ephemeral_ata.amount = 500;
     pt.add_account(

--- a/e-token/tests/withdraw_spl_tokens.rs
+++ b/e-token/tests/withdraw_spl_tokens.rs
@@ -1,7 +1,7 @@
 use ephemeral_spl_api::instruction;
 use ephemeral_spl_api::program::ID;
 use ephemeral_spl_api::state::ephemeral_ata::EphemeralAta;
-use ephemeral_spl_api::state::{load_mut_unchecked, RawType};
+use ephemeral_spl_api::state::{load, RawType};
 use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
 use solana_program_pack::Pack;
@@ -183,6 +183,6 @@ async fn withdraw_spl_tokens_decrements_ephemeral_amount() {
     assert_eq!(account.data.len(), EphemeralAta::LEN);
 
     let mut mut_acc = account.data.clone();
-    let ata_data = unsafe { load_mut_unchecked::<EphemeralAta>(mut_acc.as_mut_slice()).unwrap() };
+    let ata_data = load::<EphemeralAta>(mut_acc.as_mut_slice()).unwrap();
     assert_eq!(ata_data.amount, deposit_amount - withdraw_amount);
 }

--- a/e-token/tests/withdraw_through_delegated_shuttle_with_merge.rs
+++ b/e-token/tests/withdraw_through_delegated_shuttle_with_merge.rs
@@ -4,11 +4,14 @@ use std::{
 };
 
 use dlp_api::state::DelegationRecord;
-use ephemeral_spl_api::instruction::{self, internal};
 use ephemeral_spl_api::program::ID;
 use ephemeral_spl_api::state::ephemeral_ata::EphemeralAta;
 use ephemeral_spl_api::state::shuttle_ephemeral_ata::ShuttleMetadata;
-use ephemeral_spl_api::state::{load_mut_unchecked, Initializable, RawType};
+use ephemeral_spl_api::state::{load, Initializable, RawType};
+use ephemeral_spl_api::{
+    instruction::{self, internal},
+    state::load_mut,
+};
 use magicblock_magic_program_api::{
     args::{MagicIntentBundleArgs, UndelegateTypeArgs},
     instruction::MagicBlockInstruction,
@@ -301,8 +304,7 @@ async fn withdraw_through_delegated_shuttle_with_merge_stores_transfer_and_clean
         .unwrap()
         .expect("shuttle metadata must exist");
     let mut shuttle_data = shuttle_account.data.clone();
-    let shuttle =
-        unsafe { load_mut_unchecked::<ShuttleMetadata>(shuttle_data.as_mut_slice()).unwrap() };
+    let shuttle = load::<ShuttleMetadata>(shuttle_data.as_mut_slice()).unwrap();
     assert!(shuttle.is_initialized());
     assert_eq!(shuttle.owner.as_array(), &owner.pubkey().to_bytes());
     assert_eq!(shuttle.payer.as_array(), &rent_pda.to_bytes());
@@ -318,8 +320,7 @@ async fn withdraw_through_delegated_shuttle_with_merge_stores_transfer_and_clean
         ephemeral_spl_api::program::DELEGATION_PROGRAM_ID
     );
     let mut shuttle_eata_data = shuttle_eata_account.data.clone();
-    let shuttle_eata_state =
-        unsafe { load_mut_unchecked::<EphemeralAta>(shuttle_eata_data.as_mut_slice()).unwrap() };
+    let shuttle_eata_state = load::<EphemeralAta>(shuttle_eata_data.as_mut_slice()).unwrap();
     assert_eq!(shuttle_eata_state.amount, 0);
 
     let owner_source_account = context
@@ -371,15 +372,13 @@ async fn undelegate_withdraw_and_close_shuttle_ephemeral_ata_schedules_close_act
     let shuttle_wallet_ata = utils::derive_associated_token_address(shuttle_metadata, mint);
 
     let mut shuttle_data = vec![0u8; ShuttleMetadata::LEN];
-    let shuttle_state =
-        unsafe { load_mut_unchecked::<ShuttleMetadata>(shuttle_data.as_mut_slice()).unwrap() };
+    let shuttle_state = load_mut::<ShuttleMetadata>(shuttle_data.as_mut_slice()).unwrap();
     shuttle_state.owner = owner.pubkey();
     shuttle_state.payer = rent_pda;
     shuttle_state.id = shuttle_id;
 
     let mut shuttle_eata_data = vec![0u8; EphemeralAta::LEN];
-    let shuttle_eata_state =
-        unsafe { load_mut_unchecked::<EphemeralAta>(shuttle_eata_data.as_mut_slice()).unwrap() };
+    let shuttle_eata_state = load_mut::<EphemeralAta>(shuttle_eata_data.as_mut_slice()).unwrap();
     shuttle_eata_state.owner = shuttle_metadata;
     shuttle_eata_state.mint = mint;
     shuttle_eata_state.amount = 0;

--- a/e-token/tests/withdraw_through_delegated_shuttle_with_merge.rs
+++ b/e-token/tests/withdraw_through_delegated_shuttle_with_merge.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use dlp_api::state::DelegationRecord;
-use ephemeral_spl_api::program::ID;
 use ephemeral_spl_api::state::ephemeral_ata::EphemeralAta;
 use ephemeral_spl_api::state::shuttle_ephemeral_ata::ShuttleMetadata;
 use ephemeral_spl_api::state::{load, Initializable, RawType};
@@ -12,6 +11,7 @@ use ephemeral_spl_api::{
     instruction::{self, internal},
     state::load_mut,
 };
+use ephemeral_spl_api::{program::ID, state::load_initialized};
 use magicblock_magic_program_api::{
     args::{MagicIntentBundleArgs, UndelegateTypeArgs},
     instruction::MagicBlockInstruction,
@@ -320,7 +320,8 @@ async fn withdraw_through_delegated_shuttle_with_merge_stores_transfer_and_clean
         ephemeral_spl_api::program::DELEGATION_PROGRAM_ID
     );
     let mut shuttle_eata_data = shuttle_eata_account.data.clone();
-    let shuttle_eata_state = load::<EphemeralAta>(shuttle_eata_data.as_mut_slice()).unwrap();
+    let shuttle_eata_state =
+        load_initialized::<EphemeralAta>(shuttle_eata_data.as_mut_slice()).unwrap();
     assert_eq!(shuttle_eata_state.amount, 0);
 
     let owner_source_account = context


### PR DESCRIPTION
This PR tries to use the same logic for several security checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized validation utilities and assertion macros to standardize account, signer, and ownership checks.

* **Bug Fixes**
  * Replaced unsafe/unchecked account parsing with safer, initialization-aware loaders across processors and state handling.
  * Consolidated token-account and mint-decimals validation into shared helpers to reduce duplicated logic and improve consistency.

* **Tests**
  * Updated tests to use the safer loading and validation helpers.

* **Chores**
  * Made the ID-address helper usable in constant contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->