### PR TITLE
feat: per validator queue

### DIFF
--- a/e-token-api/src/lib.rs
+++ b/e-token-api/src/lib.rs
@@ -136,6 +136,8 @@ pub mod instruction {
     ///      [5..13] transfer amount (u64 LE)
     ///      [13..45] optional validator pubkey
     pub const WITHDRAW_THROUGH_DELEGATED_SHUTTLE_WITH_MERGE: u8 = 26;
+    /// 27 - AllocateTransferQueue: allocates more space for the transfer queue
+    pub const ALLOCATE_TRANSFER_QUEUE: u8 = 27;
 
     /// Internal-only instruction discriminators used by the on-chain program.
     pub mod internal {

--- a/e-token-api/src/state/transfer_queue.rs
+++ b/e-token-api/src/state/transfer_queue.rs
@@ -21,6 +21,7 @@ pub struct TransferQueueHeader {
     pub _pad1: [u8; 4],
     pub next_task_id: u64,
     pub crank_task_id: i64,
+    pub validator: Address,
 }
 
 /// One queued transfer entry.
@@ -38,9 +39,6 @@ pub struct QueuedTransfer {
     pub flags: u8,
     pub _pad0: [u8; 7],
 }
-
-const _: [(); 64] = [(); core::mem::size_of::<TransferQueueHeader>()];
-const _: [(); 104] = [(); core::mem::size_of::<QueuedTransfer>()];
 
 impl QueuedTransfer {
     #[inline(always)]
@@ -114,7 +112,12 @@ pub fn queue_views_mut(
 
 /// Initializes an uninitialized queue (version == 0).
 /// Idempotent when already initialized with the same version.
-pub fn init_queue(data: &mut [u8], bump: u8, mint: Address) -> Result<(), ProgramError> {
+pub fn init_queue(
+    data: &mut [u8],
+    bump: u8,
+    mint: Address,
+    validator: Address,
+) -> Result<(), ProgramError> {
     let (header, items) = queue_views_mut(data)?;
     if items.is_empty() {
         return Err(ProgramError::InvalidAccountData);
@@ -126,6 +129,7 @@ pub fn init_queue(data: &mut [u8], bump: u8, mint: Address) -> Result<(), Progra
             header.version = TRANSFER_QUEUE_VERSION;
             header.bump = bump;
             header.mint = mint;
+            header.validator = validator;
             Ok(())
         }
         TRANSFER_QUEUE_VERSION => {
@@ -177,7 +181,7 @@ pub fn queue_len_for_mint_with_capacity(
     data: &[u8],
     expected_mint: &Address,
     required_slots: usize,
-) -> Result<usize, ProgramError> {
+) -> Result<(usize, Address), ProgramError> {
     let (header, items) = queue_views_checked(data)?;
     if header.mint != *expected_mint {
         return Err(ProgramError::InvalidAccountData);
@@ -189,7 +193,7 @@ pub fn queue_len_for_mint_with_capacity(
         return Err(ProgramError::AccountDataTooSmall);
     }
 
-    Ok(queue_len)
+    Ok((queue_len, header.validator))
 }
 
 #[inline(always)]
@@ -394,7 +398,7 @@ mod tests {
         let mut aligned = std::vec![0u64; words];
         let data = &mut bytemuck::cast_slice_mut::<u64, u8>(&mut aligned)[..data_len];
 
-        init_queue(data, 1, addr(9)).unwrap();
+        init_queue(data, 1, addr(9), addr(10)).unwrap();
 
         queue_push_from_data(data, item(2, 2, 100, 10, 5)).unwrap();
         queue_push_from_data(data, item(3, 3, 200, 10, 2)).unwrap();
@@ -427,7 +431,7 @@ mod tests {
         let mut aligned = std::vec![0u64; words];
         let data = &mut bytemuck::cast_slice_mut::<u64, u8>(&mut aligned)[..data_len];
 
-        init_queue(data, 1, addr(9)).unwrap();
+        init_queue(data, 1, addr(9), addr(10)).unwrap();
 
         queue_push_from_data(data, item(1, 1, 100, 10, 5)).unwrap();
         queue_push_from_data(data, item(9, 9, 50, 10, 5)).unwrap();
@@ -445,7 +449,7 @@ mod tests {
         let mut aligned = std::vec![0u64; words];
         let data = &mut bytemuck::cast_slice_mut::<u64, u8>(&mut aligned)[..data_len];
 
-        init_queue(data, 1, addr(7)).unwrap();
+        init_queue(data, 1, addr(7), addr(10)).unwrap();
         assert_eq!(queue_crank_task_id_from_data(data).unwrap(), None);
 
         queue_set_crank_task_id_from_data(data, 42).unwrap();

--- a/e-token/src/entrypoint.rs
+++ b/e-token/src/entrypoint.rs
@@ -218,6 +218,12 @@ pub(crate) fn inner_process_instruction(
 
             process_initialize_rent_pda(accounts, instruction_data)
         }
+        instruction::ALLOCATE_TRANSFER_QUEUE => {
+            #[cfg(feature = "logging")]
+            pinocchio_log::log!("Instruction: AllocateTransferQueue");
+
+            process_allocate_transfer_queue(accounts, instruction_data)
+        }
         internal::UNDELEGATION_CALLBACK => {
             #[cfg(feature = "logging")]
             pinocchio_log::log!("Instruction: UndelegationCallback");

--- a/e-token/src/processor/allocate_transfer_queue.rs
+++ b/e-token/src/processor/allocate_transfer_queue.rs
@@ -1,0 +1,55 @@
+use ephemeral_spl_api::state::transfer_queue::{item_len, queue_views_checked, QUEUE_SEED};
+use pinocchio::address::address_eq;
+use pinocchio::sysvars::rent::Rent;
+use pinocchio::sysvars::Sysvar;
+use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+
+use crate::assert_owner;
+
+pub const MAX_ITEMS_PER_REALLOC: usize = 10_240 / item_len();
+
+#[inline(always)]
+pub fn process_allocate_transfer_queue(
+    accounts: &[AccountView],
+    _instruction_data: &[u8],
+) -> ProgramResult {
+    // Expected accounts:
+    // 1. [writable] Transfer queue account (PDA derived from [QUEUE_SEED, mint, validator])
+    // 2. []         System program
+
+    let [queue_info, _system_program_info, ..] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    assert_owner!(queue_info, &ephemeral_spl_api::program::id_address());
+
+    let realloc_size = {
+        let (header, _) = queue_views_checked(unsafe { queue_info.borrow_unchecked() })?;
+        let bump_seed = [header.bump];
+        let derived_queue = ephemeral_spl_api::Address::create_program_address(
+            &[
+                QUEUE_SEED,
+                header.mint.as_ref(),
+                header.validator.as_ref(),
+                bump_seed.as_ref(),
+            ],
+            &ephemeral_spl_api::program::id_address(),
+        )?;
+        if !address_eq(&derived_queue, queue_info.address()) {
+            return Err(ProgramError::InvalidSeeds);
+        }
+
+        let rent = Rent::get()?;
+        let cost_per_item = rent.try_minimum_balance(item_len())? - rent.try_minimum_balance(0)?;
+        let remaining_capacity =
+            queue_info.lamports() - rent.try_minimum_balance(queue_info.data_len())?;
+        let current_items = remaining_capacity / cost_per_item;
+        current_items.min(MAX_ITEMS_PER_REALLOC as u64) as usize * item_len()
+    };
+
+    pinocchio_log::log!("Reallocating transfer queue to size: {}", realloc_size);
+
+    queue_info.resize(queue_info.data_len() + realloc_size)?;
+
+    Ok(())
+}

--- a/e-token/src/processor/allocate_transfer_queue.rs
+++ b/e-token/src/processor/allocate_transfer_queue.rs
@@ -47,8 +47,6 @@ pub fn process_allocate_transfer_queue(
         current_items.min(MAX_ITEMS_PER_REALLOC as u64) as usize * item_len()
     };
 
-    pinocchio_log::log!("Reallocating transfer queue to size: {}", realloc_size);
-
     queue_info.resize(queue_info.data_len() + realloc_size)?;
 
     Ok(())

--- a/e-token/src/processor/close_shuttle_ata_intent.rs
+++ b/e-token/src/processor/close_shuttle_ata_intent.rs
@@ -100,7 +100,7 @@ pub fn process_close_shuttle_ata_intent(
         let (mint, shuttle_wallet_amount) = {
             let token_account = validate_token_account(
                 shuttle_wallet_ata_info,
-                &mint_info.address(),
+                mint_info.address(),
                 Some(shuttle_info.address()),
                 Some(token_program_info.address()),
             )?;

--- a/e-token/src/processor/delegate_transfer_queue.rs
+++ b/e-token/src/processor/delegate_transfer_queue.rs
@@ -11,7 +11,7 @@ pub fn process_delegate_transfer_queue(
 ) -> ProgramResult {
     // Expected accounts:
     // 0. [signer]   Payer
-    // 1. [writable] Transfer queue PDA derived from [QUEUE_SEED, mint]
+    // 1. [writable] Transfer queue PDA derived from [QUEUE_SEED, mint, validator]
     // 2. []         Mint account
     // 3. []         Owner program (this program)
     // 4. [writable] Buffer account
@@ -37,7 +37,7 @@ pub fn process_delegate_transfer_queue(
         return Err(ProgramError::IllegalOwner);
     }
 
-    let bump = {
+    let (bump, validator) = {
         let data = unsafe { queue_info.borrow_unchecked() };
         let (header, _) = queue_views_checked(data)?;
         if header.mint != *mint_info.address() {
@@ -47,7 +47,12 @@ pub fn process_delegate_transfer_queue(
         let bump = header.bump;
         let bump_seed = [bump];
         let derived_queue = ephemeral_spl_api::Address::create_program_address(
-            &[QUEUE_SEED, mint_info.address().as_ref(), bump_seed.as_ref()],
+            &[
+                QUEUE_SEED,
+                mint_info.address().as_ref(),
+                header.validator.as_ref(),
+                bump_seed.as_ref(),
+            ],
             &program_id,
         )
         .map_err(|_| ProgramError::InvalidAccountData)?;
@@ -55,7 +60,7 @@ pub fn process_delegate_transfer_queue(
             return Err(ProgramError::InvalidSeeds);
         }
 
-        bump
+        (bump, header.validator)
     };
 
     if queue_info.owned_by(&delegation_program) {
@@ -70,10 +75,10 @@ pub fn process_delegate_transfer_queue(
     }
 
     let config = DelegateConfig {
-        validator: Some(pinocchio_system::ID),
+        validator: Some(validator),
         ..DelegateConfig::default()
     };
-    let seeds: &[&[u8]] = &[QUEUE_SEED, mint_info.address().as_ref()];
+    let seeds: &[&[u8]] = &[QUEUE_SEED, mint_info.address().as_ref(), validator.as_ref()];
 
     DelegateAccountCpiBuilder::new(
         payer_info,

--- a/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
+++ b/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
@@ -9,6 +9,7 @@ use dlp_api::args::{
     MaybeEncryptedPubkey,
 };
 use dlp_api::compact::{self};
+use dlp_api::consts::DEFAULT_VALIDATOR_IDENTITY;
 
 use ephemeral_spl_api::state::transfer_queue::QUEUE_SEED;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
@@ -31,7 +32,7 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private
     // Expected accounts:
     // 0..17 Same as DepositAndDelegateShuttleEphemeralAtaWithMerge, except there is no
     //        cleartext destination ATA account in this outer instruction.
-    // 18. [writable] Transfer queue PDA derived from [QUEUE_SEED, mint]
+    // 18. [writable] Transfer queue PDA derived from [QUEUE_SEED, mint, validator]
     //
     let args = DepositAndDelegateShuttleWithPrivateTransferArgs::try_from_bytes(instruction_data)?;
     if args.amount() == 0 {
@@ -76,7 +77,13 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private
 
     let program_id = ephemeral_spl_api::program::id_address();
     let (derived_queue, _) = ephemeral_spl_api::Address::find_program_address(
-        &[QUEUE_SEED, common_accounts.mint_info.address().as_ref()],
+        &[
+            QUEUE_SEED,
+            common_accounts.mint_info.address().as_ref(),
+            args.validator()?
+                .unwrap_or(DEFAULT_VALIDATOR_IDENTITY.to_bytes())
+                .as_ref(),
+        ],
         &program_id,
     );
     if derived_queue != *queue_info.address() {

--- a/e-token/src/processor/deposit_and_queue_transfer.rs
+++ b/e-token/src/processor/deposit_and_queue_transfer.rs
@@ -19,7 +19,7 @@ pub fn process_deposit_and_queue_transfer(
     instruction_data: &[u8],
 ) -> ProgramResult {
     // Expected accounts:
-    // 0. [writable] Transfer queue PDA derived from [QUEUE_SEED, mint]
+    // 0. [writable] Transfer queue PDA derived from [QUEUE_SEED, mint, validator]
     // 1. []         Global vault PDA derived from [mint]
     // 2. []         Mint account
     // 3. [writable] User source token account
@@ -47,19 +47,20 @@ pub fn process_deposit_and_queue_transfer(
     )?;
 
     let split = args.split() as usize;
+    let (queue_len_before, validator) = {
+        let data = unsafe { queue_info.borrow_unchecked() };
+        queue_len_for_mint_with_capacity(data, mint_info.address(), split)?
+    };
+
     let program_id = ephemeral_spl_api::program::id_address();
     let (derived_queue, _) = ephemeral_spl_api::Address::find_program_address(
-        &[QUEUE_SEED, mint_info.address().as_ref()],
+        &[QUEUE_SEED, mint_info.address().as_ref(), validator.as_ref()],
         &program_id,
     );
     if derived_queue != *queue_info.address() {
         return Err(ProgramError::InvalidSeeds);
     }
 
-    let queue_len_before = {
-        let data = unsafe { queue_info.borrow_unchecked() };
-        queue_len_for_mint_with_capacity(data, mint_info.address(), split)?
-    };
     #[cfg(not(feature = "logging"))]
     let _ = queue_len_before;
 

--- a/e-token/src/processor/ensure_transfer_queue_crank.rs
+++ b/e-token/src/processor/ensure_transfer_queue_crank.rs
@@ -1,5 +1,6 @@
 use core::mem::MaybeUninit;
 
+use dlp_api::pda::magic_fee_vault_pda_from_validator;
 use ephemeral_rollups_pinocchio::crank::{CrankInstruction, ScheduleCrankArgs, ScheduleCrankCpi};
 use ephemeral_spl_api::instruction::internal::PROCESS_TRANSFER_QUEUE_TICK;
 use ephemeral_spl_api::state::transfer_queue::{
@@ -14,8 +15,8 @@ use crate::{assert_owner, assert_signer};
 
 pub const CRANK_EXECUTION_INTERVAL_MILLIS: i64 = 500;
 
-const PROCESS_QUEUE_TICK_CRANK_ACCOUNTS: usize = 3;
-const SCHEDULE_CRANK_CPI_ACCOUNTS: usize = 4;
+const PROCESS_QUEUE_TICK_CRANK_ACCOUNTS: usize = 4;
+const SCHEDULE_CRANK_CPI_ACCOUNTS: usize = 5;
 const SCHEDULE_CRANK_DATA_LEN: usize =
     4 + 8 + 8 + 8 + 8 + 32 + 8 + (PROCESS_QUEUE_TICK_CRANK_ACCOUNTS * 34) + 8 + 1;
 
@@ -31,9 +32,12 @@ pub fn process_ensure_transfer_queue_crank(
     // Expected accounts:
     // 0. [writable, signer] Payer for the recurring crank
     // 1. [writable] Transfer queue PDA derived from [QUEUE_SEED, mint, validator]
-    // 2. [writable] Magic context account
-    // 3. []         Magic program
-    let [payer_info, queue_info, magic_context_info, magic_program_info, ..] = accounts else {
+    // 2. [writable] Validator magic fee vault PDA derived from ["magic-fee-vault", validator]
+    // 3. [writable] Magic context account
+    // 4. []         Magic program
+    let [payer_info, queue_info, magic_fee_vault_info, magic_context_info, magic_program_info, ..] =
+        accounts
+    else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
@@ -65,6 +69,10 @@ pub fn process_ensure_transfer_queue_crank(
     if derived_queue != *queue_info.address() {
         return Err(ProgramError::InvalidSeeds);
     }
+    let derived_magic_fee_vault = magic_fee_vault_pda_from_validator(&validator.to_bytes().into());
+    if derived_magic_fee_vault.to_bytes() != magic_fee_vault_info.address().to_bytes() {
+        return Err(ProgramError::InvalidSeeds);
+    }
 
     let crank_task_id = derive_queue_crank_task_id(queue_info.address());
     let data = unsafe { queue_info.borrow_unchecked() };
@@ -79,6 +87,11 @@ pub fn process_ensure_transfer_queue_crank(
     let tick_accounts = [
         InstructionAccount {
             address: queue_info.address(),
+            is_signer: false,
+            is_writable: true,
+        },
+        InstructionAccount {
+            address: magic_fee_vault_info.address(),
             is_signer: false,
             is_writable: true,
         },
@@ -120,9 +133,12 @@ pub fn process_ensure_transfer_queue_crank(
             .write(InstructionAccount::readonly(queue_info.address()));
         schedule_accounts
             .get_unchecked_mut(2)
-            .write(InstructionAccount::readonly(magic_context_info.address()));
+            .write(InstructionAccount::readonly(magic_fee_vault_info.address()));
         schedule_accounts
             .get_unchecked_mut(3)
+            .write(InstructionAccount::readonly(magic_context_info.address()));
+        schedule_accounts
+            .get_unchecked_mut(4)
             .write(InstructionAccount::readonly(magic_program_info.address()));
     }
 
@@ -139,6 +155,7 @@ pub fn process_ensure_transfer_queue_crank(
     let schedule_account_refs = [
         payer_info,
         queue_info,
+        magic_fee_vault_info,
         magic_context_info,
         magic_program_info,
     ];

--- a/e-token/src/processor/ensure_transfer_queue_crank.rs
+++ b/e-token/src/processor/ensure_transfer_queue_crank.rs
@@ -30,7 +30,7 @@ pub fn process_ensure_transfer_queue_crank(
 
     // Expected accounts:
     // 0. [writable, signer] Payer for the recurring crank
-    // 1. [writable] Transfer queue PDA derived from [QUEUE_SEED, mint]
+    // 1. [writable] Transfer queue PDA derived from [QUEUE_SEED, mint, validator]
     // 2. [writable] Magic context account
     // 3. []         Magic program
     let [payer_info, queue_info, magic_context_info, magic_program_info, ..] = accounts else {
@@ -45,15 +45,20 @@ pub fn process_ensure_transfer_queue_crank(
         return Err(ProgramError::IncorrectProgramId);
     }
 
-    let (mint, bump) = {
+    let (mint, bump, validator) = {
         let data = unsafe { queue_info.borrow_unchecked() };
         let (header, _) = queue_views_checked(data)?;
-        (header.mint, header.bump)
+        (header.mint, header.bump, header.validator)
     };
 
     let bump_seed = [bump];
     let derived_queue = ephemeral_spl_api::Address::create_program_address(
-        &[QUEUE_SEED, mint.as_ref(), bump_seed.as_ref()],
+        &[
+            QUEUE_SEED,
+            mint.as_ref(),
+            validator.as_ref(),
+            bump_seed.as_ref(),
+        ],
         &program_id,
     )
     .map_err(|_| ProgramError::InvalidAccountData)?;

--- a/e-token/src/processor/initialize_transfer_queue.rs
+++ b/e-token/src/processor/initialize_transfer_queue.rs
@@ -10,7 +10,8 @@ use pinocchio_system::instructions::CreateAccount;
 
 pub const DEFAULT_TRANSFER_QUEUE_ITEMS: u32 = 92;
 /// Default queue size in bytes. (HEADER_LEN + ITEM_LEN * DEFAULT_TRANSFER_QUEUE_ITEMS)
-pub const DEFAULT_TRANSFER_QUEUE_SIZE_BYTES: u64 = 96 + 104 * DEFAULT_TRANSFER_QUEUE_ITEMS as u64;
+pub const DEFAULT_TRANSFER_QUEUE_SIZE_BYTES: u64 =
+    (header_len() + item_len() * DEFAULT_TRANSFER_QUEUE_ITEMS as usize) as u64;
 
 #[inline(always)]
 pub fn process_initialize_transfer_queue(

--- a/e-token/src/processor/initialize_transfer_queue.rs
+++ b/e-token/src/processor/initialize_transfer_queue.rs
@@ -8,7 +8,9 @@ use pinocchio::sysvars::Sysvar;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 use pinocchio_system::instructions::CreateAccount;
 
-pub const DEFAULT_TRANSFER_QUEUE_SIZE_BYTES: usize = 9_728;
+pub const DEFAULT_TRANSFER_QUEUE_ITEMS: u32 = 92;
+/// Default queue size in bytes. (HEADER_LEN + ITEM_LEN * DEFAULT_TRANSFER_QUEUE_ITEMS)
+pub const DEFAULT_TRANSFER_QUEUE_SIZE_BYTES: u64 = 96 + 104 * DEFAULT_TRANSFER_QUEUE_ITEMS as u64;
 
 #[inline(always)]
 pub fn process_initialize_transfer_queue(
@@ -17,30 +19,36 @@ pub fn process_initialize_transfer_queue(
 ) -> ProgramResult {
     // Expected accounts:
     // 0. [signer]   Payer (funds account creation)
-    // 1. [writable] Transfer queue account (PDA derived from [QUEUE_SEED, mint])
+    // 1. [writable] Transfer queue account (PDA derived from [QUEUE_SEED, mint, validator])
     // 2. []         Mint account (seed)
-    // 3. []         System program
+    // 3. []         Validator
+    // 4. []         System program
     let args = InitializeTransferQueueArgs::try_from_bytes(instruction_data)?;
 
-    let [payer_info, queue_info, mint_info, _system_program_info, ..] = accounts else {
+    let [payer_info, queue_info, mint_info, validator_info, _system_program_info, ..] = accounts
+    else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    let requested_size = args.size_bytes() as usize;
-    let queue_size = if requested_size == 0 {
-        DEFAULT_TRANSFER_QUEUE_SIZE_BYTES
+    let (requested_items, queue_size) = if let Some(items) = args.requested_items() {
+        (items, header_len() + item_len() * items as usize)
     } else {
-        requested_size
+        (
+            DEFAULT_TRANSFER_QUEUE_ITEMS,
+            DEFAULT_TRANSFER_QUEUE_SIZE_BYTES as usize,
+        )
     };
-
-    let min_size = header_len() + item_len();
-    if queue_size < min_size {
+    if requested_items == 0 {
         return Err(ProgramError::InvalidInstructionData);
-    }
+    };
 
     let program_id = ephemeral_spl_api::program::id_address();
     let (derived_queue, bump) = ephemeral_spl_api::Address::find_program_address(
-        &[QUEUE_SEED, mint_info.address().as_ref()],
+        &[
+            QUEUE_SEED,
+            mint_info.address().as_ref(),
+            validator_info.address().as_ref(),
+        ],
         &program_id,
     );
     if derived_queue != *queue_info.address() {
@@ -60,14 +68,16 @@ pub fn process_initialize_transfer_queue(
         let signer_seeds = [
             Seed::from(QUEUE_SEED),
             Seed::from(mint_info.address().as_ref()),
+            Seed::from(validator_info.address().as_ref()),
             Seed::from(&bump_seed),
         ];
         let signer = Signer::from(&signer_seeds);
 
+        // Allocate the default space but fund the desired size's rent.
         CreateAccount {
             from: payer_info,
             to: queue_info,
-            space: queue_size as u64,
+            space: (queue_size as u64).min(DEFAULT_TRANSFER_QUEUE_SIZE_BYTES),
             lamports: Rent::get()?.try_minimum_balance(queue_size)?,
             owner: &program_id,
         }
@@ -80,10 +90,13 @@ pub fn process_initialize_transfer_queue(
     }
 
     let data = unsafe { queue_info.borrow_unchecked_mut() };
-    init_queue(data, bump, *mint_info.address())?;
+    init_queue(data, bump, *mint_info.address(), *validator_info.address())?;
 
     let (header, _) = queue_views_mut_checked(data)?;
-    if header.bump != bump || header.mint != *mint_info.address() {
+    if header.bump != bump
+        || header.mint != *mint_info.address()
+        || header.validator != *validator_info.address()
+    {
         return Err(ProgramError::InvalidAccountData);
     }
 
@@ -111,15 +124,15 @@ impl InitializeTransferQueueArgs<'_> {
     }
 
     #[inline]
-    pub fn size_bytes(&self) -> u32 {
+    pub fn requested_items(&self) -> Option<u32> {
         if self.len == 0 {
-            0
+            None
         } else {
             let mut buf = [0u8; 4];
             unsafe {
                 core::ptr::copy_nonoverlapping(self.raw, buf.as_mut_ptr(), 4);
             }
-            u32::from_le_bytes(buf)
+            Some(u32::from_le_bytes(buf))
         }
     }
 }

--- a/e-token/src/processor/initialize_transfer_queue.rs
+++ b/e-token/src/processor/initialize_transfer_queue.rs
@@ -57,11 +57,15 @@ pub fn process_initialize_transfer_queue(
     }
 
     let rent = Rent::get()?;
+    let target_lamports = rent
+        .try_minimum_balance(queue_size)?
+        .checked_add(1_000_000_000) // Cover for 10_000 commits (0.0001 SOL each)
+        .ok_or(ProgramError::ArithmeticOverflow)?;
+
     if !queue_info.owned_by(&program_id) {
         if queue_info.lamports() > 0 {
             return Err(ProgramError::IllegalOwner);
         }
-
         if !payer_info.is_signer() {
             return Err(ProgramError::MissingRequiredSignature);
         }
@@ -75,21 +79,22 @@ pub fn process_initialize_transfer_queue(
         ];
         let signer = Signer::from(&signer_seeds);
 
-        // Allocate the default space but fund the desired size's rent.
         CreateAccount {
             from: payer_info,
             to: queue_info,
             space: (queue_size as u64).min(DEFAULT_TRANSFER_QUEUE_SIZE_BYTES),
-            lamports: rent.try_minimum_balance(queue_size)?,
+            lamports: target_lamports,
             owner: &program_id,
         }
         .invoke_signed(&[signer])?;
-    } else if queue_info.lamports() < rent.try_minimum_balance(queue_size)? {
-        // Transfer missing lamports
+    }
+
+    let shortfall = target_lamports.saturating_sub(queue_info.lamports());
+    if shortfall > 0 {
         Transfer {
             from: payer_info,
             to: queue_info,
-            lamports: rent.try_minimum_balance(queue_size)? - queue_info.lamports(),
+            lamports: shortfall,
         }
         .invoke()?;
     }

--- a/e-token/src/processor/initialize_transfer_queue.rs
+++ b/e-token/src/processor/initialize_transfer_queue.rs
@@ -6,7 +6,7 @@ use pinocchio::cpi::{Seed, Signer};
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
-use pinocchio_system::instructions::CreateAccount;
+use pinocchio_system::instructions::{CreateAccount, Transfer};
 
 pub const DEFAULT_TRANSFER_QUEUE_ITEMS: u32 = 92;
 /// Default queue size in bytes. (HEADER_LEN + ITEM_LEN * DEFAULT_TRANSFER_QUEUE_ITEMS)
@@ -56,6 +56,7 @@ pub fn process_initialize_transfer_queue(
         return Err(ProgramError::InvalidSeeds);
     }
 
+    let rent = Rent::get()?;
     if !queue_info.owned_by(&program_id) {
         if queue_info.lamports() > 0 {
             return Err(ProgramError::IllegalOwner);
@@ -79,14 +80,22 @@ pub fn process_initialize_transfer_queue(
             from: payer_info,
             to: queue_info,
             space: (queue_size as u64).min(DEFAULT_TRANSFER_QUEUE_SIZE_BYTES),
-            lamports: Rent::get()?.try_minimum_balance(queue_size)?,
+            lamports: rent.try_minimum_balance(queue_size)?,
             owner: &program_id,
         }
         .invoke_signed(&[signer])?;
+    } else if queue_info.lamports() < rent.try_minimum_balance(queue_size)? {
+        // Transfer missing lamports
+        Transfer {
+            from: payer_info,
+            to: queue_info,
+            lamports: rent.try_minimum_balance(queue_size)? - queue_info.lamports(),
+        }
+        .invoke()?;
     }
 
     let data_len = queue_info.data_len();
-    if data_len < header_len() || capacity_from_data_len(data_len) == 0 {
+    if capacity_from_data_len(data_len) == 0 {
         return Err(ProgramError::InvalidAccountData);
     }
 

--- a/e-token/src/processor/mod.rs
+++ b/e-token/src/processor/mod.rs
@@ -1,3 +1,4 @@
+pub mod allocate_transfer_queue;
 pub mod close_ephemeral_ata;
 pub mod close_shuttle_ata_intent;
 pub mod create_ephemeral_ata_permission;
@@ -29,6 +30,7 @@ pub(crate) mod utils;
 pub mod withdraw_spl_tokens;
 pub mod withdraw_through_delegated_shuttle_with_merge;
 
+pub use allocate_transfer_queue::process_allocate_transfer_queue;
 pub use close_ephemeral_ata::process_close_ephemeral_ata;
 pub use close_shuttle_ata_intent::process_close_shuttle_ata_intent;
 pub use create_ephemeral_ata_permission::process_create_ephemeral_ata_permission;

--- a/e-token/src/processor/process_transfer_queue_tick.rs
+++ b/e-token/src/processor/process_transfer_queue_tick.rs
@@ -1,4 +1,5 @@
 use crate::processor::rent_pda::derive_rent_pda;
+use dlp_api::pda::magic_fee_vault_pda_from_validator;
 use ephemeral_rollups_pinocchio::intent_bundle::{
     ActionArgs, CallHandler, MagicIntentBundleBuilder, ShortAccountMeta,
 };
@@ -31,9 +32,11 @@ pub fn process_transfer_queue_tick(
 
     // Expected accounts:
     // 0. [writable] Transfer queue PDA, used as the scheduled-action authority
-    // 1. [writable] Magic context account
-    // 2. []         Magic program
-    let [queue_info, magic_context_info, magic_program_info, ..] = accounts else {
+    // 1. [writable] Validator magic fee vault PDA derived from ["magic-fee-vault", validator]
+    // 2. [writable] Magic context account
+    // 3. []         Magic program
+    let [queue_info, magic_fee_vault_info, magic_context_info, magic_program_info, ..] = accounts
+    else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
@@ -151,12 +154,17 @@ pub fn process_transfer_queue_tick(
         Seed::from(&queue_bump_seed),
     ];
     let signer = Signer::from(&signer_seeds);
+    let derived_magic_fee_vault = magic_fee_vault_pda_from_validator(&validator.to_bytes().into());
+    if derived_magic_fee_vault.to_bytes() != magic_fee_vault_info.address().to_bytes() {
+        return Err(ProgramError::InvalidSeeds);
+    }
 
     MagicIntentBundleBuilder::new(
         queue_info.clone(),
         magic_context_info.clone(),
         magic_program_info.clone(),
     )
+    .magic_fee_vault(magic_fee_vault_info.clone())
     .set_standalone_actions(&standalone_actions)
     .build_and_invoke_signed(&mut intent_bundle_data, &[signer])?;
 

--- a/e-token/src/processor/process_transfer_queue_tick.rs
+++ b/e-token/src/processor/process_transfer_queue_tick.rs
@@ -39,7 +39,7 @@ pub fn process_transfer_queue_tick(
 
     let program_id = ephemeral_spl_api::program::id_address();
     let clock = Clock::get()?;
-    let (mint, queue_bump, queue_len, queued_transfer) = {
+    let (mint, queue_bump, queue_len, queued_transfer, validator) = {
         let data = unsafe { queue_info.borrow_unchecked() };
         let (header, _) = queue_views_checked(data)?;
         let mint = header.mint;
@@ -50,7 +50,7 @@ pub fn process_transfer_queue_tick(
             .ok_or(ProgramError::InvalidInstructionData)?;
 
         let (derived_queue, queue_bump) = ephemeral_spl_api::Address::find_program_address(
-            &[QUEUE_SEED, mint.as_ref()],
+            &[QUEUE_SEED, mint.as_ref(), header.validator.as_ref()],
             &program_id,
         );
         if derived_queue != *queue_info.address() {
@@ -80,7 +80,7 @@ pub fn process_transfer_queue_tick(
             queue_len
         );
 
-        (mint, queue_bump, queue_len, next)
+        (mint, queue_bump, queue_len, next, header.validator)
     };
     #[cfg(not(feature = "logging"))]
     let _ = queue_len;
@@ -147,6 +147,7 @@ pub fn process_transfer_queue_tick(
     let signer_seeds = [
         Seed::from(QUEUE_SEED),
         Seed::from(mint.as_ref()),
+        Seed::from(validator.as_ref()),
         Seed::from(&queue_bump_seed),
     ];
     let signer = Signer::from(&signer_seeds);

--- a/e-token/src/processor/process_transfer_queue_tick.rs
+++ b/e-token/src/processor/process_transfer_queue_tick.rs
@@ -39,6 +39,9 @@ pub fn process_transfer_queue_tick(
     else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
+    if magic_program_info.address() != &ephemeral_rollups_pinocchio::consts::MAGIC_PROGRAM_ID {
+        return Err(ProgramError::IncorrectProgramId);
+    }
 
     let program_id = ephemeral_spl_api::program::id_address();
     let clock = Clock::get()?;

--- a/e-token/src/processor/utils/asserts.rs
+++ b/e-token/src/processor/utils/asserts.rs
@@ -1,7 +1,10 @@
 #[macro_export]
 macro_rules! assert_owner {
     ($account:expr, $expected_owner:expr) => {
-        if !pinocchio::address::address_eq(unsafe { $account.owner() }, $expected_owner) {
+        let account = $account;
+        let expected_owner = $expected_owner;
+        let actual_owner = unsafe { account.owner() };
+        if !pinocchio::address::address_eq(actual_owner, expected_owner) {
             return Err(pinocchio::error::ProgramError::InvalidAccountOwner);
         }
     };

--- a/e-token/tests/allocate_transfer_queue.rs
+++ b/e-token/tests/allocate_transfer_queue.rs
@@ -116,10 +116,7 @@ async fn allocate_transfer_queue_succeeds_and_is_idempotent() {
     let (header, items) = queue_views_checked(&queue_account.data).unwrap();
     assert_eq!(header.version, TRANSFER_QUEUE_VERSION);
     assert_eq!(header.bump, bump);
-    assert_eq!(
-        header.mint,
-        ephemeral_spl_api::Address::new_from_array(mint.to_bytes())
-    );
+    assert_eq!(header.mint, mint);
     assert_eq!(header.length, 0);
     assert_eq!(header.validator, validator);
 

--- a/e-token/tests/allocate_transfer_queue.rs
+++ b/e-token/tests/allocate_transfer_queue.rs
@@ -1,0 +1,116 @@
+use ephemeral_spl_api::instruction;
+use ephemeral_spl_api::program::ID;
+use ephemeral_spl_api::state::transfer_queue::{
+    header_len, item_len, queue_views_checked, QUEUE_SEED, TRANSFER_QUEUE_VERSION,
+};
+use solana_account::Account;
+use solana_instruction::{AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_program_test::{tokio, ProgramTest};
+use solana_pubkey::Pubkey;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+
+pub const PROGRAM: Pubkey = Pubkey::new_from_array(ID);
+
+#[tokio::test]
+async fn allocate_transfer_queue_succeeds_and_is_idempotent() {
+    let mut pt = ProgramTest::new("ephemeral_token_program", PROGRAM, None);
+    pt.prefer_bpf(true);
+
+    let mint = Pubkey::new_unique();
+    pt.add_account(
+        mint,
+        Account {
+            lamports: 1,
+            data: vec![],
+            owner: solana_system_interface::program::ID,
+            executable: false,
+            rent_epoch: 0,
+        },
+    );
+
+    let context = &mut pt.start_with_context().await;
+    let payer = context.payer.pubkey();
+    let validator = Keypair::new().pubkey();
+    let (queue, bump) =
+        Pubkey::find_program_address(&[QUEUE_SEED, mint.as_ref(), validator.as_ref()], &PROGRAM);
+
+    const N_ITEMS: usize = 9999;
+    // Overallocate to test idempotency
+    const N_ALLOCS: usize = (N_ITEMS * item_len()).div_ceil(10_240) + 10;
+    eprintln!("N_ALLOCS: {}", N_ALLOCS);
+    let ix_init_queue = Instruction {
+        program_id: PROGRAM,
+        accounts: vec![
+            AccountMeta::new(payer, true),
+            AccountMeta::new(queue, false),
+            AccountMeta::new_readonly(mint, false),
+            AccountMeta::new_readonly(validator, false),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+        ],
+        data: [
+            vec![instruction::INITIALIZE_TRANSFER_QUEUE],
+            (N_ITEMS as u32).to_le_bytes().to_vec(),
+        ]
+        .concat(),
+    };
+
+    let tx_init = Transaction::new_signed_with_payer(
+        &[ix_init_queue],
+        Some(&payer),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(tx_init)
+        .await
+        .unwrap();
+
+    let ix_allocate = Instruction {
+        program_id: PROGRAM,
+        accounts: vec![
+            AccountMeta::new(queue, false),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+        ],
+        data: vec![instruction::ALLOCATE_TRANSFER_QUEUE],
+    };
+    // Splitting into chunks of 10 to avoid MaxInstructionTraceLengthExceeded
+    for chunk in
+        core::array::from_fn::<Instruction, N_ALLOCS, _>(|_| ix_allocate.clone()).chunks(10)
+    {
+        let blockhash = context.get_new_latest_blockhash().await.unwrap();
+        let tx_allocate =
+            Transaction::new_signed_with_payer(chunk, Some(&payer), &[&context.payer], blockhash);
+        context
+            .banks_client
+            .process_transaction(tx_allocate)
+            .await
+            .unwrap();
+    }
+
+    let queue_account = context
+        .banks_client
+        .get_account(queue)
+        .await
+        .unwrap()
+        .expect("queue account must exist");
+
+    assert_eq!(
+        (queue_account.data.len() - header_len()) / item_len(),
+        N_ITEMS
+    );
+
+    let (header, items) = queue_views_checked(&queue_account.data).unwrap();
+    assert_eq!(header.version, TRANSFER_QUEUE_VERSION);
+    assert_eq!(header.bump, bump);
+    assert_eq!(
+        header.mint,
+        ephemeral_spl_api::Address::new_from_array(mint.to_bytes())
+    );
+    assert_eq!(header.length, 0);
+    assert_eq!(header.validator, validator);
+
+    assert_eq!(items.len(), N_ITEMS);
+}

--- a/e-token/tests/allocate_transfer_queue.rs
+++ b/e-token/tests/allocate_transfer_queue.rs
@@ -37,9 +37,6 @@ async fn allocate_transfer_queue_succeeds_and_is_idempotent() {
         Pubkey::find_program_address(&[QUEUE_SEED, mint.as_ref(), validator.as_ref()], &PROGRAM);
 
     const N_ITEMS: usize = 9999;
-    // Overallocate to test idempotency
-    const N_ALLOCS: usize = (N_ITEMS * item_len()).div_ceil(10_240) + 10;
-    eprintln!("N_ALLOCS: {}", N_ALLOCS);
     let ix_init_queue = Instruction {
         program_id: PROGRAM,
         accounts: vec![
@@ -76,31 +73,45 @@ async fn allocate_transfer_queue_succeeds_and_is_idempotent() {
         ],
         data: vec![instruction::ALLOCATE_TRANSFER_QUEUE],
     };
+
+    let mut previous_data_len = 0usize;
+    let mut final_data_len = None;
     // Splitting into chunks of 10 to avoid MaxInstructionTraceLengthExceeded
-    for chunk in
-        core::array::from_fn::<Instruction, N_ALLOCS, _>(|_| ix_allocate.clone()).chunks(10)
-    {
+    for _ in 0..256 {
         let blockhash = context.get_new_latest_blockhash().await.unwrap();
+        let batch = vec![ix_allocate.clone(); 10];
         let tx_allocate =
-            Transaction::new_signed_with_payer(chunk, Some(&payer), &[&context.payer], blockhash);
+            Transaction::new_signed_with_payer(&batch, Some(&payer), &[&context.payer], blockhash);
         context
             .banks_client
             .process_transaction(tx_allocate)
             .await
             .unwrap();
+
+        let current_data_len = context
+            .banks_client
+            .get_account(queue)
+            .await
+            .unwrap()
+            .expect("queue account must exist")
+            .data
+            .len();
+        if current_data_len == previous_data_len {
+            final_data_len = Some(current_data_len);
+            break;
+        }
+        previous_data_len = current_data_len;
     }
 
+    let final_data_len = final_data_len.expect("queue allocation must converge");
     let queue_account = context
         .banks_client
         .get_account(queue)
         .await
         .unwrap()
         .expect("queue account must exist");
-
-    assert_eq!(
-        (queue_account.data.len() - header_len()) / item_len(),
-        N_ITEMS
-    );
+    let final_capacity = (final_data_len - header_len()) / item_len();
+    assert!(final_capacity >= N_ITEMS);
 
     let (header, items) = queue_views_checked(&queue_account.data).unwrap();
     assert_eq!(header.version, TRANSFER_QUEUE_VERSION);
@@ -112,5 +123,29 @@ async fn allocate_transfer_queue_succeeds_and_is_idempotent() {
     assert_eq!(header.length, 0);
     assert_eq!(header.validator, validator);
 
-    assert_eq!(items.len(), N_ITEMS);
+    assert_eq!(items.len(), final_capacity);
+
+    let blockhash = context.get_new_latest_blockhash().await.unwrap();
+    let tx_allocate_again = Transaction::new_signed_with_payer(
+        &[ix_allocate],
+        Some(&payer),
+        &[&context.payer],
+        blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(tx_allocate_again)
+        .await
+        .unwrap();
+
+    let queue_account_after_extra_allocate = context
+        .banks_client
+        .get_account(queue)
+        .await
+        .unwrap()
+        .expect("queue account must still exist");
+    assert_eq!(
+        queue_account_after_extra_allocate.data.len(),
+        final_data_len
+    );
 }

--- a/e-token/tests/delegate_transfer_queue.rs
+++ b/e-token/tests/delegate_transfer_queue.rs
@@ -6,7 +6,6 @@ use ephemeral_spl_api::state::transfer_queue::{
 };
 use solana_account::Account;
 use solana_instruction::{AccountMeta, Instruction};
-use solana_keypair::Keypair;
 use solana_program::{
     account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError, rent::Rent,
 };
@@ -16,6 +15,7 @@ use solana_signer::Signer;
 use solana_transaction::Transaction;
 
 pub const PROGRAM: Pubkey = Pubkey::new_from_array(ID);
+pub const VALIDATOR: Pubkey = Pubkey::new_from_array([77; 32]);
 
 fn read_header_unaligned(data: &[u8]) -> TransferQueueHeader {
     assert!(data.len() >= header_len());
@@ -91,7 +91,10 @@ fn process_delegation_program_mock(
         return Err(ProgramError::IncorrectProgramId);
     }
 
-    let (commit_frequency_ms, _) = parse_delegate_validator(&instruction_data[8..])?;
+    let (commit_frequency_ms, validator) = parse_delegate_validator(&instruction_data[8..])?;
+    if validator != Some(VALIDATOR.to_bytes()) {
+        return Err(ProgramError::InvalidInstructionData);
+    }
 
     {
         let buffer_data = buffer.try_borrow_data()?;
@@ -141,9 +144,8 @@ async fn delegate_transfer_queue_succeeds_and_is_idempotent() {
 
     let context = &mut pt.start_with_context().await;
     let payer = context.payer.pubkey();
-    let validator = Keypair::new().pubkey();
     let (queue, bump) =
-        Pubkey::find_program_address(&[QUEUE_SEED, mint.as_ref(), validator.as_ref()], &PROGRAM);
+        Pubkey::find_program_address(&[QUEUE_SEED, mint.as_ref(), VALIDATOR.as_ref()], &PROGRAM);
 
     let ix_init_queue = Instruction {
         program_id: PROGRAM,
@@ -151,7 +153,7 @@ async fn delegate_transfer_queue_succeeds_and_is_idempotent() {
             AccountMeta::new(payer, true),
             AccountMeta::new(queue, false),
             AccountMeta::new_readonly(mint, false),
-            AccountMeta::new_readonly(validator, false),
+            AccountMeta::new_readonly(VALIDATOR, false),
             AccountMeta::new_readonly(solana_system_interface::program::ID, false),
         ],
         data: vec![instruction::INITIALIZE_TRANSFER_QUEUE],

--- a/e-token/tests/delegate_transfer_queue.rs
+++ b/e-token/tests/delegate_transfer_queue.rs
@@ -6,6 +6,7 @@ use ephemeral_spl_api::state::transfer_queue::{
 };
 use solana_account::Account;
 use solana_instruction::{AccountMeta, Instruction};
+use solana_keypair::Keypair;
 use solana_program::{
     account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError, rent::Rent,
 };
@@ -90,10 +91,7 @@ fn process_delegation_program_mock(
         return Err(ProgramError::IncorrectProgramId);
     }
 
-    let (commit_frequency_ms, validator) = parse_delegate_validator(&instruction_data[8..])?;
-    if validator != Some(solana_system_interface::program::ID.to_bytes()) {
-        return Err(ProgramError::InvalidInstructionData);
-    }
+    let (commit_frequency_ms, _) = parse_delegate_validator(&instruction_data[8..])?;
 
     {
         let buffer_data = buffer.try_borrow_data()?;
@@ -143,7 +141,9 @@ async fn delegate_transfer_queue_succeeds_and_is_idempotent() {
 
     let context = &mut pt.start_with_context().await;
     let payer = context.payer.pubkey();
-    let (queue, bump) = Pubkey::find_program_address(&[QUEUE_SEED, mint.as_ref()], &PROGRAM);
+    let validator = Keypair::new().pubkey();
+    let (queue, bump) =
+        Pubkey::find_program_address(&[QUEUE_SEED, mint.as_ref(), validator.as_ref()], &PROGRAM);
 
     let ix_init_queue = Instruction {
         program_id: PROGRAM,
@@ -151,6 +151,7 @@ async fn delegate_transfer_queue_succeeds_and_is_idempotent() {
             AccountMeta::new(payer, true),
             AccountMeta::new(queue, false),
             AccountMeta::new_readonly(mint, false),
+            AccountMeta::new_readonly(validator, false),
             AccountMeta::new_readonly(solana_system_interface::program::ID, false),
         ],
         data: vec![instruction::INITIALIZE_TRANSFER_QUEUE],

--- a/e-token/tests/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
+++ b/e-token/tests/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
@@ -95,7 +95,8 @@ async fn deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_trans
     let (vault_eata, _) = Pubkey::find_program_address(&[vault.as_ref(), mint.as_ref()], &PROGRAM);
     let vault_ata = utils::derive_associated_token_address(vault, mint);
     let owner_source_ata = owner_token.pubkey();
-    let queue = Pubkey::find_program_address(&[QUEUE_SEED, mint.as_ref()], &PROGRAM).0;
+    let queue =
+        Pubkey::find_program_address(&[QUEUE_SEED, mint.as_ref(), validator.as_ref()], &PROGRAM).0;
 
     let ix_init_rent = Instruction {
         program_id: PROGRAM,
@@ -127,6 +128,7 @@ async fn deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_trans
             AccountMeta::new(payer, true),
             AccountMeta::new(queue, false),
             AccountMeta::new_readonly(mint, false),
+            AccountMeta::new_readonly(validator, false),
             AccountMeta::new_readonly(solana_system_interface::program::ID, false),
         ],
         data: vec![instruction::INITIALIZE_TRANSFER_QUEUE],

--- a/e-token/tests/deposit_and_queue_transfer.rs
+++ b/e-token/tests/deposit_and_queue_transfer.rs
@@ -44,7 +44,7 @@ fn read_item_unaligned(data: &[u8], index: usize) -> QueuedTransfer {
     unsafe { core::ptr::read_unaligned(data[offset..].as_ptr() as *const QueuedTransfer) }
 }
 
-async fn setup_fixture(queue_size_bytes: Option<u32>) -> Fixture {
+async fn setup_fixture(items: Option<u32>) -> Fixture {
     let mut pt = ProgramTest::new("ephemeral_token_program", PROGRAM, None);
     utils::add_associated_token_program(&mut pt);
     let mut context = pt.start_with_context().await;
@@ -52,6 +52,7 @@ async fn setup_fixture(queue_size_bytes: Option<u32>) -> Fixture {
     let payer = context.payer.pubkey();
     let mint_kp = Keypair::new();
     let mint = mint_kp.pubkey();
+    let validator = Keypair::new().pubkey();
 
     let pdas = utils::derive_pdas(PROGRAM, payer, mint);
     let setup = utils::setup_mint_and_token_accounts(
@@ -64,7 +65,8 @@ async fn setup_fixture(queue_size_bytes: Option<u32>) -> Fixture {
     )
     .await;
 
-    let queue = Pubkey::find_program_address(&[QUEUE_SEED, mint.as_ref()], &PROGRAM).0;
+    let queue =
+        Pubkey::find_program_address(&[QUEUE_SEED, mint.as_ref(), validator.as_ref()], &PROGRAM).0;
     let vault = pdas.vault;
     let user_source_ata = setup.user_tokens[0];
     let destination_ata = utils::derive_associated_token_address(payer, mint);
@@ -87,8 +89,8 @@ async fn setup_fixture(queue_size_bytes: Option<u32>) -> Fixture {
     };
 
     let mut queue_init_data = vec![instruction::INITIALIZE_TRANSFER_QUEUE];
-    if let Some(queue_size_bytes) = queue_size_bytes {
-        queue_init_data.extend_from_slice(&queue_size_bytes.to_le_bytes());
+    if let Some(items) = items {
+        queue_init_data.extend_from_slice(&items.to_le_bytes());
     }
     let ix_init_queue = Instruction {
         program_id: PROGRAM,
@@ -96,6 +98,7 @@ async fn setup_fixture(queue_size_bytes: Option<u32>) -> Fixture {
             AccountMeta::new(payer, true),
             AccountMeta::new(queue, false),
             AccountMeta::new_readonly(mint, false),
+            AccountMeta::new_readonly(validator, false),
             AccountMeta::new_readonly(solana_system_interface::program::ID, false),
         ],
         data: queue_init_data,
@@ -377,8 +380,8 @@ async fn deposit_and_queue_transfer_rejects_split_greater_than_amount() {
 
 #[tokio::test]
 async fn deposit_and_queue_transfer_rejects_when_queue_is_full() {
-    let queue_size_bytes = (header_len() + (item_len() * 2)) as u32;
-    let fixture = setup_fixture(Some(queue_size_bytes)).await;
+    let items = 2;
+    let fixture = setup_fixture(Some(items)).await;
     let ix = build_deposit_and_queue_ix(&fixture, 6, 0, 0, 3);
     let blockhash = fixture
         .context

--- a/e-token/tests/initialize_transfer_queue.rs
+++ b/e-token/tests/initialize_transfer_queue.rs
@@ -5,6 +5,7 @@ use ephemeral_spl_api::state::transfer_queue::{
 };
 use solana_account::Account as SolanaAccount;
 use solana_instruction::Instruction;
+use solana_keypair::Keypair;
 use {
     ephemeral_spl_api::instruction,
     solana_instruction::AccountMeta,
@@ -38,8 +39,10 @@ async fn initialize_transfer_queue_default_size() {
 
     let context = &mut pt.start_with_context().await;
     let payer = context.payer.pubkey();
+    let validator = Keypair::new().pubkey();
 
-    let (queue, bump) = Pubkey::find_program_address(&[QUEUE_SEED, mint.as_ref()], &PROGRAM);
+    let (queue, bump) =
+        Pubkey::find_program_address(&[QUEUE_SEED, mint.as_ref(), validator.as_ref()], &PROGRAM);
 
     let ix = Instruction {
         program_id: PROGRAM,
@@ -47,6 +50,7 @@ async fn initialize_transfer_queue_default_size() {
             AccountMeta::new(payer, true),
             AccountMeta::new(queue, false),
             AccountMeta::new_readonly(mint, false),
+            AccountMeta::new_readonly(validator, false),
             AccountMeta::new_readonly(solana_system_interface::program::ID, false),
         ],
         data: vec![instruction::INITIALIZE_TRANSFER_QUEUE],
@@ -68,7 +72,7 @@ async fn initialize_transfer_queue_default_size() {
         .expect("queue account must exist");
 
     assert_eq!(queue_account.owner, PROGRAM);
-    assert_eq!(queue_account.data.len(), 9_728);
+    assert_eq!(queue_account.data.len(), 9_664);
     assert!(capacity_from_data_len(queue_account.data.len()) >= 1);
 
     let header = read_header_unaligned(&queue_account.data);
@@ -98,11 +102,13 @@ async fn initialize_transfer_queue_custom_size_is_idempotent() {
 
     let context = &mut pt.start_with_context().await;
     let payer = context.payer.pubkey();
-    let (queue, bump) = Pubkey::find_program_address(&[QUEUE_SEED, mint.as_ref()], &PROGRAM);
+    let validator = Keypair::new().pubkey();
+    let (queue, bump) =
+        Pubkey::find_program_address(&[QUEUE_SEED, mint.as_ref(), validator.as_ref()], &PROGRAM);
 
-    let custom_size = (header_len() + (item_len() * 4)) as u32;
+    let items = 4_u32;
     let mut data = vec![instruction::INITIALIZE_TRANSFER_QUEUE];
-    data.extend_from_slice(&custom_size.to_le_bytes());
+    data.extend_from_slice(&items.to_le_bytes());
 
     let ix_init_custom = Instruction {
         program_id: PROGRAM,
@@ -110,6 +116,7 @@ async fn initialize_transfer_queue_custom_size_is_idempotent() {
             AccountMeta::new(payer, true),
             AccountMeta::new(queue, false),
             AccountMeta::new_readonly(mint, false),
+            AccountMeta::new_readonly(validator, false),
             AccountMeta::new_readonly(solana_system_interface::program::ID, false),
         ],
         data,
@@ -134,6 +141,7 @@ async fn initialize_transfer_queue_custom_size_is_idempotent() {
             AccountMeta::new(payer, true),
             AccountMeta::new(queue, false),
             AccountMeta::new_readonly(mint, false),
+            AccountMeta::new_readonly(validator, false),
             AccountMeta::new_readonly(solana_system_interface::program::ID, false),
         ],
         data: vec![instruction::INITIALIZE_TRANSFER_QUEUE],
@@ -157,7 +165,10 @@ async fn initialize_transfer_queue_custom_size_is_idempotent() {
         .unwrap()
         .expect("queue account must exist after idempotent init");
 
-    assert_eq!(queue_account.data.len(), custom_size as usize);
+    assert_eq!(
+        queue_account.data.len(),
+        header_len() + item_len() * items as usize
+    );
     assert!(capacity_from_data_len(queue_account.data.len()) >= 1);
 
     let header = read_header_unaligned(&queue_account.data);

--- a/e-token/tests/transfer_queue_automation.rs
+++ b/e-token/tests/transfer_queue_automation.rs
@@ -259,6 +259,7 @@ async fn setup_fixture() -> Fixture {
     let payer = context.payer.pubkey();
     let mint_kp = Keypair::new();
     let mint = mint_kp.pubkey();
+    let validator = Keypair::new().pubkey();
 
     let pdas = utils::derive_pdas(PROGRAM, payer, mint);
     let setup = utils::setup_mint_and_token_accounts(
@@ -271,7 +272,8 @@ async fn setup_fixture() -> Fixture {
     )
     .await;
 
-    let queue = Pubkey::find_program_address(&[QUEUE_SEED, mint.as_ref()], &PROGRAM).0;
+    let queue =
+        Pubkey::find_program_address(&[QUEUE_SEED, mint.as_ref(), validator.as_ref()], &PROGRAM).0;
     let vault = pdas.vault;
     let source_ata = setup.user_tokens[0];
     let destination_ata = utils::derive_associated_token_address(payer, mint);
@@ -299,6 +301,7 @@ async fn setup_fixture() -> Fixture {
             AccountMeta::new(payer, true),
             AccountMeta::new(queue, false),
             AccountMeta::new_readonly(mint, false),
+            AccountMeta::new_readonly(validator, false),
             AccountMeta::new_readonly(solana_system_interface::program::ID, false),
         ],
         data: vec![instruction::INITIALIZE_TRANSFER_QUEUE],
@@ -556,6 +559,7 @@ async fn ensure_transfer_queue_crank_rejects_non_magic_program() {
         let payer = context.payer.pubkey();
         let mint_kp = Keypair::new();
         let mint = mint_kp.pubkey();
+        let validator = Keypair::new().pubkey();
 
         let pdas = utils::derive_pdas(PROGRAM, payer, mint);
         let setup = utils::setup_mint_and_token_accounts(
@@ -568,7 +572,11 @@ async fn ensure_transfer_queue_crank_rejects_non_magic_program() {
         )
         .await;
 
-        let queue = Pubkey::find_program_address(&[QUEUE_SEED, mint.as_ref()], &PROGRAM).0;
+        let queue = Pubkey::find_program_address(
+            &[QUEUE_SEED, mint.as_ref(), validator.as_ref()],
+            &PROGRAM,
+        )
+        .0;
         let vault = pdas.vault;
         let source_ata = setup.user_tokens[0];
         let destination_ata = utils::derive_associated_token_address(payer, mint);
@@ -597,6 +605,7 @@ async fn ensure_transfer_queue_crank_rejects_non_magic_program() {
                 AccountMeta::new(payer, true),
                 AccountMeta::new(queue, false),
                 AccountMeta::new_readonly(mint, false),
+                AccountMeta::new_readonly(validator, false),
                 AccountMeta::new_readonly(solana_system_interface::program::ID, false),
             ],
             data: vec![instruction::INITIALIZE_TRANSFER_QUEUE],

--- a/e-token/tests/transfer_queue_automation.rs
+++ b/e-token/tests/transfer_queue_automation.rs
@@ -3,6 +3,7 @@ use std::{
     sync::{Mutex, OnceLock},
 };
 
+use dlp_api::pda::magic_fee_vault_pda_from_validator;
 use ephemeral_spl_api::instruction::{self, internal};
 use ephemeral_spl_api::program::ID;
 use ephemeral_spl_api::state::transfer_queue::{
@@ -216,6 +217,16 @@ fn read_item_unaligned(data: &[u8], index: usize) -> QueuedTransfer {
     unsafe { core::ptr::read_unaligned(data[offset..].as_ptr() as *const QueuedTransfer) }
 }
 
+fn magic_fee_vault(validator: &Pubkey) -> Pubkey {
+    Pubkey::new_from_array(
+        magic_fee_vault_pda_from_validator(&validator.to_bytes().into()).to_bytes(),
+    )
+}
+
+fn delegation_program() -> Pubkey {
+    Pubkey::new_from_array(ephemeral_rollups_pinocchio::consts::DELEGATION_PROGRAM_ID.to_bytes())
+}
+
 struct Fixture {
     context: ProgramTestContext,
     payer: Pubkey,
@@ -223,6 +234,7 @@ struct Fixture {
     magic_program: Pubkey,
     magic_context: Pubkey,
     queue: Pubkey,
+    magic_fee_vault: Pubkey,
     vault: Pubkey,
     vault_ata: Pubkey,
     source_ata: Pubkey,
@@ -274,6 +286,18 @@ async fn setup_fixture() -> Fixture {
 
     let queue =
         Pubkey::find_program_address(&[QUEUE_SEED, mint.as_ref(), validator.as_ref()], &PROGRAM).0;
+    let magic_fee_vault = magic_fee_vault(&validator);
+    context.set_account(
+        &magic_fee_vault,
+        &SolanaAccount {
+            lamports: 1_000_000,
+            data: vec![],
+            owner: delegation_program(),
+            executable: false,
+            rent_epoch: 0,
+        }
+        .into(),
+    );
     let vault = pdas.vault;
     let source_ata = setup.user_tokens[0];
     let destination_ata = utils::derive_associated_token_address(payer, mint);
@@ -339,6 +363,7 @@ async fn setup_fixture() -> Fixture {
         magic_program,
         magic_context,
         queue,
+        magic_fee_vault,
         vault,
         vault_ata,
         source_ata,
@@ -396,6 +421,7 @@ fn ensure_queue_crank_ix_with_magic_program(
         accounts: vec![
             AccountMeta::new(fixture.payer, true),
             AccountMeta::new(fixture.queue, false),
+            AccountMeta::new(fixture.magic_fee_vault, false),
             AccountMeta::new(fixture.magic_context, false),
             AccountMeta::new_readonly(magic_program, false),
         ],
@@ -408,6 +434,7 @@ fn process_queue_tick_ix(fixture: &Fixture) -> Instruction {
         program_id: PROGRAM,
         accounts: vec![
             AccountMeta::new(fixture.queue, false),
+            AccountMeta::new(fixture.magic_fee_vault, false),
             AccountMeta::new(fixture.magic_context, false),
             AccountMeta::new_readonly(fixture.magic_program, false),
         ],
@@ -469,6 +496,11 @@ async fn ensure_transfer_queue_crank_schedules_one_recurring_queue_crank() {
                 is_writable: false,
             },
             CapturedScheduleAccount {
+                pubkey: fixture.magic_fee_vault,
+                is_signer: false,
+                is_writable: false,
+            },
+            CapturedScheduleAccount {
                 pubkey: fixture.magic_context,
                 is_signer: false,
                 is_writable: false,
@@ -487,7 +519,7 @@ async fn ensure_transfer_queue_crank_schedules_one_recurring_queue_crank() {
         captured[0].args.instructions[0].program_id.to_bytes(),
         PROGRAM.to_bytes()
     );
-    assert_eq!(captured[0].args.instructions[0].accounts.len(), 3);
+    assert_eq!(captured[0].args.instructions[0].accounts.len(), 4);
     assert_eq!(
         captured[0].args.instructions[0].accounts[0]
             .pubkey
@@ -498,10 +530,16 @@ async fn ensure_transfer_queue_crank_schedules_one_recurring_queue_crank() {
         captured[0].args.instructions[0].accounts[1]
             .pubkey
             .to_bytes(),
-        fixture.magic_context.to_bytes()
+        fixture.magic_fee_vault.to_bytes()
     );
     assert_eq!(
         captured[0].args.instructions[0].accounts[2]
+            .pubkey
+            .to_bytes(),
+        fixture.magic_context.to_bytes()
+    );
+    assert_eq!(
+        captured[0].args.instructions[0].accounts[3]
             .pubkey
             .to_bytes(),
         fixture.magic_program.to_bytes()
@@ -577,6 +615,18 @@ async fn ensure_transfer_queue_crank_rejects_non_magic_program() {
             &PROGRAM,
         )
         .0;
+        let magic_fee_vault = magic_fee_vault(&validator);
+        context.set_account(
+            &magic_fee_vault,
+            &SolanaAccount {
+                lamports: 1_000_000,
+                data: vec![],
+                owner: delegation_program(),
+                executable: false,
+                rent_epoch: 0,
+            }
+            .into(),
+        );
         let vault = pdas.vault;
         let source_ata = setup.user_tokens[0];
         let destination_ata = utils::derive_associated_token_address(payer, mint);
@@ -643,6 +693,7 @@ async fn ensure_transfer_queue_crank_rejects_non_magic_program() {
             magic_program,
             magic_context,
             queue,
+            magic_fee_vault,
             vault,
             vault_ata,
             source_ata,
@@ -810,6 +861,14 @@ async fn recurring_queue_crank_executes_ready_transfer_via_magic_bundle() {
     let captured_bundles = peek_captured_intent_bundles(fixture.magic_program);
     assert_eq!(captured_bundles.len(), 1);
     assert_eq!(captured_bundles[0].args.standalone_actions.len(), 1);
+    assert_eq!(
+        captured_bundles[0].schedule_accounts,
+        vec![
+            fixture.queue,
+            fixture.magic_context,
+            fixture.magic_fee_vault
+        ]
+    );
 
     let queue_after_scheduling = queue_account(&mut fixture.context, fixture.queue).await;
     let header_after_scheduling = read_header_unaligned(&queue_after_scheduling.data);

--- a/e-token/tests/transfer_queue_automation.rs
+++ b/e-token/tests/transfer_queue_automation.rs
@@ -430,13 +430,20 @@ fn ensure_queue_crank_ix_with_magic_program(
 }
 
 fn process_queue_tick_ix(fixture: &Fixture) -> Instruction {
+    process_queue_tick_ix_with_magic_program(fixture, fixture.magic_program)
+}
+
+fn process_queue_tick_ix_with_magic_program(
+    fixture: &Fixture,
+    magic_program: Pubkey,
+) -> Instruction {
     Instruction {
         program_id: PROGRAM,
         accounts: vec![
             AccountMeta::new(fixture.queue, false),
             AccountMeta::new(fixture.magic_fee_vault, false),
             AccountMeta::new(fixture.magic_context, false),
-            AccountMeta::new_readonly(fixture.magic_program, false),
+            AccountMeta::new_readonly(magic_program, false),
         ],
         data: vec![internal::PROCESS_TRANSFER_QUEUE_TICK],
     }
@@ -764,6 +771,168 @@ async fn process_transfer_queue_tick_is_noop_when_queue_is_empty() {
     assert_eq!(
         token_amount(&mut fixture.context, fixture.destination_ata).await,
         0
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn process_transfer_queue_tick_rejects_non_magic_program() {
+    let _test_guard = test_lock().lock().await;
+    let fake_magic_program = Pubkey::new_unique();
+
+    let mut fixture = {
+        let magic_program = solana_pubkey::Pubkey::new_from_array(
+            ephemeral_rollups_pinocchio::consts::MAGIC_PROGRAM_ID.to_bytes(),
+        );
+        let magic_context = convert_magic_pubkey(MAGIC_CONTEXT_PUBKEY);
+        clear_captured_schedules(magic_program);
+        clear_captured_intent_bundles(magic_program);
+
+        let mut pt = ProgramTest::new("ephemeral_token_program", PROGRAM, None);
+        utils::add_associated_token_program(&mut pt);
+        add_magic_program_mock(&mut pt, magic_program);
+        add_noop_program_mock(&mut pt, fake_magic_program);
+        pt.add_account(
+            magic_context,
+            SolanaAccount {
+                lamports: 1_000_000,
+                data: vec![0; 8],
+                owner: magic_program,
+                executable: false,
+                rent_epoch: 0,
+            },
+        );
+
+        let mut context = pt.start_with_context().await;
+        let payer = context.payer.pubkey();
+        let mint_kp = Keypair::new();
+        let mint = mint_kp.pubkey();
+        let validator = Keypair::new().pubkey();
+
+        let pdas = utils::derive_pdas(PROGRAM, payer, mint);
+        let setup = utils::setup_mint_and_token_accounts(
+            &mut context,
+            payer,
+            &mint_kp,
+            DECIMALS,
+            STARTING_BALANCE,
+            2,
+        )
+        .await;
+
+        let queue = Pubkey::find_program_address(
+            &[QUEUE_SEED, mint.as_ref(), validator.as_ref()],
+            &PROGRAM,
+        )
+        .0;
+        let magic_fee_vault = magic_fee_vault(&validator);
+        context.set_account(
+            &magic_fee_vault,
+            &SolanaAccount {
+                lamports: 1_000_000,
+                data: vec![],
+                owner: delegation_program(),
+                executable: false,
+                rent_epoch: 0,
+            }
+            .into(),
+        );
+        let vault = pdas.vault;
+        let source_ata = setup.user_tokens[0];
+        let destination_ata = utils::derive_associated_token_address(payer, mint);
+        let (vault_eata, _) =
+            Pubkey::find_program_address(&[vault.as_ref(), mint.as_ref()], &PROGRAM);
+        let vault_ata = utils::derive_associated_token_address(vault, mint);
+
+        let ix_init_vault = Instruction {
+            program_id: PROGRAM,
+            accounts: vec![
+                AccountMeta::new(vault, false),
+                AccountMeta::new(payer, true),
+                AccountMeta::new_readonly(mint, false),
+                AccountMeta::new(vault_eata, false),
+                AccountMeta::new(vault_ata, false),
+                AccountMeta::new_readonly(spl_token_interface::ID, false),
+                AccountMeta::new_readonly(utils::associated_token_program_id(), false),
+                AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+            ],
+            data: vec![instruction::INITIALIZE_GLOBAL_VAULT],
+        };
+
+        let ix_init_queue = Instruction {
+            program_id: PROGRAM,
+            accounts: vec![
+                AccountMeta::new(payer, true),
+                AccountMeta::new(queue, false),
+                AccountMeta::new_readonly(mint, false),
+                AccountMeta::new_readonly(validator, false),
+                AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+            ],
+            data: vec![instruction::INITIALIZE_TRANSFER_QUEUE],
+        };
+
+        let ix_init_destination_ata = Instruction {
+            program_id: utils::associated_token_program_id(),
+            accounts: vec![
+                AccountMeta::new(payer, true),
+                AccountMeta::new(destination_ata, false),
+                AccountMeta::new_readonly(payer, false),
+                AccountMeta::new_readonly(mint, false),
+                AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+                AccountMeta::new_readonly(spl_token_interface::ID, false),
+            ],
+            data: vec![1],
+        };
+
+        let tx_init = Transaction::new_signed_with_payer(
+            &[ix_init_vault, ix_init_queue, ix_init_destination_ata],
+            Some(&payer),
+            &[&context.payer],
+            context.last_blockhash,
+        );
+        context
+            .banks_client
+            .process_transaction(tx_init)
+            .await
+            .unwrap();
+
+        Fixture {
+            context,
+            payer,
+            mint,
+            magic_program,
+            magic_context,
+            queue,
+            magic_fee_vault,
+            vault,
+            vault_ata,
+            source_ata,
+            destination_ata,
+        }
+    };
+
+    let blockhash = latest_blockhash(&mut fixture.context).await;
+    let tx = Transaction::new_signed_with_payer(
+        &[process_queue_tick_ix_with_magic_program(
+            &fixture,
+            fake_magic_program,
+        )],
+        Some(&fixture.payer),
+        &[&fixture.context.payer],
+        blockhash,
+    );
+    let err = fixture
+        .context
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        err,
+        solana_transaction::TransactionError::InstructionError(
+            0,
+            solana_program::instruction::InstructionError::IncorrectProgramId,
+        )
     );
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an on-chain instruction to allocate/grow transfer-queue capacity.
  * Queue initialization accepts an explicit requested item count with a capped default.

* **Behavior Changes**
  * Transfer queues now include a validator identity in their address derivation and headers.
  * Queue processing, cranking, and fee handling validate and use validator-derived fee vaults; allocation is idempotent.

* **Tests**
  * Added end-to-end allocation test and updated tests to cover validator-aware flows and vault validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->