### PR TITLE
feat: generalize using address_eq

### DIFF
--- a/e-token-api/src/state/ephemeral_ata.rs
+++ b/e-token-api/src/state/ephemeral_ata.rs
@@ -1,4 +1,5 @@
 use pinocchio::{cpi::Seed, error::ProgramError, Address};
+use solana_address::address_eq;
 
 use crate::state::load_mut;
 
@@ -149,7 +150,7 @@ pub fn read_ephemeral_ata_compat(
 
     if bytes.len() == LEGACY_EPHEMERAL_ATA_LEN {
         let ephemeral_ata = load::<LegacyEphemeralAta>(bytes)?;
-        if ephemeral_ata.mint == Address::default() {
+        if address_eq(&ephemeral_ata.mint, &Address::default()) {
             return Err(ProgramError::UninitializedAccount);
         }
         #[allow(clippy::clone_on_copy)]

--- a/e-token-api/src/state/global_vault.rs
+++ b/e-token-api/src/state/global_vault.rs
@@ -1,4 +1,5 @@
 use pinocchio::{cpi::Seed, error::ProgramError, Address};
+use solana_address::address_eq;
 
 use super::{Initializable, RawType};
 
@@ -20,7 +21,7 @@ impl RawType for GlobalVault {
 impl Initializable for GlobalVault {
     #[inline(always)]
     fn is_initialized(&self) -> bool {
-        self.mint != Address::default()
+        !address_eq(&self.mint, &Address::default())
     }
 }
 

--- a/e-token-api/src/state/shuttle_ephemeral_ata.rs
+++ b/e-token-api/src/state/shuttle_ephemeral_ata.rs
@@ -1,4 +1,5 @@
 use pinocchio::{cpi::Seed, error::ProgramError, Address};
+use solana_address::address_eq;
 
 use super::{Initializable, RawType};
 
@@ -23,7 +24,7 @@ impl RawType for ShuttleMetadata {
 impl Initializable for ShuttleMetadata {
     #[inline(always)]
     fn is_initialized(&self) -> bool {
-        self.owner != Address::default()
+        !address_eq(&self.owner, &Address::default())
     }
 }
 

--- a/e-token-api/src/state/transfer_queue.rs
+++ b/e-token-api/src/state/transfer_queue.rs
@@ -1,5 +1,6 @@
 use bytemuck::{Pod, Zeroable};
 use pinocchio::{cpi::Seed, error::ProgramError, Address};
+use solana_address::address_eq;
 
 /// Current queue version that stores ready timestamps in milliseconds and client reference ids.
 /// Bump this value only when the on-chain layout changes or queue semantics require it.
@@ -295,7 +296,7 @@ pub fn queue_len_and_bump_for_mint_with_capacity(
     required_slots: usize,
 ) -> Result<(usize, Address, u8), ProgramError> {
     let (header, items) = queue_views_checked(data)?;
-    if header.mint != *expected_mint {
+    if !address_eq(&header.mint, expected_mint) {
         return Err(ProgramError::InvalidAccountData);
     }
 
@@ -331,10 +332,10 @@ fn higher_priority(a: &QueuedTransfer, b: &QueuedTransfer) -> bool {
     if a.amount != b.amount {
         return a.amount < b.amount;
     }
-    if a.destination_owner.as_ref() != b.destination_owner.as_ref() {
+    if !address_eq(&a.destination_owner, &b.destination_owner) {
         return a.destination_owner.as_ref() < b.destination_owner.as_ref();
     }
-    if a.source.as_ref() != b.source.as_ref() {
+    if !address_eq(&a.source, &b.source) {
         return a.source.as_ref() < b.source.as_ref();
     }
 

--- a/e-token/src/processor/close_ephemeral_ata.rs
+++ b/e-token/src/processor/close_ephemeral_ata.rs
@@ -1,5 +1,5 @@
 use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
-use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+use pinocchio::{address::address_eq, error::ProgramError, AccountView, ProgramResult};
 
 use crate::{assert_owner, assert_signer};
 
@@ -35,11 +35,11 @@ pub fn process_close_ephemeral_ata(
     };
 
     let derived_pda = EphemeralAta::derive_pda(owner_info.address(), &mint, bump)?;
-    if derived_pda != *ephemeral_ata_info.address() {
+    if !address_eq(&derived_pda, ephemeral_ata_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
 
-    if *recipient_info.address() == *ephemeral_ata_info.address() {
+    if address_eq(recipient_info.address(), ephemeral_ata_info.address()) {
         return Err(ProgramError::InvalidArgument);
     }
 

--- a/e-token/src/processor/close_shuttle_ata_intent.rs
+++ b/e-token/src/processor/close_shuttle_ata_intent.rs
@@ -142,14 +142,14 @@ pub fn process_close_shuttle_ata_intent(
             let shuttle_ephemeral_ata_data = shuttle_ephemeral_ata_info.try_borrow()?;
             let (ephemeral_owner, mint, amount, shuttle_eata_bump) =
                 read_ephemeral_ata_compat(&shuttle_ephemeral_ata_data)?;
-            if ephemeral_owner != *shuttle_info.address() {
+            if !address_eq(&ephemeral_owner, shuttle_info.address()) {
                 return Err(ProgramError::InvalidAccountData);
             }
             (mint, amount, shuttle_eata_bump)
         };
 
         if shuttle_ephemeral_amount != 0 {
-            if mint != *mint_info.address() {
+            if !address_eq(&mint, mint_info.address()) {
                 return Err(ProgramError::InvalidAccountData);
             }
 
@@ -168,13 +168,16 @@ pub fn process_close_shuttle_ata_intent(
 
         let derived_shuttle =
             ShuttleMetadata::derive_pda(shuttle_owner, &mint, shuttle_id, shuttle_bump)?;
-        if derived_shuttle != *shuttle_info.address() {
+        if !address_eq(&derived_shuttle, shuttle_info.address()) {
             return Err(ProgramError::InvalidSeeds);
         }
 
         let derived_shuttle_ephemeral_ata =
             EphemeralAta::derive_pda(shuttle_info.address(), &mint, shuttle_eata_bump)?;
-        if derived_shuttle_ephemeral_ata != *shuttle_ephemeral_ata_info.address() {
+        if !address_eq(
+            &derived_shuttle_ephemeral_ata,
+            shuttle_ephemeral_ata_info.address(),
+        ) {
             return Err(ProgramError::InvalidSeeds);
         }
 
@@ -193,7 +196,7 @@ fn close_program_account_to_recipient(
     account: &AccountView,
     recipient: &AccountView,
 ) -> ProgramResult {
-    if *recipient.address() == *account.address() {
+    if address_eq(recipient.address(), account.address()) {
         return Err(ProgramError::InvalidArgument);
     }
 

--- a/e-token/src/processor/create_ephemeral_ata_permission.rs
+++ b/e-token/src/processor/create_ephemeral_ata_permission.rs
@@ -6,7 +6,7 @@ use ephemeral_rollups_pinocchio::acl::{
     types::{Member, MemberFlags, MembersArgs},
 };
 use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
-use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+use pinocchio::{address::address_eq, error::ProgramError, AccountView, ProgramResult};
 
 use crate::assert_signer;
 
@@ -53,7 +53,7 @@ pub fn process_create_ephemeral_ata_permission(
 
     let expected_permission =
         permission_pda_from_permissioned_account(ephemeral_ata_info.address());
-    if expected_permission != *permission_info.address() {
+    if !address_eq(&expected_permission, permission_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
 

--- a/e-token/src/processor/delegate_ephemeral_ata_permission.rs
+++ b/e-token/src/processor/delegate_ephemeral_ata_permission.rs
@@ -3,7 +3,9 @@ use ephemeral_rollups_pinocchio::acl::{
     pda::permission_pda_from_permissioned_account,
 };
 use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
-use pinocchio::{cpi::Signer, error::ProgramError, AccountView, ProgramResult};
+use pinocchio::{
+    address::address_eq, cpi::Signer, error::ProgramError, AccountView, ProgramResult,
+};
 
 use crate::assert_signer;
 
@@ -32,7 +34,7 @@ pub fn process_delegate_ephemeral_ata_permission(
 
     assert_signer!(payer_info);
 
-    if *permission_program.address() != PERMISSION_PROGRAM_ID {
+    if !address_eq(permission_program.address(), &PERMISSION_PROGRAM_ID) {
         return Err(ProgramError::InvalidAccountData);
     }
 
@@ -47,7 +49,7 @@ pub fn process_delegate_ephemeral_ata_permission(
 
     let expected_permission =
         permission_pda_from_permissioned_account(ephemeral_ata_info.address());
-    if expected_permission != *permission_info.address() {
+    if !address_eq(&expected_permission, permission_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
 

--- a/e-token/src/processor/delegate_shuttle_ephemeral_ata.rs
+++ b/e-token/src/processor/delegate_shuttle_ephemeral_ata.rs
@@ -3,7 +3,7 @@ use ephemeral_rollups_pinocchio::types::DelegateConfig;
 use ephemeral_spl_api::state::{
     ephemeral_ata::EphemeralAta, load_initialized, shuttle_ephemeral_ata::ShuttleMetadata,
 };
-use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
+use pinocchio::{address::address_eq, error::ProgramError, AccountView, Address, ProgramResult};
 
 use crate::assert_owner;
 
@@ -53,7 +53,7 @@ pub fn process_delegate_shuttle_ephemeral_ata(
     };
 
     let derived_ephemeral_ata = EphemeralAta::derive_pda(shuttle_info.address(), &mint, eata_bump)?;
-    if derived_ephemeral_ata != *ephemeral_ata_info.address() {
+    if !address_eq(&derived_ephemeral_ata, ephemeral_ata_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
 

--- a/e-token/src/processor/delegate_transfer_queue.rs
+++ b/e-token/src/processor/delegate_transfer_queue.rs
@@ -1,7 +1,7 @@
 use ephemeral_rollups_pinocchio::instruction::DelegateAccountCpiBuilder;
 use ephemeral_rollups_pinocchio::types::DelegateConfig;
 use ephemeral_spl_api::state::transfer_queue::{queue_views_checked, TransferQueue, QUEUE_SEED};
-use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+use pinocchio::{address::address_eq, error::ProgramError, AccountView, ProgramResult};
 
 use crate::assert_signer;
 
@@ -39,14 +39,14 @@ pub fn process_delegate_transfer_queue(
     let (bump, validator) = {
         let data = unsafe { queue_info.borrow_unchecked() };
         let (header, _) = queue_views_checked(data)?;
-        if header.mint != *mint_info.address() {
+        if !address_eq(&header.mint, mint_info.address()) {
             return Err(ProgramError::InvalidAccountData);
         }
 
         let bump = header.bump;
         let derived_queue =
             TransferQueue::derive_pda(mint_info.address(), &header.validator, bump)?;
-        if derived_queue != *queue_info.address() {
+        if !address_eq(&derived_queue, queue_info.address()) {
             return Err(ProgramError::InvalidSeeds);
         }
 
@@ -57,10 +57,10 @@ pub fn process_delegate_transfer_queue(
         return Ok(());
     }
 
-    if owner_program.address() != &crate::ID {
+    if !address_eq(owner_program.address(), &crate::ID) {
         return Err(ProgramError::IncorrectProgramId);
     }
-    if system_program.address() != &pinocchio_system::ID {
+    if !address_eq(system_program.address(), &pinocchio_system::ID) {
         return Err(ProgramError::IncorrectProgramId);
     }
 

--- a/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge.rs
+++ b/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge.rs
@@ -18,6 +18,7 @@ use ephemeral_spl_api::state::{
     shuttle_ephemeral_ata::ShuttleMetadata,
 };
 use pinocchio::{
+    address::address_eq,
     cpi::{invoke_signed_with_bounds, Seed, Signer},
     error::ProgramError,
     instruction::{InstructionAccount, InstructionView},
@@ -291,7 +292,7 @@ pub(crate) fn prepare_sponsored_shuttle_delegation(
         );
     }
 
-    if &RENT_PDA != rent_pda_info.address() {
+    if !address_eq(&RENT_PDA, rent_pda_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
     if rent_pda_info.data_len() != 0 {
@@ -342,25 +343,27 @@ pub(crate) fn prepare_sponsored_shuttle_delegation(
     assert_owner!(shuttle_eata_info, &crate::ID);
 
     let shuttle = load_initialized::<ShuttleMetadata>(unsafe { shuttle_info.borrow_unchecked() })?;
-    if shuttle.owner != *owner_info.address() || shuttle.payer != *rent_pda_info.address() {
+    if !address_eq(&shuttle.owner, owner_info.address())
+        || !address_eq(&shuttle.payer, rent_pda_info.address())
+    {
         return Err(ProgramError::IncorrectAuthority);
     }
 
     let (mint, bump) = {
         let shuttle_eata =
             load_initialized::<EphemeralAta>(unsafe { shuttle_eata_info.borrow_unchecked() })?;
-        if shuttle_eata.owner != *shuttle_info.address() {
+        if !address_eq(&shuttle_eata.owner, shuttle_info.address()) {
             return Err(ProgramError::InvalidAccountData);
         }
         (shuttle_eata.mint, shuttle_eata.bump)
     };
 
-    if mint != *mint_info.address() {
+    if !address_eq(&mint, mint_info.address()) {
         return Err(ProgramError::InvalidAccountData);
     }
 
     let derived_shuttle_eata = EphemeralAta::derive_pda(shuttle_info.address(), &mint, bump)?;
-    if derived_shuttle_eata != *shuttle_eata_info.address() {
+    if !address_eq(&derived_shuttle_eata, shuttle_eata_info.address()) {
         #[cfg(feature = "logging")]
         {
             let expected = derived_shuttle_eata.to_string();
@@ -411,7 +414,7 @@ pub(crate) fn delegate_sponsored_shuttle_with_post_actions(
     };
 
     let mut action_signer_accounts = alloc::vec![owner_info];
-    if owner_info.address() != payer_info.address() {
+    if !address_eq(owner_info.address(), payer_info.address()) {
         action_signer_accounts.push(payer_info);
     }
 
@@ -561,11 +564,11 @@ pub(crate) fn delegate_account_with_actions_from_sponsor(
     let delegate_signer = Signer::from(filled);
 
     let current_owner = unsafe { pda_acc.owner() };
-    if current_owner != &pinocchio_system::ID {
+    if !address_eq(current_owner, &pinocchio_system::ID) {
         unsafe { pda_acc.assign(&pinocchio_system::ID) };
     }
     let current_owner = unsafe { pda_acc.owner() };
-    if current_owner != &DELEGATION_PROGRAM_ID {
+    if !address_eq(current_owner, &DELEGATION_PROGRAM_ID) {
         Assign {
             account: pda_acc,
             owner: &DELEGATION_PROGRAM_ID,

--- a/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
+++ b/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
@@ -9,6 +9,7 @@ use dlp_api::args::{
     MaybeEncryptedPubkey,
 };
 use dlp_api::compact::{self};
+use pinocchio::address::address_eq;
 
 use ephemeral_spl_api::state::transfer_queue::{queue_views, TransferQueue};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
@@ -86,7 +87,7 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private
     };
     let derived_queue =
         TransferQueue::derive_pda(common_accounts.mint_info.address(), &validator, bump)?;
-    if derived_queue != *queue_info.address() {
+    if !address_eq(&derived_queue, queue_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
 

--- a/e-token/src/processor/deposit_and_queue_transfer.rs
+++ b/e-token/src/processor/deposit_and_queue_transfer.rs
@@ -84,7 +84,7 @@ pub fn process_deposit_and_queue_transfer(
     };
 
     let derived_queue = TransferQueue::derive_pda(mint_info.address(), &validator, bump)?;
-    if derived_queue != *queue_info.address() {
+    if !address_eq(&derived_queue, queue_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
 

--- a/e-token/src/processor/deposit_spl_tokens.rs
+++ b/e-token/src/processor/deposit_spl_tokens.rs
@@ -1,4 +1,5 @@
 use ephemeral_spl_api::state::{load_initialized, load_mut_initialized};
+use pinocchio::address::address_eq;
 
 use core::marker::PhantomData;
 
@@ -76,9 +77,9 @@ pub(crate) fn transfer_to_vault_for_mint(
     assert_owner!(vault_info, &crate::ID);
 
     let vault = load_initialized::<GlobalVault>(unsafe { vault_info.borrow_unchecked() })?;
-    if vault.mint != *mint_info.address()
-        || vault.token_account != *vault_token_acc.address()
-        || vault.mint != *expected_mint
+    if !address_eq(&vault.mint, mint_info.address())
+        || !address_eq(&vault.token_account, vault_token_acc.address())
+        || !address_eq(&vault.mint, expected_mint)
     {
         return Err(ProgramError::InvalidAccountData);
     }

--- a/e-token/src/processor/ensure_transfer_queue_crank.rs
+++ b/e-token/src/processor/ensure_transfer_queue_crank.rs
@@ -9,8 +9,10 @@ use ephemeral_spl_api::state::transfer_queue::{
     queue_crank_task_id_from_data, queue_set_crank_task_id_from_data, queue_views_checked,
     TransferQueue,
 };
+use pinocchio::address::address_eq;
 use pinocchio::cpi::{invoke_signed_with_bounds, Signer};
 use pinocchio::instruction::{InstructionAccount, InstructionView};
+use pinocchio::Address;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
 use crate::{assert_owner, assert_signer};
@@ -46,7 +48,10 @@ pub fn process_ensure_transfer_queue_crank(
     assert_signer!(payer_info);
     assert_owner!(queue_info, &crate::ID);
 
-    if magic_program_info.address() != &ephemeral_rollups_pinocchio::consts::MAGIC_PROGRAM_ID {
+    if !address_eq(
+        magic_program_info.address(),
+        &ephemeral_rollups_pinocchio::consts::MAGIC_PROGRAM_ID,
+    ) {
         return Err(ProgramError::IncorrectProgramId);
     }
 
@@ -57,11 +62,12 @@ pub fn process_ensure_transfer_queue_crank(
     };
 
     let derived_queue = TransferQueue::derive_pda(&mint, &validator, bump)?;
-    if derived_queue != *queue_info.address() {
+    if !address_eq(&derived_queue, queue_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
-    let derived_magic_fee_vault = magic_fee_vault_pda_from_validator(&validator.to_bytes().into());
-    if derived_magic_fee_vault.to_bytes() != magic_fee_vault_info.address().to_bytes() {
+    let derived_magic_fee_vault =
+        Address::from(magic_fee_vault_pda_from_validator(&validator.to_bytes().into()).to_bytes());
+    if !address_eq(&derived_magic_fee_vault, magic_fee_vault_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
 

--- a/e-token/src/processor/execute_ready_queued_transfer.rs
+++ b/e-token/src/processor/execute_ready_queued_transfer.rs
@@ -62,14 +62,16 @@ pub fn process_execute_ready_queued_transfer(
 
     if args.should_create_destination_ata_idempotent() {
         assert_owner!(rent_pda_info, &SYSTEM_PROGRAM_ID);
-        if &RENT_PDA != rent_pda_info.address() {
+        if !address_eq(&RENT_PDA, rent_pda_info.address()) {
             return Err(ProgramError::InvalidSeeds);
         }
         if rent_pda_info.data_len() != 0 {
             return Err(ProgramError::InvalidAccountData);
         }
-        if associated_token_program_info.address() != &pinocchio_associated_token_account::ID
-            || system_program_info.address() != &SYSTEM_PROGRAM_ID
+        if !address_eq(
+            associated_token_program_info.address(),
+            &pinocchio_associated_token_account::ID,
+        ) || !address_eq(system_program_info.address(), &SYSTEM_PROGRAM_ID)
         {
             return Err(ProgramError::InvalidAccountData);
         }
@@ -126,10 +128,11 @@ pub(crate) fn validate_vault_for_mint(
 
     let vault = load_initialized::<GlobalVault>(unsafe { vault_info.borrow_unchecked() })?;
     let derived_vault = GlobalVault::derive_pda(mint_info.address(), vault.bump)?;
-    if derived_vault != *vault_info.address() {
+    if !address_eq(&derived_vault, vault_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
-    if vault.mint != *mint_info.address() || vault.token_account != *vault_token_acc_info.address()
+    if !address_eq(&vault.mint, mint_info.address())
+        || !address_eq(&vault.token_account, vault_token_acc_info.address())
     {
         return Err(ProgramError::InvalidAccountData);
     }

--- a/e-token/src/processor/initialize_ephemeral_ata.rs
+++ b/e-token/src/processor/initialize_ephemeral_ata.rs
@@ -1,7 +1,7 @@
 use ephemeral_spl_api::state::{load_initialized, load_mut, RawType};
-use pinocchio::cpi::Signer;
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
+use pinocchio::{address::address_eq, cpi::Signer};
 use pinocchio_system::instructions::{CreateAccount, Transfer};
 use {
     ephemeral_spl_api::state::ephemeral_ata::EphemeralAta,
@@ -44,7 +44,7 @@ pub(crate) fn initialize_ephemeral_ata_with_sponsor(
 ) -> ProgramResult {
     // Validate PDA derivation up front, even for idempotent re-initialization.
     let (derived_pda, eata_bump) = EphemeralAta::find_pda(user_info.address(), mint_info.address());
-    if derived_pda != *ephemeral_ata_info.address() {
+    if !address_eq(&derived_pda, ephemeral_ata_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
 
@@ -52,7 +52,8 @@ pub(crate) fn initialize_ephemeral_ata_with_sponsor(
     if let Ok(ephemeral_ata) =
         load_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked() })
     {
-        if ephemeral_ata.owner == *user_info.address() && ephemeral_ata.mint == *mint_info.address()
+        if address_eq(&ephemeral_ata.owner, user_info.address())
+            && address_eq(&ephemeral_ata.mint, mint_info.address())
         {
             return Ok(());
         }

--- a/e-token/src/processor/initialize_global_vault.rs
+++ b/e-token/src/processor/initialize_global_vault.rs
@@ -1,8 +1,8 @@
 use crate::processor::initialize_ephemeral_ata::process_initialize_ephemeral_ata;
 use ephemeral_spl_api::state::RawType;
-use pinocchio::cpi::Signer;
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
+use pinocchio::{address::address_eq, cpi::Signer};
 use pinocchio_system::instructions::{CreateAccount, Transfer};
 use {
     ephemeral_spl_api::state::global_vault::GlobalVault,
@@ -40,7 +40,7 @@ pub fn process_initialize_global_vault(
 
     let program_id = crate::ID;
     let (vault_derived_pda, vault_bump) = GlobalVault::find_pda(mint_info.address());
-    if vault_derived_pda != *vault_info.address() {
+    if !address_eq(&vault_derived_pda, vault_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
 
@@ -61,7 +61,7 @@ pub fn process_initialize_global_vault(
                 let legacy_data = unsafe { vault_info.borrow_unchecked() };
                 unsafe { *(legacy_data.as_ptr() as *const pinocchio::Address) }
             };
-            if legacy_mint.ne(mint_info.address()) {
+            if !address_eq(&legacy_mint, mint_info.address()) {
                 return Err(ProgramError::InvalidAccountData);
             }
 

--- a/e-token/src/processor/initialize_shuttle_ephemeral_ata.rs
+++ b/e-token/src/processor/initialize_shuttle_ephemeral_ata.rs
@@ -1,9 +1,9 @@
 use crate::processor::initialize_ephemeral_ata::initialize_ephemeral_ata_with_sponsor;
 use core::marker::PhantomData;
 use ephemeral_spl_api::state::{load_initialized, load_mut, RawType};
-use pinocchio::cpi::Signer;
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
+use pinocchio::{address::address_eq, cpi::Signer};
 use pinocchio_system::instructions::{CreateAccount, Transfer};
 use {
     ephemeral_spl_api::state::shuttle_ephemeral_ata::ShuttleMetadata,
@@ -74,7 +74,7 @@ pub(crate) fn initialize_shuttle_ephemeral_ata_with_sponsor(
     let shuttle_id_seed = shuttle_id.to_le_bytes();
     let (derived_shuttle_pda, shuttle_bump) =
         ShuttleMetadata::find_pda(owner_info.address(), mint_info.address(), shuttle_id);
-    if derived_shuttle_pda != *shuttle_info.address() {
+    if !address_eq(&derived_shuttle_pda, shuttle_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
 
@@ -143,8 +143,8 @@ pub(crate) fn initialize_shuttle_ephemeral_ata_with_sponsor(
         let shuttle =
             load_initialized::<ShuttleMetadata>(unsafe { shuttle_info.borrow_unchecked() })?;
         if shuttle.id != shuttle_id
-            || shuttle.owner != *owner_info.address()
-            || shuttle.payer != *refund_recipient_info.address()
+            || !address_eq(&shuttle.owner, owner_info.address())
+            || !address_eq(&shuttle.payer, refund_recipient_info.address())
         {
             return Err(ProgramError::InvalidAccountData);
         }

--- a/e-token/src/processor/initialize_transfer_queue.rs
+++ b/e-token/src/processor/initialize_transfer_queue.rs
@@ -8,6 +8,7 @@ use ephemeral_spl_api::state::transfer_queue::{
     capacity_from_data_len, header_len, init_queue, item_len, queue_views_mut_checked,
     TransferQueue,
 };
+use pinocchio::address::address_eq;
 use pinocchio::cpi::Signer;
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
@@ -55,15 +56,15 @@ pub fn process_initialize_transfer_queue(
     let program_id = crate::ID;
     let (derived_queue, bump) =
         TransferQueue::find_pda(mint_info.address(), validator_info.address());
-    if derived_queue != *queue_info.address() {
+    if !address_eq(&derived_queue, queue_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
 
-    if *permission_program_info.address() != PERMISSION_PROGRAM_ID {
+    if !address_eq(permission_program_info.address(), &PERMISSION_PROGRAM_ID) {
         return Err(ProgramError::IncorrectProgramId);
     }
     let expected_permission = permission_pda_from_permissioned_account(queue_info.address());
-    if expected_permission != *queue_permission_info.address() {
+    if !address_eq(&expected_permission, queue_permission_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
     let queue_permission_exists = queue_permission_info.lamports() > 0;
@@ -140,8 +141,8 @@ pub fn process_initialize_transfer_queue(
 
     let (header, _) = queue_views_mut_checked(data)?;
     if header.bump != bump
-        || header.mint != *mint_info.address()
-        || header.validator != *validator_info.address()
+        || !address_eq(&header.mint, mint_info.address())
+        || !address_eq(&header.validator, validator_info.address())
     {
         return Err(ProgramError::InvalidAccountData);
     }

--- a/e-token/src/processor/lamports_pda.rs
+++ b/e-token/src/processor/lamports_pda.rs
@@ -51,7 +51,7 @@ pub fn process_sponsored_lamports_transfer(
         return Err(ProgramError::IncorrectProgramId);
     }
 
-    if RENT_PDA != *rent_pda_info.address() {
+    if !address_eq(rent_pda_info.address(), &RENT_PDA) {
         return Err(ProgramError::InvalidSeeds);
     }
     if rent_pda_info.data_len() != 0 {
@@ -62,7 +62,7 @@ pub fn process_sponsored_lamports_transfer(
         read_destination_validator(destination_info, destination_delegation_record_info)?;
     let (derived_lamports_pda, lamports_pda_bump) =
         derive_lamports_pda(payer_info.address(), destination_info.address(), &salt);
-    if derived_lamports_pda != *lamports_pda_info.address() {
+    if !address_eq(&derived_lamports_pda, lamports_pda_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
     if lamports_pda_info.lamports() > 0 {
@@ -168,7 +168,7 @@ pub fn process_transfer_lamports_pda(
 
     let (derived_lamports_pda, _) =
         derive_lamports_pda(payer_info.address(), destination_info.address(), &salt);
-    if derived_lamports_pda != *lamports_pda_info.address() {
+    if !address_eq(&derived_lamports_pda, lamports_pda_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
 
@@ -204,7 +204,7 @@ pub fn process_undelegate_lamports_pda(
 
     let (derived_lamports_pda, _) =
         derive_lamports_pda(payer_info.address(), destination_info.address(), &salt);
-    if derived_lamports_pda != *lamports_pda_info.address() {
+    if !address_eq(&derived_lamports_pda, lamports_pda_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
 
@@ -285,7 +285,7 @@ pub fn process_close_lamports_pda_intent(
         return Err(ProgramError::InvalidSeeds);
     }
 
-    if RENT_PDA != *rent_pda_info.address() {
+    if !address_eq(rent_pda_info.address(), &RENT_PDA) {
         return Err(ProgramError::InvalidSeeds);
     }
     if rent_pda_info.data_len() != 0 || lamports_pda_info.data_len() != 0 {
@@ -294,7 +294,7 @@ pub fn process_close_lamports_pda_intent(
 
     let (derived_lamports_pda, _) =
         derive_lamports_pda(payer_info.address(), destination_info.address(), &salt);
-    if derived_lamports_pda != *lamports_pda_info.address() {
+    if !address_eq(&derived_lamports_pda, lamports_pda_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
 

--- a/e-token/src/processor/merge_shuttle_into_ephemeral_ata.rs
+++ b/e-token/src/processor/merge_shuttle_into_ephemeral_ata.rs
@@ -1,5 +1,6 @@
 use ephemeral_spl_api::state::load_initialized;
 use ephemeral_spl_api::state::shuttle_ephemeral_ata::ShuttleMetadata;
+use pinocchio::address::address_eq;
 use pinocchio::cpi::Signer;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
@@ -46,7 +47,7 @@ pub fn process_merge_shuttle_into_ephemeral_ata(
     let shuttle_id_seed = shuttle_id.to_le_bytes();
     let derived_shuttle =
         ShuttleMetadata::derive_pda(&shuttle_owner, mint_info.address(), shuttle_id, bump)?;
-    if derived_shuttle != *shuttle_info.address() {
+    if !address_eq(&derived_shuttle, shuttle_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
 

--- a/e-token/src/processor/process_transfer_queue_tick.rs
+++ b/e-token/src/processor/process_transfer_queue_tick.rs
@@ -12,9 +12,15 @@ use ephemeral_spl_api::instruction::internal::{
 use ephemeral_spl_api::state::transfer_queue::{
     queue_peek_from_data, queue_pop_from_data, queue_views_checked, QueuedTransfer, QUEUE_SEED,
 };
-use pinocchio::cpi::{Seed, Signer};
-use pinocchio::sysvars::{clock::Clock, Sysvar};
+use pinocchio::{
+    address::address_eq,
+    cpi::{Seed, Signer},
+};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+use pinocchio::{
+    sysvars::{clock::Clock, Sysvar},
+    Address,
+};
 use pinocchio_system::ID as SYSTEM_PROGRAM_ID;
 
 use crate::{
@@ -104,7 +110,10 @@ fn parse_tick_accounts(accounts: &[AccountView]) -> Result<TickAccounts<'_>, Pro
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    if magic_program_info.address() != &ephemeral_rollups_pinocchio::consts::MAGIC_PROGRAM_ID {
+    if !address_eq(
+        magic_program_info.address(),
+        &ephemeral_rollups_pinocchio::consts::MAGIC_PROGRAM_ID,
+    ) {
         return Err(ProgramError::IncorrectProgramId);
     }
 
@@ -131,7 +140,7 @@ fn read_queue_tick_state(
         &[QUEUE_SEED, mint.as_ref(), validator.as_ref()],
         program_id,
     );
-    if derived_queue != *queue_info.address() {
+    if !address_eq(&derived_queue, queue_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
 
@@ -319,10 +328,13 @@ fn invoke_queue_standalone_action(
     ];
     let signers = [Signer::from(&signer_seeds)];
     let mut intent_bundle_data = [0_u8; MAGIC_INTENT_BUNDLE_DATA_LEN];
-    let derived_magic_fee_vault =
-        magic_fee_vault_pda_from_validator(&queue_state.validator.to_bytes().into());
-    if derived_magic_fee_vault.to_bytes() != tick_accounts.magic_fee_vault_info.address().to_bytes()
-    {
+    let derived_magic_fee_vault = Address::from(
+        magic_fee_vault_pda_from_validator(&queue_state.validator.to_bytes().into()).to_bytes(),
+    );
+    if !address_eq(
+        &derived_magic_fee_vault,
+        tick_accounts.magic_fee_vault_info.address(),
+    ) {
         return Err(ProgramError::InvalidSeeds);
     }
 

--- a/e-token/src/processor/rent_pda.rs
+++ b/e-token/src/processor/rent_pda.rs
@@ -1,3 +1,4 @@
+use pinocchio::address::address_eq;
 use pinocchio::cpi::{Seed, Signer};
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
@@ -29,7 +30,7 @@ pub fn process_initialize_rent_pda(
     };
 
     let required_lamports = Rent::get()?.try_minimum_balance(0)?;
-    if &RENT_PDA != rent_pda_info.address() {
+    if !address_eq(rent_pda_info.address(), &RENT_PDA) {
         return Err(ProgramError::InvalidSeeds);
     }
 

--- a/e-token/src/processor/reset_ephemeral_ata_permission.rs
+++ b/e-token/src/processor/reset_ephemeral_ata_permission.rs
@@ -5,7 +5,7 @@ use ephemeral_rollups_pinocchio::acl::{
     types::{Member, MemberFlags, MembersArgs},
 };
 use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
-use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+use pinocchio::{address::address_eq, error::ProgramError, AccountView, ProgramResult};
 
 #[inline(always)]
 pub fn process_reset_ephemeral_ata_permission(
@@ -30,14 +30,14 @@ pub fn process_reset_ephemeral_ata_permission(
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    if *permission_program.address() != PERMISSION_PROGRAM_ID {
+    if !address_eq(permission_program.address(), &PERMISSION_PROGRAM_ID) {
         return Err(ProgramError::InvalidAccountData);
     }
 
     let ephemeral_ata =
         load_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked() })?;
 
-    if ephemeral_ata.owner != *owner_info.address() {
+    if !address_eq(&ephemeral_ata.owner, owner_info.address()) {
         return Err(ProgramError::IncorrectAuthority);
     }
 

--- a/e-token/src/processor/shuttle_close_schedule.rs
+++ b/e-token/src/processor/shuttle_close_schedule.rs
@@ -1,7 +1,9 @@
 use ephemeral_rollups_pinocchio::intent_bundle::{
     ActionArgs, CallHandler, MagicIntentBundleBuilder, ShortAccountMeta,
 };
-use ephemeral_spl_api::instruction::internal::SETTLE_AND_CLOSE_SHUTTLE_INTENT;
+use ephemeral_spl_api::{
+    instruction::internal::SETTLE_AND_CLOSE_SHUTTLE_INTENT, state::global_vault::GlobalVault,
+};
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
 
 use crate::processor::utils::get_associated_token_address;
@@ -36,8 +38,7 @@ pub(crate) fn schedule_shuttle_close_after_undelegate(
     magic_program: &AccountView,
     escrow_index: u8,
 ) -> ProgramResult {
-    let (vault_info, _) =
-        ephemeral_spl_api::Address::find_program_address(&[mint.as_ref()], &crate::ID);
+    let (vault_info, _) = GlobalVault::find_pda(mint);
     let vault_token_info =
         get_associated_token_address(&vault_info, mint, token_program_info.address());
     let close_handler_data = [SETTLE_AND_CLOSE_SHUTTLE_INTENT, escrow_index];

--- a/e-token/src/processor/transfer_queue_refill.rs
+++ b/e-token/src/processor/transfer_queue_refill.rs
@@ -56,7 +56,7 @@ pub fn process_mark_transfer_queue_refill_pending(
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    if system_program_info.address() != &pinocchio_system::ID {
+    if !address_eq(system_program_info.address(), &pinocchio_system::ID) {
         return Err(ProgramError::IncorrectProgramId);
     }
     if !address_eq(source_program.address(), &crate::ID) {
@@ -106,7 +106,7 @@ pub fn process_pending_transfer_queue_refill(
 
     let (_, refill_lamports) = refill_transfer_queue_amounts(queue_info.data_len())?;
     let (refill_lamports_pda, _, refill_salt) = queue_refill_lamports_pda(queue_info.address());
-    if refill_lamports_pda != *lamports_pda_info.address() {
+    if !address_eq(&refill_lamports_pda, lamports_pda_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
     if !address_eq(owner_program_info.address(), &crate::ID) {
@@ -164,7 +164,7 @@ fn validate_queue_account(queue_info: &AccountView) -> Result<(), ProgramError> 
         &crate::ID,
     )
     .map_err(|_| ProgramError::InvalidAccountData)?;
-    if derived_queue != *queue_info.address() {
+    if !address_eq(&derived_queue, queue_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
 
@@ -173,7 +173,7 @@ fn validate_queue_account(queue_info: &AccountView) -> Result<(), ProgramError> 
 
 fn validate_rent_pda(rent_pda_info: &AccountView) -> Result<(), ProgramError> {
     assert_owner!(rent_pda_info, &pinocchio_system::ID);
-    if RENT_PDA != *rent_pda_info.address() {
+    if !address_eq(&RENT_PDA, rent_pda_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
     if rent_pda_info.data_len() != 0 {
@@ -188,7 +188,7 @@ fn validate_queue_refill_state_address(
     queue: &Address,
 ) -> Result<(Address, u8), ProgramError> {
     let (expected_refill_state, bump) = derive_transfer_queue_refill_state_address(queue);
-    if expected_refill_state != *refill_state_info.address() {
+    if !address_eq(&expected_refill_state, refill_state_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
 
@@ -329,7 +329,7 @@ fn close_program_account_to_recipient(
     account: &AccountView,
     recipient: &AccountView,
 ) -> ProgramResult {
-    if *recipient.address() == *account.address() {
+    if address_eq(recipient.address(), account.address()) {
         return Err(ProgramError::InvalidArgument);
     }
 

--- a/e-token/src/processor/undelegate_and_close_shuttle_to_owner.rs
+++ b/e-token/src/processor/undelegate_and_close_shuttle_to_owner.rs
@@ -1,6 +1,7 @@
 use ephemeral_spl_api::state::{
     ephemeral_ata::EphemeralAta, load_initialized, shuttle_ephemeral_ata::ShuttleMetadata,
 };
+use pinocchio::address::address_eq;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
 use crate::assert_owner;
@@ -50,7 +51,7 @@ pub fn process_undelegate_and_close_shuttle_to_owner(
         let shuttle_ephemeral_ata = load_initialized::<EphemeralAta>(unsafe {
             shuttle_ephemeral_ata_info.borrow_unchecked()
         })?;
-        if shuttle_ephemeral_ata.owner != *shuttle_info.address() {
+        if !address_eq(&shuttle_ephemeral_ata.owner, shuttle_info.address()) {
             return Err(ProgramError::InvalidAccountData);
         }
         #[allow(clippy::clone_on_copy)]
@@ -62,13 +63,19 @@ pub fn process_undelegate_and_close_shuttle_to_owner(
         &[shuttle_info.address().as_ref(), mint.as_ref()],
         &crate::ID,
     );
-    if derived_shuttle_ephemeral_ata != *shuttle_ephemeral_ata_info.address() {
+    if !address_eq(
+        &derived_shuttle_ephemeral_ata,
+        shuttle_ephemeral_ata_info.address(),
+    ) {
         return Err(ProgramError::InvalidSeeds);
     }
 
     let expected_shuttle_wallet_ata =
         get_associated_token_address(shuttle_info.address(), &mint, token_program_info.address());
-    if expected_shuttle_wallet_ata != *shuttle_wallet_ata_info.address() {
+    if !address_eq(
+        &expected_shuttle_wallet_ata,
+        shuttle_wallet_ata_info.address(),
+    ) {
         return Err(ProgramError::InvalidAccountData);
     }
 

--- a/e-token/src/processor/undelegate_ephemeral_ata.rs
+++ b/e-token/src/processor/undelegate_ephemeral_ata.rs
@@ -1,5 +1,5 @@
 use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
-use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+use pinocchio::{address::address_eq, error::ProgramError, AccountView, ProgramResult};
 
 use crate::processor::utils::validate_token_account;
 
@@ -54,7 +54,7 @@ pub fn process_undelegate_ephemeral_ata(
     // Derive PDA: seeds = [payer, mint], program id = e-token program id (ephemeral_spl_api::program::ID)
     let derived_pda = EphemeralAta::derive_pda(payer.address(), &mint, bump)?;
 
-    if derived_pda != *ephemeral_ata_info.address() {
+    if !address_eq(&derived_pda, ephemeral_ata_info.address()) {
         return Err(ProgramError::InvalidSeeds);
     }
 

--- a/e-token/src/processor/undelegate_ephemeral_ata_permission.rs
+++ b/e-token/src/processor/undelegate_ephemeral_ata_permission.rs
@@ -2,7 +2,7 @@ use ephemeral_rollups_pinocchio::acl::{
     consts::PERMISSION_PROGRAM_ID, instruction::commit_and_undelegate_permission,
 };
 use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
-use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+use pinocchio::{address::address_eq, error::ProgramError, AccountView, ProgramResult};
 
 use crate::assert_signer;
 
@@ -27,14 +27,14 @@ pub fn process_undelegate_ephemeral_ata_permission(
 
     assert_signer!(payer_info);
 
-    if *permission_program.address() != PERMISSION_PROGRAM_ID {
+    if !address_eq(permission_program.address(), &PERMISSION_PROGRAM_ID) {
         return Err(ProgramError::InvalidAccountData);
     }
 
     let ephemeral_ata =
         load_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked() })?;
 
-    if ephemeral_ata.owner != *payer_info.address() {
+    if !address_eq(&ephemeral_ata.owner, payer_info.address()) {
         return Err(ProgramError::InvalidAccountData);
     }
 

--- a/e-token/src/processor/withdraw_spl_tokens.rs
+++ b/e-token/src/processor/withdraw_spl_tokens.rs
@@ -1,7 +1,7 @@
 use crate::{assert_owner, assert_signer, processor::utils::read_mint_decimals};
 use core::marker::PhantomData;
 use ephemeral_spl_api::{error::EphemeralSplError, state::load_initialized};
-use pinocchio::cpi::Signer;
+use pinocchio::{address::address_eq, cpi::Signer};
 
 use {
     ephemeral_spl_api::state::{
@@ -74,10 +74,10 @@ pub(crate) fn withdraw_ephemeral_ata_tokens(
     let vault = load_initialized::<GlobalVault>(unsafe { vault_info.borrow_unchecked() })?;
 
     // Check eata consistency
-    if ephemeral_ata.mint() != mint_info.address()
-        || vault.mint != *mint_info.address()
-        || ephemeral_ata.owner() != owner.address()
-        || vault.token_account != *vault_source_token_acc.address()
+    if !address_eq(ephemeral_ata.mint(), mint_info.address())
+        || !address_eq(&vault.mint, mint_info.address())
+        || !address_eq(ephemeral_ata.owner(), owner.address())
+        || !address_eq(&vault.token_account, vault_source_token_acc.address())
     {
         return Err(EphemeralSplError::EphemeralAtaMismatch.into());
     }

--- a/metrics/baseline.json
+++ b/metrics/baseline.json
@@ -1,93 +1,93 @@
 {
-  "create_eata_perm::default": {
-    "compute_units_consumed": 13686
-  },
-  "tq_auto::tick_empty": {
-    "compute_units_consumed": 2105
-  },
-  "del_eata_perm::delegate": {
-    "compute_units_consumed": 48480
-  },
-  "dep_queue::reject_zero_split": {
-    "compute_units_consumed": 323
-  },
-  "dep_queue::accepts_legacy_destination_ata": {
-    "compute_units_consumed": 13486
-  },
-  "undel_eata_cb::undelegate": {
-    "compute_units_consumed": 36852
-  },
-  "merge_shuttle::merge": {
-    "compute_units_consumed": 9494
-  },
-  "rent_pda::reinit": {
-    "compute_units_consumed": 240
-  },
-  "tq_auto::run_scheduled_tick_via_magic_bundle": {
-    "compute_units_consumed": 15308
-  },
-  "del_eata_perm::non_owner": {
-    "compute_units_consumed": 52980
-  },
-  "tq_alloc::first_allocate": {
-    "compute_units_consumed": 18880
-  },
-  "dep_queue::reject_split_gt_amt": {
-    "compute_units_consumed": 328
-  },
-  "del_shuttle_priv::shuttle": {
-    "compute_units_consumed": 128237
-  },
-  "tq_auto::crank_bad_magic": {
-    "compute_units_consumed": 289
-  },
-  "tq_auto::schedule_with_client_ref_id": {
-    "compute_units_consumed": 5324
-  },
-  "undel_perm_cb::undelegate": {
-    "compute_units_consumed": 34444
-  },
-  "dep_spl::deposit": {
-    "compute_units_consumed": 7856
-  },
-  "del_shuttle_eata::delegate": {
-    "compute_units_consumed": 24974
-  },
-  "tq_auto::schedule": {
-    "compute_units_consumed": 5324
-  },
-  "tq_auto::tick_not_ready": {
-    "compute_units_consumed": 2191
-  },
-  "rent_pda::init": {
-    "compute_units_consumed": 1630
-  },
-  "dep_queue::assign_group_id_0": {
-    "compute_units_consumed": 10732
-  },
-  "del_shuttle_priv::queue": {
-    "compute_units_consumed": 27430
-  },
-  "dep_queue::split4_mod5": {
-    "compute_units_consumed": 11554
-  },
-  "lamports_pda::sponsored_lamports_transfer": {
-    "compute_units_consumed": 60590
-  },
-  "init_tq::default": {
-    "compute_units_consumed": 13518
-  },
-  "close_eata::close": {
-    "compute_units_consumed": 1724
+  "init_tq::custom": {
+    "compute_units_consumed": 14984
   },
   "tq_auto::crank_2": {
     "compute_units_consumed": 6489
   },
-  "tq_auto::enqueue_ready": {
-    "compute_units_consumed": 10426
+  "del_eata_perm::non_owner": {
+    "compute_units_consumed": 52980
+  },
+  "tq_auto::run_scheduled_tick_via_magic_bundle": {
+    "compute_units_consumed": 15308
+  },
+  "del_shuttle_priv::queue": {
+    "compute_units_consumed": 27430
+  },
+  "del_eata::delegate": {
+    "compute_units_consumed": 42865
+  },
+  "init_gvault::init": {
+    "compute_units_consumed": 15938
+  },
+  "del_shuttle_merge::delegate": {
+    "compute_units_consumed": 80016
+  },
+  "del_eata::non_owner": {
+    "compute_units_consumed": 29365
+  },
+  "rent_pda::reinit": {
+    "compute_units_consumed": 240
+  },
+  "init_eata::init": {
+    "compute_units_consumed": 4723
+  },
+  "dep_queue::return_to_shuttle": {
+    "compute_units_consumed": 7835
   },
   "tq_auto::enqueue_with_client_ref_id": {
     "compute_units_consumed": 10427
+  },
+  "ud_wd_close::undelegate": {
+    "compute_units_consumed": 13767
+  },
+  "init_shuttle::init": {
+    "compute_units_consumed": 18991
+  },
+  "tq_auto::run_scheduled_tick": {
+    "compute_units_consumed": 15310
+  },
+  "create_eata_perm::default": {
+    "compute_units_consumed": 13686
+  },
+  "dep_queue::all_splits_use_client_ref_id": {
+    "compute_units_consumed": 11031
+  },
+  "undel_perm_cb::undelegate": {
+    "compute_units_consumed": 34444
+  },
+  "del_eata_perm::delegate": {
+    "compute_units_consumed": 48480
+  },
+  "del_tq::delegate": {
+    "compute_units_consumed": 22930
+  },
+  "merge_shuttle::merge": {
+    "compute_units_consumed": 9494
+  },
+  "dep_queue::split4_mod5": {
+    "compute_units_consumed": 11554
+  },
+  "init_gvault::migrate": {
+    "compute_units_consumed": 13015
+  },
+  "dep_queue::reject_split_gt_amt": {
+    "compute_units_consumed": 328
+  },
+  "reset_eata_perm::reset": {
+    "compute_units_consumed": 26484
+  },
+  "tq_auto::enqueue_delayed": {
+    "compute_units_consumed": 10426
+  },
+  "undel_eata_cb::undelegate": {
+    "compute_units_consumed": 36852
+  },
+  "dep_queue::accepts_legacy_destination_ata": {
+    "compute_units_consumed": 13486
+  },
+  "rent_pda::init": {
+    "compute_units_consumed": 1630
   },
   "dep_queue::once_split": {
     "compute_units_consumed": 10970
@@ -95,106 +95,106 @@
   "dep_queue::reject_delay_range": {
     "compute_units_consumed": 331
   },
-  "tq_auto::run_scheduled_tick": {
-    "compute_units_consumed": 15310
-  },
-  "del_eata::delegate": {
-    "compute_units_consumed": 42865
-  },
-  "init_shuttle::init": {
-    "compute_units_consumed": 18991
-  },
-  "tq_auto::tick_after_bundle": {
-    "compute_units_consumed": 2105
-  },
-  "del_shuttle_merge::delegate": {
-    "compute_units_consumed": 80016
-  },
-  "del_eata::reinit": {
-    "compute_units_consumed": 7708
+  "create_eata_perm::permissionless": {
+    "compute_units_consumed": 24175
   },
   "del_eata::redelegate": {
     "compute_units_consumed": 145
   },
-  "dep_shuttle::deposit": {
-    "compute_units_consumed": 7856
-  },
-  "del_shuttle_eata::redelegate": {
-    "compute_units_consumed": 152
-  },
-  "tq_auto::enqueue_delayed": {
-    "compute_units_consumed": 10426
-  },
-  "del_tq::delegate": {
-    "compute_units_consumed": 22930
-  },
-  "ud_wd_close::undelegate": {
-    "compute_units_consumed": 13767
-  },
-  "init_gvault::init": {
-    "compute_units_consumed": 15938
-  },
-  "tq_auto::crank_1": {
-    "compute_units_consumed": 5324
-  },
-  "dep_queue::deterministic_delays": {
-    "compute_units_consumed": 11363
-  },
-  "wd_spl::withdraw": {
-    "compute_units_consumed": 7869
-  },
-  "dep_queue::assign_group_id_1": {
-    "compute_units_consumed": 11232
-  },
-  "dep_queue::all_splits_use_client_ref_id": {
-    "compute_units_consumed": 11031
-  },
-  "tq_alloc::already_allocated": {
-    "compute_units_consumed": 1822
-  },
-  "lamports_pda::allow_extra_lamports": {
-    "compute_units_consumed": 1835
-  },
-  "dep_queue::return_to_shuttle": {
-    "compute_units_consumed": 7835
-  },
-  "del_tq::redelegate": {
-    "compute_units_consumed": 1794
-  },
-  "del_eata::non_owner": {
-    "compute_units_consumed": 29365
-  },
-  "dep_queue::reject_queue_full": {
-    "compute_units_consumed": 275
-  },
-  "create_eata_perm::permissionless": {
-    "compute_units_consumed": 24175
-  },
-  "del_eata_perm::redelegate": {
-    "compute_units_consumed": 168
-  },
-  "init_tq::custom": {
-    "compute_units_consumed": 14984
+  "dep_queue::reject_zero_split": {
+    "compute_units_consumed": 323
   },
   "dep_queue::split3_mod5": {
     "compute_units_consumed": 11171
   },
-  "reset_eata_perm::reset": {
-    "compute_units_consumed": 26484
+  "tq_alloc::first_allocate": {
+    "compute_units_consumed": 18880
   },
-  "wd_shuttle::withdraw": {
-    "compute_units_consumed": 63668
+  "dep_queue::assign_group_id_1": {
+    "compute_units_consumed": 11232
   },
-  "init_tq::noop": {
-    "compute_units_consumed": 6417
-  },
-  "init_eata::init": {
-    "compute_units_consumed": 4723
+  "close_eata::close": {
+    "compute_units_consumed": 1724
   },
   "lamports_pda::transfer_lamports_pda": {
     "compute_units_consumed": 6335
   },
-  "init_gvault::migrate": {
-    "compute_units_consumed": 13015
+  "lamports_pda::allow_extra_lamports": {
+    "compute_units_consumed": 1835
+  },
+  "dep_shuttle::deposit": {
+    "compute_units_consumed": 7856
+  },
+  "tq_auto::crank_bad_magic": {
+    "compute_units_consumed": 289
+  },
+  "init_tq::default": {
+    "compute_units_consumed": 13518
+  },
+  "del_shuttle_eata::redelegate": {
+    "compute_units_consumed": 152
+  },
+  "tq_auto::tick_not_ready": {
+    "compute_units_consumed": 2191
+  },
+  "tq_auto::tick_empty": {
+    "compute_units_consumed": 2105
+  },
+  "del_shuttle_eata::delegate": {
+    "compute_units_consumed": 24974
+  },
+  "del_shuttle_priv::shuttle": {
+    "compute_units_consumed": 128237
+  },
+  "del_eata::reinit": {
+    "compute_units_consumed": 7708
+  },
+  "tq_auto::schedule_with_client_ref_id": {
+    "compute_units_consumed": 5324
+  },
+  "tq_auto::schedule": {
+    "compute_units_consumed": 5324
+  },
+  "tq_auto::crank_1": {
+    "compute_units_consumed": 5324
+  },
+  "tq_auto::enqueue_ready": {
+    "compute_units_consumed": 10426
+  },
+  "lamports_pda::sponsored_lamports_transfer": {
+    "compute_units_consumed": 60590
+  },
+  "wd_spl::withdraw": {
+    "compute_units_consumed": 7869
+  },
+  "init_tq::noop": {
+    "compute_units_consumed": 6417
+  },
+  "dep_queue::assign_group_id_0": {
+    "compute_units_consumed": 10732
+  },
+  "del_eata_perm::redelegate": {
+    "compute_units_consumed": 168
+  },
+  "wd_shuttle::withdraw": {
+    "compute_units_consumed": 63668
+  },
+  "tq_auto::tick_after_bundle": {
+    "compute_units_consumed": 2105
+  },
+  "tq_alloc::already_allocated": {
+    "compute_units_consumed": 1822
+  },
+  "dep_queue::reject_queue_full": {
+    "compute_units_consumed": 275
+  },
+  "dep_queue::deterministic_delays": {
+    "compute_units_consumed": 11363
+  },
+  "dep_spl::deposit": {
+    "compute_units_consumed": 7856
+  },
+  "del_tq::redelegate": {
+    "compute_units_consumed": 1794
   }
 }


### PR DESCRIPTION
```bash
───────────────────────────────────────────────────────────────────────────────
Key                                          Baseline CU Current CU Δ CU    Δ %
───────────────────────────────────────────────────────────────────────────────
close_eata::close                                  1,724      1,711  -13 -0.75%
create_eata_perm::default                         13,686     13,679   -7 -0.05%
create_eata_perm::permissionless                  24,175     24,168   -7 -0.03%
del_eata::delegate                                42,865     42,848  -17 -0.04%
del_eata::non_owner                               29,365     29,348  -17 -0.06%
del_eata::redelegate                                 145        145   +0 +0.00%
del_eata::reinit                                   7,708      7,699   -9 -0.12%
del_eata_perm::delegate                           48,480     48,475   -5 -0.01%
del_eata_perm::non_owner                          52,980     52,975   -5 -0.01%
del_eata_perm::redelegate                            168        165   -3 -1.79%
del_shuttle_eata::delegate                        24,974     24,945  -29 -0.12%
del_shuttle_eata::redelegate                         152        152   +0 +0.00%
del_shuttle_merge::delegate                       80,016     79,797 -219 -0.27%
del_shuttle_priv::queue                           27,430     27,399  -31 -0.11%
del_shuttle_priv::shuttle                        128,237    128,013 -224 -0.17%
del_tq::delegate                                  22,930     22,899  -31 -0.14%
del_tq::redelegate                                 1,794      1,786   -8 -0.45%
dep_queue::accepts_legacy_destination_ata         13,486     13,468  -18 -0.13%
dep_queue::all_splits_use_client_ref_id           11,031     10,947  -84 -0.76%
dep_queue::assign_group_id_0                      10,732     10,681  -51 -0.48%
dep_queue::assign_group_id_1                      11,232     11,147  -85 -0.76%
dep_queue::deterministic_delays                   11,363     11,344  -19 -0.17%
dep_queue::once_split                             10,970     10,920  -50 -0.46%
dep_queue::reject_delay_range                        331        331   +0 +0.00%
dep_queue::reject_queue_full                         275        273   -2 -0.73%
dep_queue::reject_split_gt_amt                       328        328   +0 +0.00%
dep_queue::reject_zero_split                         323        323   +0 +0.00%
dep_queue::return_to_shuttle                       7,835      7,833   -2 -0.03%
dep_queue::split3_mod5                            11,171     11,119  -52 -0.47%
dep_queue::split4_mod5                            11,554     11,469  -85 -0.74%
dep_shuttle::deposit                               7,856      7,831  -25 -0.32%
dep_spl::deposit                                   7,856      7,831  -25 -0.32%
init_eata::init                                    4,723      4,717   -6 -0.13%
init_gvault::init                                 15,938     15,919  -19 -0.12%
init_gvault::migrate                              13,015     12,993  -22 -0.17%
init_shuttle::init                                18,991     18,977  -14 -0.07%
init_tq::custom                                   14,984     14,972  -12 -0.08%
init_tq::default                                  13,518     13,506  -12 -0.09%
init_tq::noop                                      6,417      6,406  -11 -0.17%
lamports_pda::allow_extra_lamports                 1,835      1,825  -10 -0.54%
lamports_pda::sponsored_lamports_transfer         60,590     60,552  -38 -0.06%
lamports_pda::transfer_lamports_pda                6,335      6,325  -10 -0.16%
merge_shuttle::merge                               9,494      9,484  -10 -0.11%
rent_pda::init                                     1,630      1,627   -3 -0.18%
rent_pda::reinit                                     240        237   -3 -1.25%
reset_eata_perm::reset                            26,484     26,483   -1 -0.00%
tq_alloc::already_allocated                        1,822      1,822   +0 +0.00%
tq_alloc::first_allocate                          18,880     18,880   +0 +0.00%
tq_auto::crank_1                                   5,324      5,308  -16 -0.30%
tq_auto::crank_2                                   6,489      6,473  -16 -0.25%
tq_auto::crank_bad_magic                             289        284   -5 -1.73%
tq_auto::enqueue_delayed                          10,426     10,408  -18 -0.17%
tq_auto::enqueue_ready                            10,426     10,408  -18 -0.17%
tq_auto::enqueue_with_client_ref_id               10,427     10,409  -18 -0.17%
tq_auto::run_scheduled_tick                       15,310     15,297  -13 -0.08%
tq_auto::run_scheduled_tick_via_magic_bundle      15,308     15,295  -13 -0.08%
tq_auto::schedule                                  5,324      5,308  -16 -0.30%
tq_auto::schedule_with_client_ref_id               5,324      5,308  -16 -0.30%
tq_auto::tick_after_bundle                         2,105      2,096   -9 -0.43%
tq_auto::tick_empty                                2,105      2,096   -9 -0.43%
tq_auto::tick_not_ready                            2,191      2,182   -9 -0.41%
ud_wd_close::undelegate                           13,767     13,752  -15 -0.11%
undel_eata_cb::undelegate                         36,852     36,852   +0 +0.00%
undel_perm_cb::undelegate                         34,444     34,444   +0 +0.00%
wd_shuttle::withdraw                              63,668     63,454 -214 -0.34%
wd_spl::withdraw                                   7,869      7,841  -28 -0.36%
───────────────────────────────────────────────────────────────────────────────
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Standardized address validation mechanisms across all protocol operations to improve consistency and reliability.

* **Chores**
  * Updated baseline compute unit metrics to reflect current platform performance characteristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->