### PR TITLE
feat: derive const rent pda

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,6 +1844,7 @@ version = "0.0.0"
 dependencies = [
  "bincode 1.3.3",
  "bytemuck",
+ "const-crypto",
  "ephemeral-rollups-pinocchio",
  "ephemeral-spl-api",
  "magicblock-delegation-program-api",
@@ -1851,7 +1852,6 @@ dependencies = [
  "pinocchio 0.10.1",
  "pinocchio-associated-token-account",
  "pinocchio-log",
- "pinocchio-pubkey",
  "pinocchio-system",
  "pinocchio-token-2022",
  "solana-account 3.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1851,6 +1851,7 @@ dependencies = [
  "pinocchio 0.10.1",
  "pinocchio-associated-token-account",
  "pinocchio-log",
+ "pinocchio-pubkey",
  "pinocchio-system",
  "pinocchio-token-2022",
  "solana-account 3.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,4 @@ solana-system-interface = { version = "2.0.0", features = ["bincode"] }
 spl-token-interface = "2.0.0"
 magicblock-delegation-program-api = { version = "0.1.1", default-features = false }
 bytemuck = { version = "1.23.1", features = ["derive"] }
+const-crypto = "0.3.0"

--- a/e-token/Cargo.toml
+++ b/e-token/Cargo.toml
@@ -15,10 +15,10 @@ crate-type = ["cdylib"]
 logging = []
 
 [dependencies]
+const-crypto = { workspace = true }
 ephemeral-rollups-pinocchio = { workspace = true }
 pinocchio = { workspace = true }
 pinocchio-log = { workspace = true }
-pinocchio-pubkey = { workspace = true }
 pinocchio-system = { workspace = true }
 pinocchio-token-2022 = { workspace = true }
 pinocchio-associated-token-account = { workspace = true }

--- a/e-token/Cargo.toml
+++ b/e-token/Cargo.toml
@@ -18,6 +18,7 @@ logging = []
 ephemeral-rollups-pinocchio = { workspace = true }
 pinocchio = { workspace = true }
 pinocchio-log = { workspace = true }
+pinocchio-pubkey = { workspace = true }
 pinocchio-system = { workspace = true }
 pinocchio-token-2022 = { workspace = true }
 pinocchio-associated-token-account = { workspace = true }

--- a/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge.rs
+++ b/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge.rs
@@ -32,7 +32,7 @@ use crate::{
     processor::{
         deposit_spl_tokens::transfer_to_vault_for_mint,
         initialize_shuttle_ephemeral_ata::initialize_shuttle_ephemeral_ata_with_sponsor,
-        rent_pda::derive_rent_pda,
+        rent_pda::{RENT_PDA, RENT_PDA_BUMP},
     },
 };
 
@@ -62,7 +62,6 @@ pub(crate) struct DepositAndDelegateShuttleWithMergeAccounts<'a> {
 
 pub(crate) struct PreparedShuttleDelegation {
     pub(crate) mint: Address,
-    pub(crate) rent_bump: u8,
     pub(crate) already_delegated: bool,
 }
 
@@ -245,7 +244,6 @@ pub(crate) fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_post_actio
         args,
         &prepared.mint,
         shuttle_eata.bump,
-        prepared.rent_bump,
         post_actions,
     )
 }
@@ -289,8 +287,7 @@ pub(crate) fn prepare_sponsored_shuttle_delegation(
         );
     }
 
-    let (derived_rent_pda, rent_bump) = derive_rent_pda();
-    if derived_rent_pda != *rent_pda_info.address() {
+    if &RENT_PDA != rent_pda_info.address() {
         return Err(ProgramError::InvalidSeeds);
     }
     if rent_pda_info.data_len() != 0 {
@@ -304,7 +301,7 @@ pub(crate) fn prepare_sponsored_shuttle_delegation(
     }
     .invoke()?;
 
-    let rent_bump_seed = [rent_bump];
+    let rent_bump_seed = [RENT_PDA_BUMP];
     let rent_signer_seed = [
         Seed::from(crate::processor::rent_pda::RENT_PDA_SEED),
         Seed::from(&rent_bump_seed),
@@ -329,7 +326,6 @@ pub(crate) fn prepare_sponsored_shuttle_delegation(
     if shuttle_eata_info.owned_by(&delegation_program) {
         return Ok(PreparedShuttleDelegation {
             mint: *mint_info.address(),
-            rent_bump,
             already_delegated: true,
         });
     }
@@ -407,7 +403,6 @@ pub(crate) fn prepare_sponsored_shuttle_delegation(
 
     Ok(PreparedShuttleDelegation {
         mint,
-        rent_bump,
         already_delegated: false,
     })
 }
@@ -427,10 +422,9 @@ pub(crate) fn delegate_sponsored_shuttle_with_post_actions(
     args: DepositAndDelegateShuttleCommonArgs,
     mint: &Address,
     shuttle_eata_bump: u8,
-    rent_bump: u8,
     post_actions: PostDelegationActions,
 ) -> ProgramResult {
-    let rent_bump_seed = [rent_bump];
+    let rent_bump_seed = [RENT_PDA_BUMP];
     let rent_signer_seed = [
         Seed::from(crate::processor::rent_pda::RENT_PDA_SEED),
         Seed::from(&rent_bump_seed),

--- a/e-token/src/processor/execute_ready_queued_transfer.rs
+++ b/e-token/src/processor/execute_ready_queued_transfer.rs
@@ -15,7 +15,7 @@ use pinocchio_system::ID as SYSTEM_PROGRAM_ID;
 use crate::{
     assert_owner,
     processor::{
-        rent_pda::{derive_rent_pda, RENT_PDA_SEED},
+        rent_pda::{RENT_PDA, RENT_PDA_BUMP, RENT_PDA_SEED},
         utils::read_mint_decimals,
     },
 };
@@ -69,8 +69,7 @@ pub fn process_execute_ready_queued_transfer(
 
     if args.should_create_destination_ata_idempotent() {
         assert_owner!(rent_pda_info, &SYSTEM_PROGRAM_ID);
-        let (derived_rent_pda, rent_bump) = derive_rent_pda();
-        if derived_rent_pda != *rent_pda_info.address() {
+        if &RENT_PDA != rent_pda_info.address() {
             return Err(ProgramError::InvalidSeeds);
         }
         if rent_pda_info.data_len() != 0 {
@@ -82,7 +81,7 @@ pub fn process_execute_ready_queued_transfer(
             return Err(ProgramError::InvalidAccountData);
         }
 
-        let rent_bump_seed = [rent_bump];
+        let rent_bump_seed = [RENT_PDA_BUMP];
         let rent_signer_seed = [Seed::from(RENT_PDA_SEED), Seed::from(&rent_bump_seed)];
         let rent_signer = Signer::from(&rent_signer_seed);
 

--- a/e-token/src/processor/process_transfer_queue_tick.rs
+++ b/e-token/src/processor/process_transfer_queue_tick.rs
@@ -1,4 +1,3 @@
-use crate::processor::rent_pda::derive_rent_pda;
 use dlp_api::pda::magic_fee_vault_pda_from_validator;
 use ephemeral_rollups_pinocchio::intent_bundle::{
     ActionArgs, CallHandler, MagicIntentBundleBuilder, ShortAccountMeta,
@@ -13,6 +12,8 @@ use pinocchio::sysvars::clock::Clock;
 use pinocchio::sysvars::Sysvar;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 use pinocchio_system::ID as SYSTEM_PROGRAM_ID;
+
+use crate::processor::rent_pda::RENT_PDA;
 pub(crate) const EXECUTE_READY_QUEUED_TRANSFER_ESCROW_INDEX: u8 = 0;
 
 const ASSOCIATED_TOKEN_PROGRAM_ID: ephemeral_spl_api::Address =
@@ -96,7 +97,6 @@ pub fn process_transfer_queue_tick(
     let vault_token_account = derive_associated_token_address(&vault, &mint);
     let destination_token_account =
         derive_associated_token_address(&queued_transfer.destination_owner, &mint);
-    let (rent_pda, _) = derive_rent_pda();
     let mut execute_data = [0_u8; 11];
     execute_data[0] = EXECUTE_READY_QUEUED_TRANSFER;
     execute_data[1] = EXECUTE_READY_QUEUED_TRANSFER_ESCROW_INDEX;
@@ -124,7 +124,7 @@ pub fn process_transfer_queue_tick(
             is_writable: true,
         },
         ShortAccountMeta {
-            pubkey: rent_pda,
+            pubkey: RENT_PDA,
             is_writable: true,
         },
         ShortAccountMeta {

--- a/e-token/src/processor/rent_pda.rs
+++ b/e-token/src/processor/rent_pda.rs
@@ -5,7 +5,7 @@ use pinocchio::Address;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 use pinocchio_system::instructions::CreateAccount;
 
-pub const RENT_PDA_SEED: &[u8; 4] = b"rent";
+pub const RENT_PDA_SEED: &[u8] = b"rent";
 pub const RENT_PDA_BUMP: u8 = 254;
 pub const RENT_PDA: Address = Address::new_from_array(pinocchio_pubkey::derive_address_const(
     &[RENT_PDA_SEED],

--- a/e-token/src/processor/rent_pda.rs
+++ b/e-token/src/processor/rent_pda.rs
@@ -29,8 +29,7 @@ pub fn process_initialize_rent_pda(
     };
 
     let required_lamports = Rent::get()?.try_minimum_balance(0)?;
-    let (derived_rent_pda, bump) = derive_rent_pda();
-    if derived_rent_pda != *rent_pda_info.address() {
+    if &RENT_PDA != rent_pda_info.address() {
         return Err(ProgramError::InvalidSeeds);
     }
 
@@ -45,7 +44,7 @@ pub fn process_initialize_rent_pda(
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    let bump_seed = [bump];
+    let bump_seed = [RENT_PDA_BUMP];
     let signer_seeds = [Seed::from(RENT_PDA_SEED), Seed::from(&bump_seed)];
     let signer = Signer::from(&signer_seeds);
 
@@ -59,11 +58,6 @@ pub fn process_initialize_rent_pda(
     .invoke_signed(&[signer])?;
 
     Ok(())
-}
-
-#[inline(always)]
-pub const fn derive_rent_pda() -> (ephemeral_spl_api::Address, u8) {
-    (RENT_PDA, RENT_PDA_BUMP)
 }
 
 #[inline(always)]

--- a/e-token/src/processor/rent_pda.rs
+++ b/e-token/src/processor/rent_pda.rs
@@ -1,10 +1,17 @@
 use pinocchio::cpi::{Seed, Signer};
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
+use pinocchio::Address;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 use pinocchio_system::instructions::CreateAccount;
 
-pub const RENT_PDA_SEED: &[u8] = b"rent";
+pub const RENT_PDA_SEED: &[u8; 4] = b"rent";
+pub const RENT_PDA_BUMP: u8 = 254;
+pub const RENT_PDA: Address = Address::new_from_array(pinocchio_pubkey::derive_address_const(
+    &[RENT_PDA_SEED],
+    Some(RENT_PDA_BUMP),
+    &crate::ID,
+));
 
 #[inline(always)]
 pub fn process_initialize_rent_pda(
@@ -58,10 +65,7 @@ pub fn process_initialize_rent_pda(
 
 #[inline(always)]
 pub fn derive_rent_pda() -> (ephemeral_spl_api::Address, u8) {
-    ephemeral_spl_api::Address::find_program_address(
-        &[RENT_PDA_SEED],
-        &ephemeral_spl_api::program::id_address(),
-    )
+    (RENT_PDA, RENT_PDA_BUMP)
 }
 
 #[inline(always)]

--- a/e-token/src/processor/rent_pda.rs
+++ b/e-token/src/processor/rent_pda.rs
@@ -6,12 +6,10 @@ use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 use pinocchio_system::instructions::CreateAccount;
 
 pub const RENT_PDA_SEED: &[u8] = b"rent";
-pub const RENT_PDA_BUMP: u8 = 254;
-pub const RENT_PDA: Address = Address::new_from_array(pinocchio_pubkey::derive_address_const(
-    &[RENT_PDA_SEED],
-    Some(RENT_PDA_BUMP),
-    &crate::ID,
-));
+const RENT_PDA_AND_BUMP: ([u8; 32], u8) =
+    const_crypto::ed25519::derive_program_address(&[RENT_PDA_SEED], &crate::ID);
+pub const RENT_PDA: Address = Address::new_from_array(RENT_PDA_AND_BUMP.0);
+pub const RENT_PDA_BUMP: u8 = RENT_PDA_AND_BUMP.1;
 
 #[inline(always)]
 pub fn process_initialize_rent_pda(
@@ -64,7 +62,7 @@ pub fn process_initialize_rent_pda(
 }
 
 #[inline(always)]
-pub fn derive_rent_pda() -> (ephemeral_spl_api::Address, u8) {
+pub const fn derive_rent_pda() -> (ephemeral_spl_api::Address, u8) {
     (RENT_PDA, RENT_PDA_BUMP)
 }
 

--- a/e-token/src/processor/withdraw_through_delegated_shuttle_with_merge.rs
+++ b/e-token/src/processor/withdraw_through_delegated_shuttle_with_merge.rs
@@ -109,7 +109,6 @@ pub fn process_withdraw_through_delegated_shuttle_with_merge(
         args.common_args(),
         &prepared.mint,
         shuttle_eata.bump,
-        prepared.rent_bump,
         post_actions.cleartext(),
     )
 }


### PR DESCRIPTION
Closes #42 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a cryptography dependency to workspace dependencies.

* **Refactor**
  * Switched runtime address derivation to compile-time constants for rent-related accounts, reducing per-call computation.
  * Simplified internal interfaces by removing now-unnecessary parameters and fields; no external APIs changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->