### PR TITLE
refactor: use requires to assert and automatically log richer information on failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,6 +1840,7 @@ dependencies = [
  "bytemuck",
  "ephemeral-rollups-pinocchio",
  "pinocchio 0.10.1",
+ "pinocchio-log",
  "pinocchio-pubkey",
  "solana-address 2.0.0",
 ]

--- a/e-token-api/Cargo.toml
+++ b/e-token-api/Cargo.toml
@@ -9,6 +9,7 @@ edition = { workspace = true }
 
 [dependencies]
 pinocchio = { workspace = true }
+pinocchio-log = { workspace = true }
 pinocchio-pubkey = { workspace = true }
 solana-address = { workspace = true, features = ["bytemuck"] }
 ephemeral-rollups-pinocchio = { workspace = true }

--- a/e-token-api/src/error.rs
+++ b/e-token-api/src/error.rs
@@ -1,13 +1,22 @@
 use pinocchio::error::{ProgramError, ToStr};
 
+#[repr(u32)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum EphemeralSplError {
     // invalid instruction data
-    InvalidInstruction,
+    InvalidInstruction = 1,
     // account already initialized / in use
-    AlreadyInUse,
-    // Ephemeral ATA, Vault, Mint or Owner mismatch
-    EphemeralAtaMismatch,
+    AlreadyInUse = 2,
+    // Ephemeral ATA mismatch
+    EphemeralAtaMismatch = 3,
+    // mint account mismatch
+    MintMismatch = 4,
+    // vault token account mismatch
+    VaultTokenAccountMismatch = 5,
+    // too many accounts were passed to the instruction
+    TooManyAccountKeys = 6,
+    // internal invariant / unreachable conversion failure
+    InfallibleError = 255,
 }
 
 impl From<EphemeralSplError> for ProgramError {
@@ -18,12 +27,16 @@ impl From<EphemeralSplError> for ProgramError {
 
 impl ToStr for EphemeralSplError {
     fn to_str(&self) -> &'static str {
+        use EphemeralSplError::*;
+
         match self {
-            EphemeralSplError::InvalidInstruction => "Error: Invalid instruction",
-            EphemeralSplError::AlreadyInUse => "Error: Account already in use",
-            EphemeralSplError::EphemeralAtaMismatch => {
-                "Error: Ephemeral ATA/Vault/Mint/Owner mismatch"
-            }
+            InvalidInstruction => "EphemeralSplError::InvalidInstruction",
+            AlreadyInUse => "EphemeralSplError::AlreadyInUse",
+            EphemeralAtaMismatch => "EphemeralSplError::EphemeralAtaMismatch",
+            MintMismatch => "EphemeralSplError::MintMismatch",
+            VaultTokenAccountMismatch => "EphemeralSplError::VaultTokenAccountMismatch",
+            TooManyAccountKeys => "EphemeralSplError::TooManyAccountKeys",
+            InfallibleError => "EphemeralSplError::InfallibleError",
         }
     }
 }
@@ -32,9 +45,13 @@ impl core::convert::TryFrom<u32> for EphemeralSplError {
     type Error = ProgramError;
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(EphemeralSplError::InvalidInstruction),
-            1 => Ok(EphemeralSplError::AlreadyInUse),
-            2 => Ok(EphemeralSplError::EphemeralAtaMismatch),
+            1 => Ok(EphemeralSplError::InvalidInstruction),
+            2 => Ok(EphemeralSplError::AlreadyInUse),
+            3 => Ok(EphemeralSplError::EphemeralAtaMismatch),
+            4 => Ok(EphemeralSplError::MintMismatch),
+            5 => Ok(EphemeralSplError::VaultTokenAccountMismatch),
+            6 => Ok(EphemeralSplError::TooManyAccountKeys),
+            255 => Ok(EphemeralSplError::InfallibleError),
             _ => Err(ProgramError::InvalidArgument),
         }
     }

--- a/e-token-api/src/lib.rs
+++ b/e-token-api/src/lib.rs
@@ -5,6 +5,7 @@
 // the on-chain program crate stays cdylib-only.
 pub mod consts;
 pub mod error;
+pub mod requires;
 pub mod state;
 pub mod program {
     pub use ephemeral_rollups_pinocchio::consts::DELEGATION_PROGRAM_ID;

--- a/e-token-api/src/requires.rs
+++ b/e-token-api/src/requires.rs
@@ -13,6 +13,26 @@ macro_rules! require {
 }
 
 ///
+/// require_owned_by: a is owned by b
+///
+#[macro_export]
+macro_rules! require_owned_by {
+    ($account:expr, $owner_ref:expr) => {{
+        if !pinocchio::address::address_eq(unsafe { $account.owner() }, $owner_ref) {
+            pinocchio_log::log!(
+                "require_owned_by!({}, {}) failed.",
+                stringify!($account),
+                stringify!($owner_ref)
+            );
+            $account.address().log();
+            unsafe { $account.owner() }.log();
+            $owner_ref.log();
+            return Err(pinocchio::error::ProgramError::InvalidAccountOwner);
+        }
+    }};
+}
+
+///
 /// require key1 == key2
 ///
 #[macro_export]

--- a/e-token-api/src/requires.rs
+++ b/e-token-api/src/requires.rs
@@ -1,0 +1,240 @@
+///
+/// require true
+///
+#[macro_export]
+macro_rules! require {
+    ($cond:expr, $error:expr) => {{
+        if !$cond {
+            let expr = stringify!($cond);
+            pinocchio_log::log!("require!({}) failed.", expr);
+            return Err($error.into());
+        }
+    }};
+}
+
+///
+/// require key1 == key2
+///
+#[macro_export]
+macro_rules! require_eq_keys {
+    ( $key1:expr, $key2:expr, $error:expr) => {{
+        if !pinocchio::address::address_eq($key1, $key2) {
+            pinocchio_log::log!(
+                "require_eq_keys!({}, {}) failed: ",
+                stringify!($key1),
+                stringify!($key2)
+            );
+            $key1.log();
+            $key2.log();
+            return Err($error.into());
+        }
+    }};
+}
+
+///
+/// require key1 != key2
+///
+#[macro_export]
+macro_rules! require_ne_keys {
+    ( $key1:expr, $key2:expr, $error:expr) => {{
+        if pinocchio::address::address_eq($key1, $key2) {
+            pinocchio_log::log!(
+                "require_ne_keys!({}, {}) failed: ",
+                stringify!($key1),
+                stringify!($key2)
+            );
+            $key1.log();
+            $key2.log();
+            return Err($error.into());
+        }
+    }};
+}
+
+///
+/// require a <= b
+///
+#[macro_export]
+macro_rules! require_le {
+    ( $val1:expr, $val2:expr, $error:expr) => {{
+        if !($val1 <= $val2) {
+            pinocchio_log::log!(
+                "require_le!({}, {}) failed: {} <= {}",
+                stringify!($val1),
+                stringify!($val2),
+                $val1,
+                $val2
+            );
+            return Err($error.into());
+        }
+    }};
+}
+
+///
+/// require a < b
+///
+#[macro_export]
+macro_rules! require_lt {
+    ( $val1:expr, $val2:expr, $error:expr) => {{
+        if !($val1 < $val2) {
+            pinocchio_log::log!(
+                "require_lt!({}, {}) failed: {} < {}",
+                stringify!($val1),
+                stringify!($val2),
+                $val1,
+                $val2
+            );
+            return Err($error.into());
+        }
+    }};
+}
+
+///
+/// require a == b
+///
+#[macro_export]
+macro_rules! require_eq {
+    ( $val1:expr, $val2:expr, $error:expr) => {{
+        if !($val1 == $val2) {
+            pinocchio_log::log!(
+                "require_eq!({}, {}) failed: {} == {}",
+                stringify!($val1),
+                stringify!($val2),
+                $val1,
+                $val2
+            );
+            return Err($error.into());
+        }
+    }};
+}
+
+///
+/// require a >= b
+///
+#[macro_export]
+macro_rules! require_ge {
+    ( $val1:expr, $val2:expr, $error:expr) => {{
+        if !($val1 >= $val2) {
+            pinocchio_log::log!(
+                "require_ge!({}, {}) failed: {} >= {}",
+                stringify!($val1),
+                stringify!($val2),
+                $val1,
+                $val2
+            );
+            return Err($error.into());
+        }
+    }};
+}
+
+///
+/// require a > b
+///
+#[macro_export]
+macro_rules! require_gt {
+    ( $val1:expr, $val2:expr, $error:expr) => {{
+        if !($val1 > $val2) {
+            pinocchio_log::log!(
+                "require_gt!({}, {}) failed: {} > {}",
+                stringify!($val1),
+                stringify!($val2),
+                $val1,
+                $val2
+            );
+            return Err($error.into());
+        }
+    }};
+}
+
+///
+/// require exactly n accounts
+///
+#[macro_export]
+macro_rules! require_n_accounts {
+    ( $accounts:expr, $n:literal) => {{
+        match $accounts.len().cmp(&$n) {
+            core::cmp::Ordering::Less => {
+                pinocchio_log::log!(
+                    "Need {} accounts, but got less ({}) accounts",
+                    $n,
+                    $accounts.len()
+                );
+                return Err(pinocchio::error::ProgramError::NotEnoughAccountKeys);
+            }
+            core::cmp::Ordering::Equal => TryInto::<&[_; $n]>::try_into($accounts)
+                .map_err(|_| $crate::error::EphemeralSplError::InfallibleError)?,
+            core::cmp::Ordering::Greater => {
+                pinocchio_log::log!(
+                    "Need {} accounts, but got more ({}) accounts",
+                    $n,
+                    $accounts.len()
+                );
+                return Err($crate::error::EphemeralSplError::TooManyAccountKeys.into());
+            }
+        }
+    }};
+}
+
+///
+/// require n-or-more accounts, more is returned as slice.
+///
+#[macro_export]
+macro_rules! require_n_accounts_with_optionals {
+    ( $accounts:expr, $n:literal) => {{
+        match $accounts.len().cmp(&$n) {
+            core::cmp::Ordering::Less => {
+                pinocchio_log::log!(
+                    "Need {} accounts, but got less ({}) accounts",
+                    $n,
+                    $accounts.len()
+                );
+                return Err(pinocchio::error::ProgramError::NotEnoughAccountKeys);
+            }
+            _ => {
+                let (exact, optionals) = $accounts.split_at($n);
+
+                (
+                    TryInto::<&[_; $n]>::try_into(exact)
+                        .map_err(|_| $crate::error::EphemeralSplError::InfallibleError)?,
+                    optionals,
+                )
+            }
+        }
+    }};
+}
+
+///
+/// require n-or-more accounts, more is ignored.
+///
+#[macro_export]
+macro_rules! require_n_accounts_with_ignored {
+    ( $accounts:expr, $n:literal) => {{
+        match $accounts.len().cmp(&$n) {
+            core::cmp::Ordering::Less => {
+                pinocchio_log::log!(
+                    "Need {} accounts, but got less ({}) accounts",
+                    $n,
+                    $accounts.len()
+                );
+                return Err(pinocchio::error::ProgramError::NotEnoughAccountKeys);
+            }
+            _ => {
+                let (exact, _) = $accounts.split_at($n);
+                TryInto::<&[_; $n]>::try_into(exact)
+                    .map_err(|_| $crate::error::EphemeralSplError::InfallibleError)?
+            }
+        }
+    }};
+}
+
+///
+/// require Option to be Some
+///
+#[macro_export]
+macro_rules! require_some {
+    ($option:expr, $error:expr) => {{
+        match $option {
+            Some(val) => val,
+            None => return Err($error.into()),
+        }
+    }};
+}

--- a/e-token/src/processor/allocate_transfer_queue.rs
+++ b/e-token/src/processor/allocate_transfer_queue.rs
@@ -1,5 +1,5 @@
 use ephemeral_spl_api::state::transfer_queue::{item_len, queue_views_checked, TransferQueue};
-use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
@@ -24,7 +24,7 @@ pub fn process_allocate_transfer_queue(
     let [
         queue_info, // force multi-line
         _system_program_info,
-    ] = require_n_accounts_with_ignored!(accounts, 2);
+    ] = require_n_accounts!(accounts, 2);
 
     require!(
         queue_info.owned_by(&crate::ID),

--- a/e-token/src/processor/allocate_transfer_queue.rs
+++ b/e-token/src/processor/allocate_transfer_queue.rs
@@ -1,10 +1,8 @@
 use ephemeral_spl_api::state::transfer_queue::{item_len, queue_views_checked, TransferQueue};
-use pinocchio::address::address_eq;
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
-
-use crate::assert_owner;
 
 pub const MAX_ITEMS_PER_REALLOC: usize = 10_240 / item_len();
 
@@ -23,19 +21,25 @@ pub fn process_allocate_transfer_queue(
     accounts: &[AccountView],
     _instruction_data: &[u8],
 ) -> ProgramResult {
-    let [queue_info, _system_program_info, ..] = accounts else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    let [
+        queue_info, // force multi-line
+        _system_program_info,
+    ] = require_n_accounts_with_ignored!(accounts, 2);
 
-    assert_owner!(queue_info, &crate::ID);
+    require!(
+        queue_info.owned_by(&crate::ID),
+        ProgramError::InvalidAccountOwner
+    );
 
     let realloc_size = {
         let (header, _) = queue_views_checked(unsafe { queue_info.borrow_unchecked() })?;
         let derived_queue =
             TransferQueue::derive_pda(&header.mint, &header.validator, header.bump)?;
-        if !address_eq(&derived_queue, queue_info.address()) {
-            return Err(ProgramError::InvalidSeeds);
-        }
+        require_eq_keys!(
+            &derived_queue,
+            queue_info.address(),
+            ProgramError::InvalidSeeds
+        );
 
         let rent = Rent::get()?;
         let cost_per_item = rent.try_minimum_balance(item_len())? - rent.try_minimum_balance(0)?;

--- a/e-token/src/processor/close_ephemeral_ata.rs
+++ b/e-token/src/processor/close_ephemeral_ata.rs
@@ -1,7 +1,6 @@
 use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
-use pinocchio::{address::address_eq, error::ProgramError, AccountView, ProgramResult};
-
-use crate::{assert_owner, assert_signer};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
 ///
 /// Executes on:
@@ -19,22 +18,30 @@ pub fn process_close_ephemeral_ata(
     accounts: &[AccountView],
     _instruction_data: &[u8],
 ) -> ProgramResult {
-    let [owner_info, ephemeral_ata_info, recipient_info, ..] = accounts else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    let [
+        owner_info, // force multi-line
+        ephemeral_ata_info,
+        recipient_info,
+    ] = require_n_accounts_with_ignored!(accounts, 3);
 
-    assert_signer!(owner_info);
-    assert_owner!(ephemeral_ata_info, &crate::ID);
+    require!(
+        owner_info.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
+    require!(
+        ephemeral_ata_info.owned_by(&crate::ID),
+        ProgramError::InvalidAccountOwner
+    );
 
     let (mint, lamports_to_refund, bump) = {
         let ephemeral_ata =
             load_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked() })?;
-        if ephemeral_ata.owner != *owner_info.address() {
-            return Err(ProgramError::IncorrectAuthority);
-        }
-        if ephemeral_ata.amount != 0 {
-            return Err(ProgramError::InvalidArgument);
-        }
+        require_eq_keys!(
+            &ephemeral_ata.owner,
+            owner_info.address(),
+            ProgramError::IncorrectAuthority
+        );
+        require!(ephemeral_ata.amount == 0, ProgramError::InvalidArgument);
 
         #[allow(clippy::clone_on_copy)]
         let mint = ephemeral_ata.mint.clone();
@@ -42,13 +49,16 @@ pub fn process_close_ephemeral_ata(
     };
 
     let derived_pda = EphemeralAta::derive_pda(owner_info.address(), &mint, bump)?;
-    if !address_eq(&derived_pda, ephemeral_ata_info.address()) {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &derived_pda,
+        ephemeral_ata_info.address(),
+        ProgramError::InvalidSeeds
+    );
 
-    if address_eq(recipient_info.address(), ephemeral_ata_info.address()) {
-        return Err(ProgramError::InvalidArgument);
-    }
+    require!(
+        recipient_info.address() != ephemeral_ata_info.address(),
+        ProgramError::InvalidArgument
+    );
 
     let updated_recipient_lamports = recipient_info
         .lamports()

--- a/e-token/src/processor/close_ephemeral_ata.rs
+++ b/e-token/src/processor/close_ephemeral_ata.rs
@@ -1,5 +1,5 @@
 use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
-use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
 ///
@@ -22,7 +22,7 @@ pub fn process_close_ephemeral_ata(
         owner_info, // force multi-line
         ephemeral_ata_info,
         recipient_info,
-    ] = require_n_accounts_with_ignored!(accounts, 3);
+    ] = require_n_accounts!(accounts, 3);
 
     require!(
         owner_info.is_signer(),

--- a/e-token/src/processor/close_lamports_pda_intent.rs
+++ b/e-token/src/processor/close_lamports_pda_intent.rs
@@ -1,4 +1,6 @@
-use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
+use ephemeral_spl_api::{
+    require, require_eq_keys, require_n_accounts, require_n_accounts_with_ignored,
+};
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
@@ -33,7 +35,7 @@ pub fn process_close_lamports_pda_intent(
         lamports_pda_info,
         payer_info,
         destination_info,
-    ] = require_n_accounts!(accounts, 4);
+    ] = require_n_accounts_with_ignored!(accounts, 4);
 
     let (escrow_index, salt) = parse_escrow_index_and_salt(instruction_data)?;
     require!(accounts.len() >= 6, ProgramError::NotEnoughAccountKeys);

--- a/e-token/src/processor/close_lamports_pda_intent.rs
+++ b/e-token/src/processor/close_lamports_pda_intent.rs
@@ -1,10 +1,10 @@
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
 
-use crate::{
-    assert_owner, assert_signer,
-    processor::{initialize_rent_pda::RENT_PDA, internal::lamports_pda::derive_lamports_pda},
+use crate::processor::{
+    initialize_rent_pda::RENT_PDA, internal::lamports_pda::derive_lamports_pda,
 };
 
 const DLP_EPHEMERAL_BALANCE_TAG: &[u8] = b"balance";
@@ -28,21 +28,31 @@ pub fn process_close_lamports_pda_intent(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let (escrow_index, salt) = parse_escrow_index_and_salt(instruction_data)?;
-    if accounts.len() < 6 {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    }
+    let [
+        rent_pda_info, // force multi-line
+        lamports_pda_info,
+        payer_info,
+        destination_info,
+    ] = require_n_accounts_with_ignored!(accounts, 4);
 
-    let rent_pda_info = &accounts[0];
-    let lamports_pda_info = &accounts[1];
-    let payer_info = &accounts[2];
-    let destination_info = &accounts[3];
+    let (escrow_index, salt) = parse_escrow_index_and_salt(instruction_data)?;
+    require!(accounts.len() >= 6, ProgramError::NotEnoughAccountKeys);
+
     let escrow_authority = &accounts[accounts.len() - 2];
     let escrow_signer = &accounts[accounts.len() - 1];
 
-    assert_signer!(escrow_signer);
-    assert_owner!(rent_pda_info, &pinocchio_system::ID);
-    assert_owner!(lamports_pda_info, &crate::ID);
+    require!(
+        escrow_signer.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
+    require!(
+        rent_pda_info.owned_by(&pinocchio_system::ID),
+        ProgramError::InvalidAccountOwner
+    );
+    require!(
+        lamports_pda_info.owned_by(&crate::ID),
+        ProgramError::InvalidAccountOwner
+    );
 
     let escrow_index_seed = [escrow_index];
     let (expected_escrow, _) = Address::find_program_address(
@@ -53,34 +63,43 @@ pub fn process_close_lamports_pda_intent(
         ],
         &ephemeral_rollups_pinocchio::ID,
     );
-    if expected_escrow != *escrow_signer.address() {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &expected_escrow,
+        escrow_signer.address(),
+        ProgramError::InvalidSeeds
+    );
 
-    if RENT_PDA != *rent_pda_info.address() {
-        return Err(ProgramError::InvalidSeeds);
-    }
-    if rent_pda_info.data_len() != 0 || lamports_pda_info.data_len() != 0 {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require_eq_keys!(
+        &RENT_PDA,
+        rent_pda_info.address(),
+        ProgramError::InvalidSeeds
+    );
+    require!(
+        rent_pda_info.data_len() == 0 && lamports_pda_info.data_len() == 0,
+        ProgramError::InvalidAccountData
+    );
 
     let (derived_lamports_pda, _) =
         derive_lamports_pda(payer_info.address(), destination_info.address(), &salt);
-    if derived_lamports_pda != *lamports_pda_info.address() {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &derived_lamports_pda,
+        lamports_pda_info.address(),
+        ProgramError::InvalidSeeds
+    );
 
-    if lamports_pda_info.lamports() < Rent::get()?.try_minimum_balance(0)? {
-        return Err(ProgramError::InvalidArgument);
-    }
+    require!(
+        lamports_pda_info.lamports() >= Rent::get()?.try_minimum_balance(0)?,
+        ProgramError::InvalidArgument
+    );
 
     close_program_account_to_recipient(lamports_pda_info, rent_pda_info)
 }
 
 fn parse_escrow_index_and_salt(instruction_data: &[u8]) -> Result<(u8, [u8; 32]), ProgramError> {
-    if instruction_data.len() != 33 {
-        return Err(ProgramError::InvalidInstructionData);
-    }
+    require!(
+        instruction_data.len() == 33,
+        ProgramError::InvalidInstructionData
+    );
 
     let mut salt = [0u8; 32];
     salt.copy_from_slice(&instruction_data[1..]);
@@ -91,9 +110,10 @@ fn close_program_account_to_recipient(
     account: &AccountView,
     recipient: &AccountView,
 ) -> ProgramResult {
-    if *recipient.address() == *account.address() {
-        return Err(ProgramError::InvalidArgument);
-    }
+    require!(
+        recipient.address() != account.address(),
+        ProgramError::InvalidArgument
+    );
 
     let lamports_to_refund = account.lamports();
     let updated_recipient_lamports = recipient

--- a/e-token/src/processor/close_lamports_pda_intent.rs
+++ b/e-token/src/processor/close_lamports_pda_intent.rs
@@ -1,6 +1,4 @@
-use ephemeral_spl_api::{
-    require, require_eq_keys, require_n_accounts, require_n_accounts_with_ignored,
-};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};

--- a/e-token/src/processor/close_lamports_pda_intent.rs
+++ b/e-token/src/processor/close_lamports_pda_intent.rs
@@ -1,4 +1,4 @@
-use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
@@ -33,7 +33,7 @@ pub fn process_close_lamports_pda_intent(
         lamports_pda_info,
         payer_info,
         destination_info,
-    ] = require_n_accounts_with_ignored!(accounts, 4);
+    ] = require_n_accounts!(accounts, 4);
 
     let (escrow_index, salt) = parse_escrow_index_and_salt(instruction_data)?;
     require!(accounts.len() >= 6, ProgramError::NotEnoughAccountKeys);

--- a/e-token/src/processor/close_shuttle_ata_intent.rs
+++ b/e-token/src/processor/close_shuttle_ata_intent.rs
@@ -1,12 +1,11 @@
 use crate::processor::internal::token_vault::withdraw_ephemeral_ata_tokens;
 use crate::processor::utils::validate_token_account;
-use crate::{assert_owner, assert_signer};
 use ephemeral_spl_api::state::ephemeral_ata::EphemeralAta;
 use ephemeral_spl_api::state::{
     ephemeral_ata::read_ephemeral_ata_compat, load_initialized,
     shuttle_ephemeral_ata::ShuttleMetadata,
 };
-use pinocchio::address::address_eq;
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts, require_some};
 use pinocchio::cpi::Signer;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 use pinocchio_token_2022::instructions::CloseAccount;
@@ -36,21 +35,37 @@ pub fn process_close_shuttle_ata_intent(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let [escrow_index] = instruction_data else {
-        return Err(ProgramError::InvalidInstructionData);
-    };
+    let [
+        rent_reimbursement_info, // force multi-line
+        shuttle_info,
+        shuttle_ephemeral_ata_info,
+        shuttle_wallet_ata_info,
+        destination_token_info,
+        mint_info,
+        vault_info,
+        vault_source_token_acc,
+        token_program_info,
+        source_program,
+        escrow_authority,
+        escrow_signer,
+    ] = require_n_accounts!(accounts, 12);
 
-    let [rent_reimbursement_info, shuttle_info, shuttle_ephemeral_ata_info, shuttle_wallet_ata_info, destination_token_info, mint_info, vault_info, vault_source_token_acc, token_program_info, source_program, escrow_authority, escrow_signer] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    require!(
+        instruction_data.len() == 1,
+        ProgramError::InvalidInstructionData
+    );
+    let escrow_index = &instruction_data[0];
 
-    if !address_eq(source_program.address(), &crate::ID) {
-        return Err(ProgramError::IncorrectAuthority);
-    }
+    require_eq_keys!(
+        source_program.address(),
+        &crate::ID,
+        ProgramError::IncorrectAuthority
+    );
 
-    assert_signer!(escrow_signer);
+    require!(
+        escrow_signer.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
 
     let escrow_index_seed = [*escrow_index];
     let (expected_escrow, _) = ephemeral_spl_api::Address::find_program_address(
@@ -61,9 +76,11 @@ pub fn process_close_shuttle_ata_intent(
         ],
         &ephemeral_rollups_pinocchio::ID,
     );
-    if !address_eq(&expected_escrow, escrow_signer.address()) {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &expected_escrow,
+        escrow_signer.address(),
+        ProgramError::InvalidSeeds
+    );
 
     let shuttle_present = shuttle_info.lamports() > 0;
     let shuttle_ephemeral_present = shuttle_ephemeral_ata_info.lamports() > 0;
@@ -73,13 +90,18 @@ pub fn process_close_shuttle_ata_intent(
     let mut shuttle_owner_opt = None;
     let mut shuttle_bump = None;
     if shuttle_present {
-        assert_owner!(shuttle_info, &crate::ID);
+        require!(
+            shuttle_info.owned_by(&crate::ID),
+            ProgramError::InvalidAccountOwner
+        );
 
         let shuttle =
             load_initialized::<ShuttleMetadata>(unsafe { shuttle_info.borrow_unchecked() })?;
-        if shuttle.payer != *rent_reimbursement_info.address() {
-            return Err(ProgramError::IncorrectAuthority);
-        }
+        require_eq_keys!(
+            &shuttle.payer,
+            rent_reimbursement_info.address(),
+            ProgramError::IncorrectAuthority
+        );
         shuttle_id = shuttle.id;
         let shuttle_owner = shuttle.owner;
         shuttle_owner_opt = Some(shuttle_owner);
@@ -87,15 +109,14 @@ pub fn process_close_shuttle_ata_intent(
     }
 
     if shuttle_wallet_present {
-        assert_owner!(shuttle_wallet_ata_info, token_program_info.address());
-        let Some(shuttle_bump) = shuttle_bump else {
-            // If the shuttle wallet is present, so is the shuttle and its bump
-            return Err(ProgramError::InvalidAccountData);
-        };
+        require!(
+            shuttle_wallet_ata_info.owned_by(token_program_info.address()),
+            ProgramError::InvalidAccountOwner
+        );
+        let shuttle_bump = require_some!(shuttle_bump, ProgramError::InvalidAccountData);
 
-        let Some(shuttle_owner) = shuttle_owner_opt.as_ref() else {
-            return Err(ProgramError::InvalidAccountData);
-        };
+        let shuttle_owner =
+            require_some!(shuttle_owner_opt.as_ref(), ProgramError::InvalidAccountData);
         let (mint, shuttle_wallet_amount) = {
             let token_account = validate_token_account(
                 shuttle_wallet_ata_info,
@@ -106,16 +127,16 @@ pub fn process_close_shuttle_ata_intent(
             (token_account.mint(), token_account.amount())
         };
 
-        if shuttle_wallet_amount != 0 {
-            return Err(ProgramError::InvalidArgument);
-        }
+        require!(shuttle_wallet_amount == 0, ProgramError::InvalidArgument);
 
         let shuttle_id_seed = shuttle_id.to_le_bytes();
         let derived_shuttle =
             ShuttleMetadata::derive_pda(shuttle_owner, mint, shuttle_id, shuttle_bump)?;
-        if derived_shuttle != *shuttle_info.address() {
-            return Err(ProgramError::InvalidSeeds);
-        }
+        require_eq_keys!(
+            &derived_shuttle,
+            shuttle_info.address(),
+            ProgramError::InvalidSeeds
+        );
 
         let bump = [shuttle_bump];
         let signer_seeds =
@@ -132,29 +153,28 @@ pub fn process_close_shuttle_ata_intent(
     }
 
     if shuttle_ephemeral_present {
-        assert_owner!(shuttle_ephemeral_ata_info, &crate::ID);
-        let Some(shuttle_bump) = shuttle_bump else {
-            // If the shuttle ephemeral ATA is present, so is the shuttle and its bump
-            return Err(ProgramError::InvalidAccountData);
-        };
+        require!(
+            shuttle_ephemeral_ata_info.owned_by(&crate::ID),
+            ProgramError::InvalidAccountOwner
+        );
+        let shuttle_bump = require_some!(shuttle_bump, ProgramError::InvalidAccountData);
 
-        let Some(shuttle_owner) = shuttle_owner_opt.as_ref() else {
-            return Err(ProgramError::InvalidAccountData);
-        };
+        let shuttle_owner =
+            require_some!(shuttle_owner_opt.as_ref(), ProgramError::InvalidAccountData);
         let (mint, shuttle_ephemeral_amount, shuttle_eata_bump) = {
             let shuttle_ephemeral_ata_data = shuttle_ephemeral_ata_info.try_borrow()?;
             let (ephemeral_owner, mint, amount, shuttle_eata_bump) =
                 read_ephemeral_ata_compat(&shuttle_ephemeral_ata_data)?;
-            if !address_eq(&ephemeral_owner, shuttle_info.address()) {
-                return Err(ProgramError::InvalidAccountData);
-            }
+            require_eq_keys!(
+                &ephemeral_owner,
+                shuttle_info.address(),
+                ProgramError::InvalidAccountData
+            );
             (mint, amount, shuttle_eata_bump)
         };
 
         if shuttle_ephemeral_amount != 0 {
-            if !address_eq(&mint, mint_info.address()) {
-                return Err(ProgramError::InvalidAccountData);
-            }
+            require_eq_keys!(&mint, mint_info.address(), ProgramError::InvalidAccountData);
 
             withdraw_ephemeral_ata_tokens(
                 shuttle_info,
@@ -171,18 +191,20 @@ pub fn process_close_shuttle_ata_intent(
 
         let derived_shuttle =
             ShuttleMetadata::derive_pda(shuttle_owner, &mint, shuttle_id, shuttle_bump)?;
-        if !address_eq(&derived_shuttle, shuttle_info.address()) {
-            return Err(ProgramError::InvalidSeeds);
-        }
+
+        require_eq_keys!(
+            &derived_shuttle,
+            shuttle_info.address(),
+            ProgramError::InvalidSeeds
+        );
 
         let derived_shuttle_ephemeral_ata =
             EphemeralAta::derive_pda(shuttle_info.address(), &mint, shuttle_eata_bump)?;
-        if !address_eq(
+        require_eq_keys!(
             &derived_shuttle_ephemeral_ata,
             shuttle_ephemeral_ata_info.address(),
-        ) {
-            return Err(ProgramError::InvalidSeeds);
-        }
+            ProgramError::InvalidSeeds
+        );
 
         close_program_account_to_recipient(shuttle_ephemeral_ata_info, rent_reimbursement_info)?;
     }
@@ -199,9 +221,10 @@ fn close_program_account_to_recipient(
     account: &AccountView,
     recipient: &AccountView,
 ) -> ProgramResult {
-    if address_eq(recipient.address(), account.address()) {
-        return Err(ProgramError::InvalidArgument);
-    }
+    require!(
+        recipient.address() != account.address(),
+        ProgramError::InvalidArgument
+    );
 
     let lamports_to_refund = account.lamports();
     let updated_recipient_lamports = recipient

--- a/e-token/src/processor/create_ephemeral_ata_permission.rs
+++ b/e-token/src/processor/create_ephemeral_ata_permission.rs
@@ -7,7 +7,7 @@ use ephemeral_rollups_pinocchio::acl::{
 };
 use ephemeral_spl_api::{require, require_eq_keys};
 use ephemeral_spl_api::{
-    require_n_accounts_with_ignored,
+    require_n_accounts,
     state::{ephemeral_ata::EphemeralAta, load_initialized},
 };
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
@@ -36,7 +36,7 @@ pub fn process_create_ephemeral_ata_permission(
         payer_info,
         system_program,
         permission_program,
-    ] = require_n_accounts_with_ignored!(accounts, 5);
+    ] = require_n_accounts!(accounts, 5);
 
     let args = CreateEphemeralAtaPermission::try_from_bytes(instruction_data)?;
 

--- a/e-token/src/processor/create_ephemeral_ata_permission.rs
+++ b/e-token/src/processor/create_ephemeral_ata_permission.rs
@@ -5,10 +5,12 @@ use ephemeral_rollups_pinocchio::acl::{
     pda::permission_pda_from_permissioned_account,
     types::{Member, MemberFlags, MembersArgs},
 };
-use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
-use pinocchio::{address::address_eq, error::ProgramError, AccountView, ProgramResult};
-
-use crate::assert_signer;
+use ephemeral_spl_api::{require, require_eq_keys};
+use ephemeral_spl_api::{
+    require_n_accounts_with_ignored,
+    state::{ephemeral_ata::EphemeralAta, load_initialized},
+};
+use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
 ///
 /// Executes on:
@@ -28,19 +30,26 @@ pub fn process_create_ephemeral_ata_permission(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
+    let [
+        ephemeral_ata_info, // force multi-line
+        permission_info,
+        payer_info,
+        system_program,
+        permission_program,
+    ] = require_n_accounts_with_ignored!(accounts, 5);
+
     let args = CreateEphemeralAtaPermission::try_from_bytes(instruction_data)?;
 
-    let [ephemeral_ata_info, permission_info, payer_info, system_program, permission_program, ..] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    require!(
+        payer_info.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
 
-    assert_signer!(payer_info);
-
-    if *permission_program.address() != PERMISSION_PROGRAM_ID {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require_eq_keys!(
+        &PERMISSION_PROGRAM_ID,
+        permission_program.address(),
+        ProgramError::InvalidAccountData
+    );
 
     let ephemeral_ata =
         load_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked() })?;
@@ -50,15 +59,18 @@ pub fn process_create_ephemeral_ata_permission(
     // Valid in 2 cases:
     // - Payer is the owner of the eata
     // - Permisionless, but permission are default (only readable for eata owner)
-    if ephemeral_ata.owner != *payer_info.address() && flag_byte != 0 {
-        return Err(ProgramError::IncorrectAuthority);
-    }
+    require!(
+        ephemeral_ata.owner == *payer_info.address() || flag_byte == 0,
+        ProgramError::IncorrectAuthority
+    );
 
     let expected_permission =
         permission_pda_from_permissioned_account(ephemeral_ata_info.address());
-    if !address_eq(&expected_permission, permission_info.address()) {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &expected_permission,
+        permission_info.address(),
+        ProgramError::InvalidSeeds
+    );
 
     // Idempotent create: if the permission account already exists, return Ok(())
     // for safe transaction batching rather than treating it as an error.
@@ -108,9 +120,7 @@ pub struct CreateEphemeralAtaPermission<'a> {
 impl CreateEphemeralAtaPermission<'_> {
     #[inline]
     pub fn try_from_bytes(bytes: &[u8]) -> Result<CreateEphemeralAtaPermission<'_>, ProgramError> {
-        if bytes.is_empty() {
-            return Err(ProgramError::InvalidInstructionData);
-        }
+        require!(!bytes.is_empty(), ProgramError::InvalidInstructionData);
 
         Ok(CreateEphemeralAtaPermission {
             raw: bytes.as_ptr(),

--- a/e-token/src/processor/delegate_ephemeral_ata.rs
+++ b/e-token/src/processor/delegate_ephemeral_ata.rs
@@ -1,5 +1,6 @@
 use ephemeral_rollups_pinocchio::instruction::DelegateAccountCpiBuilder;
 use ephemeral_rollups_pinocchio::types::DelegateConfig;
+use ephemeral_spl_api::require_n_accounts;
 use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
 
@@ -23,13 +24,18 @@ pub fn process_delegate_ephemeral_ata(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let args = DelegateArgs::try_from_bytes(instruction_data)?;
+    let [
+        payer_info, // force multi-line
+        ephemeral_ata_info,
+        owner_program,
+        buffer_acc,
+        delegation_record,
+        delegation_metadata,
+        _delegation_program,
+        system_program,
+    ] = require_n_accounts!(accounts, 8);
 
-    let [payer_info, ephemeral_ata_info, owner_program, buffer_acc, delegation_record, delegation_metadata, _delegation_program, system_program] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    let args = DelegateArgs::try_from_bytes(instruction_data)?;
 
     let delegation_program = ephemeral_spl_api::program::DELEGATION_PROGRAM_ID;
     if ephemeral_ata_info.owned_by(&delegation_program) {

--- a/e-token/src/processor/delegate_ephemeral_ata_permission.rs
+++ b/e-token/src/processor/delegate_ephemeral_ata_permission.rs
@@ -3,7 +3,7 @@ use ephemeral_rollups_pinocchio::acl::{
     pda::permission_pda_from_permissioned_account,
 };
 use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
-use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
 use pinocchio::{cpi::Signer, error::ProgramError, AccountView, ProgramResult};
 
 ///
@@ -40,7 +40,7 @@ pub fn process_delegate_ephemeral_ata_permission(
         delegation_metadata,
         delegation_program,
         validator,
-    ] = require_n_accounts_with_ignored!(accounts, 10);
+    ] = require_n_accounts!(accounts, 10);
 
     require!(
         payer_info.is_signer(),

--- a/e-token/src/processor/delegate_ephemeral_ata_permission.rs
+++ b/e-token/src/processor/delegate_ephemeral_ata_permission.rs
@@ -3,11 +3,8 @@ use ephemeral_rollups_pinocchio::acl::{
     pda::permission_pda_from_permissioned_account,
 };
 use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
-use pinocchio::{
-    address::address_eq, cpi::Signer, error::ProgramError, AccountView, ProgramResult,
-};
-
-use crate::assert_signer;
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use pinocchio::{cpi::Signer, error::ProgramError, AccountView, ProgramResult};
 
 ///
 /// Executes on:
@@ -32,17 +29,29 @@ pub fn process_delegate_ephemeral_ata_permission(
     accounts: &[AccountView],
     _instruction_data: &[u8],
 ) -> ProgramResult {
-    let [payer_info, ephemeral_ata_info, permission_program, permission_info, system_program, delegation_buffer, delegation_record, delegation_metadata, delegation_program, validator, ..] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    let [
+        payer_info, // force multi-line
+        ephemeral_ata_info,
+        permission_program,
+        permission_info,
+        system_program,
+        delegation_buffer,
+        delegation_record,
+        delegation_metadata,
+        delegation_program,
+        validator,
+    ] = require_n_accounts_with_ignored!(accounts, 10);
 
-    assert_signer!(payer_info);
+    require!(
+        payer_info.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
 
-    if !address_eq(permission_program.address(), &PERMISSION_PROGRAM_ID) {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require_eq_keys!(
+        &PERMISSION_PROGRAM_ID,
+        permission_program.address(),
+        ProgramError::InvalidAccountData
+    );
 
     let dlp_program = ephemeral_spl_api::program::DELEGATION_PROGRAM_ID;
 
@@ -55,9 +64,12 @@ pub fn process_delegate_ephemeral_ata_permission(
 
     let expected_permission =
         permission_pda_from_permissioned_account(ephemeral_ata_info.address());
-    if !address_eq(&expected_permission, permission_info.address()) {
-        return Err(ProgramError::InvalidSeeds);
-    }
+
+    require_eq_keys!(
+        &expected_permission,
+        permission_info.address(),
+        ProgramError::InvalidSeeds
+    );
 
     let bump = [ephemeral_ata.bump];
     let seeds = EphemeralAta::signer_seeds(&ephemeral_ata.owner, &ephemeral_ata.mint, &bump);

--- a/e-token/src/processor/delegate_shuttle_ephemeral_ata.rs
+++ b/e-token/src/processor/delegate_shuttle_ephemeral_ata.rs
@@ -3,9 +3,8 @@ use ephemeral_rollups_pinocchio::types::DelegateConfig;
 use ephemeral_spl_api::state::{
     ephemeral_ata::EphemeralAta, load_initialized, shuttle_ephemeral_ata::ShuttleMetadata,
 };
-use pinocchio::{address::address_eq, error::ProgramError, AccountView, Address, ProgramResult};
-
-use crate::assert_owner;
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
 
 ///
 /// Executes on:
@@ -28,41 +27,57 @@ pub fn process_delegate_shuttle_ephemeral_ata(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let args = DelegateShuttleArgs::try_from_bytes(instruction_data)?;
+    let [
+        payer_info, // force multi-line
+        shuttle_info,
+        ephemeral_ata_info,
+        owner_program,
+        buffer_acc,
+        delegation_record,
+        delegation_metadata,
+        _delegation_program,
+        system_program,
+    ] = require_n_accounts_with_ignored!(accounts, 9);
 
-    let [payer_info, shuttle_info, ephemeral_ata_info, owner_program, buffer_acc, delegation_record, delegation_metadata, _delegation_program, system_program, ..] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    let args = DelegateShuttleArgs::try_from_bytes(instruction_data)?;
 
     let delegation_program = ephemeral_spl_api::program::DELEGATION_PROGRAM_ID;
     if ephemeral_ata_info.owned_by(&delegation_program) {
         return Ok(());
     }
 
-    assert_owner!(shuttle_info, &crate::ID);
+    require!(
+        shuttle_info.owned_by(&crate::ID),
+        ProgramError::InvalidAccountOwner
+    );
 
     // Loading the account to check if the shuttle is correctly initialized
     load_initialized::<ShuttleMetadata>(unsafe { shuttle_info.borrow_unchecked() })?;
 
-    assert_owner!(ephemeral_ata_info, &crate::ID);
+    require!(
+        ephemeral_ata_info.owned_by(&crate::ID),
+        ProgramError::InvalidAccountOwner
+    );
 
     let (mint, eata_bump) = {
         let ephemeral_ata =
             load_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked() })?;
-        if ephemeral_ata.owner != *shuttle_info.address() {
-            return Err(ProgramError::InvalidAccountData);
-        }
+        require_eq_keys!(
+            &ephemeral_ata.owner,
+            shuttle_info.address(),
+            ProgramError::InvalidAccountData
+        );
         #[allow(clippy::clone_on_copy)]
         let mint = ephemeral_ata.mint.clone();
         (mint, ephemeral_ata.bump)
     };
 
     let derived_ephemeral_ata = EphemeralAta::derive_pda(shuttle_info.address(), &mint, eata_bump)?;
-    if !address_eq(&derived_ephemeral_ata, ephemeral_ata_info.address()) {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &derived_ephemeral_ata,
+        ephemeral_ata_info.address(),
+        ProgramError::InvalidSeeds
+    );
 
     let seeds: &[&[u8]] = &[shuttle_info.address().as_ref(), mint.as_ref()];
 

--- a/e-token/src/processor/delegate_shuttle_ephemeral_ata.rs
+++ b/e-token/src/processor/delegate_shuttle_ephemeral_ata.rs
@@ -3,7 +3,7 @@ use ephemeral_rollups_pinocchio::types::DelegateConfig;
 use ephemeral_spl_api::state::{
     ephemeral_ata::EphemeralAta, load_initialized, shuttle_ephemeral_ata::ShuttleMetadata,
 };
-use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
 
 ///
@@ -37,7 +37,7 @@ pub fn process_delegate_shuttle_ephemeral_ata(
         delegation_metadata,
         _delegation_program,
         system_program,
-    ] = require_n_accounts_with_ignored!(accounts, 9);
+    ] = require_n_accounts!(accounts, 9);
 
     let args = DelegateShuttleArgs::try_from_bytes(instruction_data)?;
 

--- a/e-token/src/processor/delegate_transfer_queue.rs
+++ b/e-token/src/processor/delegate_transfer_queue.rs
@@ -1,9 +1,8 @@
 use ephemeral_rollups_pinocchio::instruction::DelegateAccountCpiBuilder;
 use ephemeral_rollups_pinocchio::types::DelegateConfig;
 use ephemeral_spl_api::state::transfer_queue::{queue_views_checked, TransferQueue, QUEUE_SEED};
-use pinocchio::{address::address_eq, error::ProgramError, AccountView, ProgramResult};
-
-use crate::assert_signer;
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
 ///
 /// Executes on:
@@ -26,36 +25,51 @@ pub fn process_delegate_transfer_queue(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    if !instruction_data.is_empty() {
-        return Err(ProgramError::InvalidInstructionData);
-    }
+    let [
+        payer_info, // force multi-line
+        queue_info,
+        mint_info,
+        owner_program,
+        buffer_acc,
+        delegation_record,
+        delegation_metadata,
+        _delegation_program,
+        system_program,
+    ] = require_n_accounts_with_ignored!(accounts, 9);
 
-    let [payer_info, queue_info, mint_info, owner_program, buffer_acc, delegation_record, delegation_metadata, _delegation_program, system_program, ..] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    require!(
+        instruction_data.is_empty(),
+        ProgramError::InvalidInstructionData
+    );
 
-    assert_signer!(payer_info);
+    require!(
+        payer_info.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
 
     let delegation_program = ephemeral_spl_api::program::DELEGATION_PROGRAM_ID;
-    if !queue_info.owned_by(&crate::ID) && !queue_info.owned_by(&delegation_program) {
-        return Err(ProgramError::IllegalOwner);
-    }
+    require!(
+        queue_info.owned_by(&crate::ID) || queue_info.owned_by(&delegation_program),
+        ProgramError::IllegalOwner
+    );
 
     let (bump, validator) = {
         let data = unsafe { queue_info.borrow_unchecked() };
         let (header, _) = queue_views_checked(data)?;
-        if !address_eq(&header.mint, mint_info.address()) {
-            return Err(ProgramError::InvalidAccountData);
-        }
+        require_eq_keys!(
+            &header.mint,
+            mint_info.address(),
+            ProgramError::InvalidAccountData
+        );
 
         let bump = header.bump;
         let derived_queue =
             TransferQueue::derive_pda(mint_info.address(), &header.validator, bump)?;
-        if !address_eq(&derived_queue, queue_info.address()) {
-            return Err(ProgramError::InvalidSeeds);
-        }
+        require_eq_keys!(
+            &derived_queue,
+            queue_info.address(),
+            ProgramError::InvalidSeeds
+        );
 
         (bump, header.validator)
     };
@@ -64,12 +78,16 @@ pub fn process_delegate_transfer_queue(
         return Ok(());
     }
 
-    if !address_eq(owner_program.address(), &crate::ID) {
-        return Err(ProgramError::IncorrectProgramId);
-    }
-    if !address_eq(system_program.address(), &pinocchio_system::ID) {
-        return Err(ProgramError::IncorrectProgramId);
-    }
+    require_eq_keys!(
+        owner_program.address(),
+        &crate::ID,
+        ProgramError::IncorrectProgramId
+    );
+    require_eq_keys!(
+        system_program.address(),
+        &pinocchio_system::ID,
+        ProgramError::IncorrectProgramId
+    );
 
     let config = DelegateConfig {
         validator: Some(validator),

--- a/e-token/src/processor/delegate_transfer_queue.rs
+++ b/e-token/src/processor/delegate_transfer_queue.rs
@@ -1,7 +1,7 @@
 use ephemeral_rollups_pinocchio::instruction::DelegateAccountCpiBuilder;
 use ephemeral_rollups_pinocchio::types::DelegateConfig;
 use ephemeral_spl_api::state::transfer_queue::{queue_views_checked, TransferQueue, QUEUE_SEED};
-use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
 ///
@@ -35,7 +35,7 @@ pub fn process_delegate_transfer_queue(
         delegation_metadata,
         _delegation_program,
         system_program,
-    ] = require_n_accounts_with_ignored!(accounts, 9);
+    ] = require_n_accounts!(accounts, 9);
 
     require!(
         instruction_data.is_empty(),

--- a/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge.rs
+++ b/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 use dlp_api::compact::ClearText;
-use ephemeral_spl_api::require_n_accounts_with_ignored;
+use ephemeral_spl_api::require_n_accounts;
 use pinocchio::{AccountView, ProgramResult};
 use solana_instruction::Instruction;
 
@@ -68,7 +68,7 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge(
         global_vault_info,
         owner_source_token_info,
         vault_token_info,
-    ] = require_n_accounts_with_ignored!(accounts, 19);
+    ] = require_n_accounts!(accounts, 19);
 
     let args = DepositAndDelegateShuttleArgs::try_from_bytes(instruction_data)?;
 

--- a/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge.rs
+++ b/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
 use dlp_api::compact::ClearText;
-use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+use ephemeral_spl_api::require_n_accounts_with_ignored;
+use pinocchio::{AccountView, ProgramResult};
 use solana_instruction::Instruction;
 
 use crate::processor::internal::shuttle_delegation::{
@@ -47,27 +48,31 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
+    let [
+        payer_info, // force multi-line
+        rent_pda_info,
+        shuttle_info,
+        shuttle_eata_info,
+        shuttle_wallet_ata_info,
+        owner_info,
+        owner_program,
+        buffer_acc,
+        delegation_record,
+        delegation_metadata,
+        _delegation_program,
+        _associated_token_program,
+        system_program,
+        destination_token_info,
+        mint_info,
+        token_program_info,
+        global_vault_info,
+        owner_source_token_info,
+        vault_token_info,
+    ] = require_n_accounts_with_ignored!(accounts, 19);
+
     let args = DepositAndDelegateShuttleArgs::try_from_bytes(instruction_data)?;
-    let accounts = parse_deposit_and_delegate_shuttle_with_merge_accounts(accounts)?;
 
-    process_deposit_and_delegate_shuttle_ephemeral_ata_with_post_actions(
-        &accounts.common,
-        args.common_args(),
-        0,
-        default_post_delegation_actions(&accounts).cleartext(),
-    )
-}
-
-fn parse_deposit_and_delegate_shuttle_with_merge_accounts(
-    accounts: &[AccountView],
-) -> Result<DepositAndDelegateShuttleWithMergeAccounts<'_>, ProgramError> {
-    let [payer_info, rent_pda_info, shuttle_info, shuttle_eata_info, shuttle_wallet_ata_info, owner_info, owner_program, buffer_acc, delegation_record, delegation_metadata, _delegation_program, _associated_token_program, system_program, destination_token_info, mint_info, token_program_info, global_vault_info, owner_source_token_info, vault_token_info, ..] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
-
-    Ok(DepositAndDelegateShuttleWithMergeAccounts {
+    let accounts = DepositAndDelegateShuttleWithMergeAccounts {
         common: DepositAndDelegateShuttleAccounts {
             payer_info,
             rent_pda_info,
@@ -87,7 +92,14 @@ fn parse_deposit_and_delegate_shuttle_with_merge_accounts(
             vault_token_info,
         },
         destination_token_info,
-    })
+    };
+
+    process_deposit_and_delegate_shuttle_ephemeral_ata_with_post_actions(
+        &accounts.common,
+        args.common_args(),
+        0,
+        default_post_delegation_actions(&accounts).cleartext(),
+    )
 }
 
 fn default_post_delegation_actions(

--- a/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
+++ b/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
@@ -9,15 +9,12 @@ use dlp_api::args::{
     MaybeEncryptedPubkey,
 };
 use dlp_api::compact::{self};
-use pinocchio::address::address_eq;
 
 use ephemeral_spl_api::state::transfer_queue::{queue_views, TransferQueue};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 use solana_instruction::{AccountMeta, Instruction};
 
-use dlp_api::{args::PostDelegationActions, compact::ClearTextWithInsertable};
-
-use crate::assert_owner;
 use crate::processor::{
     internal::shuttle_delegation::{
         merge_shuttle_into_token_account_action,
@@ -27,6 +24,7 @@ use crate::processor::{
     },
     utils::read_mint_decimals,
 };
+use dlp_api::{args::PostDelegationActions, compact::ClearTextWithInsertable};
 
 const BASIS_POINTS_DENOMINATOR: u128 = 10_000;
 const TRANSFER_CHECKED_DISCRIMINATOR: u8 = 12;
@@ -63,18 +61,54 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let args = DepositAndDelegateShuttleWithPrivateTransferArgs::try_from_bytes(instruction_data)?;
-    if args.amount() == 0 {
-        return Err(ProgramError::InvalidInstructionData);
-    }
+    let [
+        payer_info, // force multi-line
+        rent_pda_info,
+        shuttle_info,
+        shuttle_eata_info,
+        shuttle_wallet_ata_info,
+        owner_info,
+        owner_program,
+        buffer_acc,
+        delegation_record,
+        delegation_metadata,
+        _delegation_program,
+        _associated_token_program,
+        system_program,
+        mint_info,
+        token_program_info,
+        global_vault_info,
+        owner_source_token_info,
+        vault_token_info,
+        queue_info,
+    ] = require_n_accounts_with_ignored!(accounts, 19);
 
-    let (common_accounts, queue_info) =
-        parse_deposit_and_delegate_shuttle_private_transfer_accounts(accounts)?;
+    let args = DepositAndDelegateShuttleWithPrivateTransferArgs::try_from_bytes(instruction_data)?;
+    require!(args.amount() != 0, ProgramError::InvalidInstructionData);
+
+    let common_accounts = DepositAndDelegateShuttleAccounts {
+        payer_info,
+        rent_pda_info,
+        shuttle_info,
+        shuttle_eata_info,
+        shuttle_wallet_ata_info,
+        owner_info,
+        owner_program,
+        buffer_acc,
+        delegation_record,
+        delegation_metadata,
+        system_program,
+        mint_info,
+        token_program_info,
+        global_vault_info,
+        owner_source_token_info,
+        vault_token_info,
+    };
 
     // require queue_info to already be delegated to the delegated program.
-    assert_owner!(
-        queue_info,
-        &ephemeral_spl_api::program::DELEGATION_PROGRAM_ID
+    require!(
+        queue_info.owned_by(&ephemeral_spl_api::program::DELEGATION_PROGRAM_ID),
+        ProgramError::InvalidAccountOwner
     );
 
     #[cfg(feature = "logging")]
@@ -113,9 +147,11 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private
     };
     let derived_queue =
         TransferQueue::derive_pda(common_accounts.mint_info.address(), &validator, bump)?;
-    if !address_eq(&derived_queue, queue_info.address()) {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &derived_queue,
+        queue_info.address(),
+        ProgramError::InvalidSeeds
+    );
 
     let fee_amount = private_transfer_fee_amount(args.amount())?;
     let private_transfer_amount = args
@@ -185,9 +221,7 @@ impl DepositAndDelegateShuttleWithPrivateTransferArgs<'_> {
             1 + 8 + 8 + 4 // min len for mandatory (min_delay_ms + max_delay_ms + split) 
             ;
 
-        if bytes.len() < MIN_LEN {
-            return Err(ProgramError::InvalidInstructionData);
-        }
+        require!(bytes.len() >= MIN_LEN, ProgramError::InvalidInstructionData);
 
         Ok(DepositAndDelegateShuttleWithPrivateTransferArgs {
             raw: bytes.as_ptr(),
@@ -225,9 +259,8 @@ impl DepositAndDelegateShuttleWithPrivateTransferArgs<'_> {
 
         if data.is_empty() {
             return Ok(None);
-        } else if data.len() != 32 {
-            return Err(ProgramError::InvalidInstructionData);
         }
+        require!(data.len() == 32, ProgramError::InvalidInstructionData);
 
         let mut validator = [0u8; 32];
         unsafe {
@@ -254,18 +287,14 @@ impl DepositAndDelegateShuttleWithPrivateTransferArgs<'_> {
         let mut offset = 12; // index where first vardata starts
         let mut var = 0;
         while var < VARINDEX {
-            if offset >= self.len {
-                return Err(ProgramError::InvalidInstructionData);
-            }
+            require!(offset < self.len, ProgramError::InvalidInstructionData);
 
             let len = *self.raw.add(offset);
 
             offset += 1 + len as usize;
             var += 1;
         }
-        if offset >= self.len {
-            return Err(ProgramError::InvalidInstructionData);
-        }
+        require!(offset < self.len, ProgramError::InvalidInstructionData);
 
         let len = *self.raw.add(offset);
 
@@ -365,36 +394,4 @@ fn private_transfer_fee_action(
         ],
         data,
     }
-}
-
-fn parse_deposit_and_delegate_shuttle_private_transfer_accounts(
-    accounts: &[AccountView],
-) -> Result<(DepositAndDelegateShuttleAccounts<'_>, &AccountView), ProgramError> {
-    let [payer_info, rent_pda_info, shuttle_info, shuttle_eata_info, shuttle_wallet_ata_info, owner_info, owner_program, buffer_acc, delegation_record, delegation_metadata, _delegation_program, _associated_token_program, system_program, mint_info, token_program_info, global_vault_info, owner_source_token_info, vault_token_info, queue_info, ..] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
-
-    Ok((
-        DepositAndDelegateShuttleAccounts {
-            payer_info,
-            rent_pda_info,
-            shuttle_info,
-            shuttle_eata_info,
-            shuttle_wallet_ata_info,
-            owner_info,
-            owner_program,
-            buffer_acc,
-            delegation_record,
-            delegation_metadata,
-            system_program,
-            mint_info,
-            token_program_info,
-            global_vault_info,
-            owner_source_token_info,
-            vault_token_info,
-        },
-        queue_info,
-    ))
 }

--- a/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
+++ b/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
@@ -11,7 +11,7 @@ use dlp_api::args::{
 use dlp_api::compact::{self};
 
 use ephemeral_spl_api::state::transfer_queue::{queue_views, TransferQueue};
-use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 use solana_instruction::{AccountMeta, Instruction};
 
@@ -81,7 +81,7 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private
         owner_source_token_info,
         vault_token_info,
         queue_info,
-    ] = require_n_accounts_with_ignored!(accounts, 19);
+    ] = require_n_accounts!(accounts, 19);
 
     let args = DepositAndDelegateShuttleWithPrivateTransferArgs::try_from_bytes(instruction_data)?;
     require!(args.amount() != 0, ProgramError::InvalidInstructionData);

--- a/e-token/src/processor/deposit_and_queue_transfer.rs
+++ b/e-token/src/processor/deposit_and_queue_transfer.rs
@@ -11,7 +11,7 @@ use ephemeral_spl_api::state::transfer_queue::{
     queue_len_and_bump_for_mint_with_capacity, queue_push_from_data, QueuedTransfer, TransferQueue,
     QUEUED_TRANSFER_FLAG_CREATE_IDEMPOTENT_ATA,
 };
-use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
 use pinocchio::address::address_eq;
 use pinocchio::sysvars::clock::Clock;
 use pinocchio::sysvars::Sysvar;
@@ -52,7 +52,7 @@ pub fn process_deposit_and_queue_transfer(
         user_authority,
         token_program_info,
         reimbursement_token_info,
-    ] = require_n_accounts_with_ignored!(accounts, 9);
+    ] = require_n_accounts!(accounts, 9);
 
     let args = DepositAndQueueTransferArgs::try_from_bytes(instruction_data)?;
 

--- a/e-token/src/processor/deposit_and_queue_transfer.rs
+++ b/e-token/src/processor/deposit_and_queue_transfer.rs
@@ -1,8 +1,9 @@
 use core::{convert::TryFrom, marker::PhantomData};
 
 use crate::processor::internal::token_vault::transfer_to_vault_for_mint;
-use crate::processor::utils::{read_mint_decimals, validate_token_account};
-use crate::{assert_associated_token_address, assert_owner, assert_signer};
+use crate::processor::utils::{
+    get_associated_token_address, read_mint_decimals, validate_token_account,
+};
 #[cfg(feature = "logging")]
 use ephemeral_spl_api::state::transfer_queue::queue_peek_next_task_id_from_data;
 use ephemeral_spl_api::state::transfer_queue::{
@@ -10,6 +11,7 @@ use ephemeral_spl_api::state::transfer_queue::{
     queue_len_and_bump_for_mint_with_capacity, queue_push_from_data, QueuedTransfer, TransferQueue,
     QUEUED_TRANSFER_FLAG_CREATE_IDEMPOTENT_ATA,
 };
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
 use pinocchio::address::address_eq;
 use pinocchio::sysvars::clock::Clock;
 use pinocchio::sysvars::Sysvar;
@@ -40,16 +42,28 @@ pub fn process_deposit_and_queue_transfer(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
+    let [
+        queue_info, // force multi-line
+        vault_info,
+        mint_info,
+        user_source_token_acc,
+        vault_token_acc,
+        destination_info,
+        user_authority,
+        token_program_info,
+        reimbursement_token_info,
+    ] = require_n_accounts_with_ignored!(accounts, 9);
+
     let args = DepositAndQueueTransferArgs::try_from_bytes(instruction_data)?;
 
-    let [queue_info, vault_info, mint_info, user_source_token_acc, vault_token_acc, destination_info, user_authority, token_program_info, reimbursement_token_info, ..] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
-
-    assert_signer!(user_authority);
-    assert_owner!(queue_info, &crate::ID);
+    require!(
+        user_authority.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
+    require!(
+        queue_info.owned_by(&crate::ID),
+        ProgramError::InvalidAccountOwner
+    );
 
     let amount = args.amount();
     validate_deposit_and_queue_transfer_params(
@@ -91,9 +105,11 @@ pub fn process_deposit_and_queue_transfer(
     };
 
     let derived_queue = TransferQueue::derive_pda(mint_info.address(), &validator, bump)?;
-    if !address_eq(&derived_queue, queue_info.address()) {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &derived_queue,
+        queue_info.address(),
+        ProgramError::InvalidSeeds
+    );
 
     #[cfg(not(feature = "logging"))]
     let _ = (queue_len_before, queue_capacity);
@@ -124,11 +140,14 @@ pub fn process_deposit_and_queue_transfer(
             None,
             Some(token_program_info.address()),
         )?;
-        assert_associated_token_address!(
+        require_eq_keys!(
             destination_info.address(),
-            mint_info.address(),
-            destination_token.owner(),
-            token_program_info.address()
+            &get_associated_token_address(
+                destination_token.owner(),
+                mint_info.address(),
+                token_program_info.address()
+            ),
+            ProgramError::InvalidAccountData
         );
         *destination_token.owner()
     } else {
@@ -225,21 +244,21 @@ impl DepositAndQueueTransferArgs<'_> {
 
     #[inline]
     pub fn try_from_bytes(bytes: &[u8]) -> Result<DepositAndQueueTransferArgs<'_>, ProgramError> {
-        if bytes.len() != Self::LEN
-            && bytes.len() != Self::LEN_WITH_FLAGS
-            && bytes.len() != Self::LEN_WITH_CLIENT_REF_ID
-            && bytes.len() != Self::LEN_WITH_FLAGS_AND_CLIENT_REF_ID
-        {
-            return Err(ProgramError::InvalidInstructionData);
-        }
+        require!(
+            bytes.len() == Self::LEN
+                || bytes.len() == Self::LEN_WITH_FLAGS
+                || bytes.len() == Self::LEN_WITH_CLIENT_REF_ID
+                || bytes.len() == Self::LEN_WITH_FLAGS_AND_CLIENT_REF_ID,
+            ProgramError::InvalidInstructionData
+        );
 
-        if matches!(
-            bytes.len(),
-            Self::LEN_WITH_FLAGS | Self::LEN_WITH_FLAGS_AND_CLIENT_REF_ID
-        ) && (bytes[Self::LEN] & !QUEUED_TRANSFER_FLAG_CREATE_IDEMPOTENT_ATA) != 0
-        {
-            return Err(ProgramError::InvalidInstructionData);
-        }
+        require!(
+            !matches!(
+                bytes.len(),
+                Self::LEN_WITH_FLAGS | Self::LEN_WITH_FLAGS_AND_CLIENT_REF_ID
+            ) || (bytes[Self::LEN] & !QUEUED_TRANSFER_FLAG_CREATE_IDEMPOTENT_ATA) == 0,
+            ProgramError::InvalidInstructionData
+        );
 
         Ok(DepositAndQueueTransferArgs {
             raw: bytes.as_ptr(),
@@ -312,12 +331,14 @@ fn validate_deposit_and_queue_transfer_params(
     max_delay_ms: u64,
     split: u32,
 ) -> ProgramResult {
-    if amount == 0 || split == 0 || (split as u64) > amount {
-        return Err(ProgramError::InvalidInstructionData);
-    }
-    if max_delay_ms < min_delay_ms {
-        return Err(ProgramError::InvalidInstructionData);
-    }
+    require!(
+        amount != 0 && split != 0 && (split as u64) <= amount,
+        ProgramError::InvalidInstructionData
+    );
+    require!(
+        max_delay_ms >= min_delay_ms,
+        ProgramError::InvalidInstructionData
+    );
 
     Ok(())
 }

--- a/e-token/src/processor/deposit_spl_tokens.rs
+++ b/e-token/src/processor/deposit_spl_tokens.rs
@@ -1,13 +1,13 @@
 use core::marker::PhantomData;
 
 use ephemeral_spl_api::state::{load_initialized, load_mut_initialized};
+use ephemeral_spl_api::{require, require_n_accounts_with_ignored};
 
 use {
     ephemeral_spl_api::state::ephemeral_ata::EphemeralAta,
     pinocchio::{error::ProgramError, AccountView, ProgramResult},
 };
 
-use crate::assert_owner;
 use crate::processor::internal::token_vault::transfer_to_vault_for_mint;
 
 ///
@@ -30,16 +30,23 @@ pub fn process_deposit_spl_tokens(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
+    let [
+        ephemeral_ata_info, // force multi-line
+        vault_info,
+        mint_info,
+        user_source_token_acc,
+        vault_token_acc,
+        user_authority,
+        token_program_info,
+    ] = require_n_accounts_with_ignored!(accounts, 7);
+
     let args = DepositArgs::try_from_bytes(instruction_data)?;
 
-    let [ephemeral_ata_info, vault_info, mint_info, user_source_token_acc, vault_token_acc, user_authority, token_program_info, ..] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
-
     // Validate EphemeralAta ownership first, before reading raw data.
-    assert_owner!(ephemeral_ata_info, &crate::ID);
+    require!(
+        ephemeral_ata_info.owned_by(&crate::ID),
+        ProgramError::InvalidAccountOwner
+    );
 
     let ephemeral_ata_mint = {
         let ephemeral_ata =
@@ -85,9 +92,7 @@ pub struct DepositArgs<'a> {
 impl DepositArgs<'_> {
     #[inline]
     pub fn try_from_bytes(bytes: &[u8]) -> Result<DepositArgs<'_>, ProgramError> {
-        if bytes.len() < 8 {
-            return Err(ProgramError::InvalidInstructionData);
-        }
+        require!(bytes.len() >= 8, ProgramError::InvalidInstructionData);
         Ok(DepositArgs {
             raw: bytes.as_ptr(),
             _data: PhantomData,

--- a/e-token/src/processor/deposit_spl_tokens.rs
+++ b/e-token/src/processor/deposit_spl_tokens.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 
 use ephemeral_spl_api::state::{load_initialized, load_mut_initialized};
-use ephemeral_spl_api::{require, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_n_accounts};
 
 use {
     ephemeral_spl_api::state::ephemeral_ata::EphemeralAta,
@@ -38,7 +38,7 @@ pub fn process_deposit_spl_tokens(
         vault_token_acc,
         user_authority,
         token_program_info,
-    ] = require_n_accounts_with_ignored!(accounts, 7);
+    ] = require_n_accounts!(accounts, 7);
 
     let args = DepositArgs::try_from_bytes(instruction_data)?;
 

--- a/e-token/src/processor/ensure_transfer_queue_crank.rs
+++ b/e-token/src/processor/ensure_transfer_queue_crank.rs
@@ -9,13 +9,10 @@ use ephemeral_spl_api::state::transfer_queue::{
     queue_crank_task_id_from_data, queue_set_crank_task_id_from_data, queue_views_checked,
     TransferQueue,
 };
-use pinocchio::address::address_eq;
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
 use pinocchio::cpi::{invoke_signed_with_bounds, Signer};
 use pinocchio::instruction::{InstructionAccount, InstructionView};
-use pinocchio::Address;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
-
-use crate::{assert_owner, assert_signer};
 
 pub const CRANK_EXECUTION_INTERVAL_MILLIS: i64 = 500;
 
@@ -42,15 +39,18 @@ pub fn process_ensure_transfer_queue_crank(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    if !instruction_data.is_empty() {
-        return Err(ProgramError::InvalidInstructionData);
-    }
+    let [
+        payer_info, // force multi-line
+        queue_info,
+        magic_fee_vault_info,
+        magic_context_info,
+        magic_program_info,
+    ] = require_n_accounts!(accounts, 5);
 
-    let [payer_info, queue_info, magic_fee_vault_info, magic_context_info, magic_program_info, ..] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    require!(
+        instruction_data.is_empty(),
+        ProgramError::InvalidInstructionData
+    );
 
     // TODO (snawaz): re-review this!
     //
@@ -60,15 +60,20 @@ pub fn process_ensure_transfer_queue_crank(
     //
     // What if attackers repeatedly invoke this current ix?
 
-    assert_signer!(payer_info);
-    assert_owner!(queue_info, &crate::ID);
+    require!(
+        payer_info.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
+    require!(
+        queue_info.owned_by(&crate::ID),
+        ProgramError::InvalidAccountOwner
+    );
 
-    if !address_eq(
+    require_eq_keys!(
         magic_program_info.address(),
         &ephemeral_rollups_pinocchio::consts::MAGIC_PROGRAM_ID,
-    ) {
-        return Err(ProgramError::IncorrectProgramId);
-    }
+        ProgramError::IncorrectProgramId
+    );
 
     let (mint, bump, validator) = {
         let data = unsafe { queue_info.borrow_unchecked() };
@@ -77,14 +82,16 @@ pub fn process_ensure_transfer_queue_crank(
     };
 
     let derived_queue = TransferQueue::derive_pda(&mint, &validator, bump)?;
-    if !address_eq(&derived_queue, queue_info.address()) {
-        return Err(ProgramError::InvalidSeeds);
-    }
-    let derived_magic_fee_vault =
-        Address::from(magic_fee_vault_pda_from_validator(&validator.to_bytes().into()).to_bytes());
-    if !address_eq(&derived_magic_fee_vault, magic_fee_vault_info.address()) {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &derived_queue,
+        queue_info.address(),
+        ProgramError::InvalidSeeds
+    );
+    let derived_magic_fee_vault = magic_fee_vault_pda_from_validator(&validator.to_bytes().into());
+    require!(
+        derived_magic_fee_vault.to_bytes() == magic_fee_vault_info.address().to_bytes(),
+        ProgramError::InvalidSeeds
+    );
 
     let bump_seed = [bump];
     let queue_signer_seeds = TransferQueue::signer_seeds(&mint, &validator, &bump_seed);

--- a/e-token/src/processor/execute_ready_queued_transfer.rs
+++ b/e-token/src/processor/execute_ready_queued_transfer.rs
@@ -5,21 +5,16 @@ use {
     ephemeral_spl_api::state::{
         global_vault::GlobalVault, transfer_queue::QUEUED_TRANSFER_FLAG_CREATE_IDEMPOTENT_ATA,
     },
+    ephemeral_spl_api::{require, require_eq_keys, require_n_accounts},
     pinocchio::{error::ProgramError, AccountView, ProgramResult},
 };
 
-use crate::{
-    assert_owner, assert_signer,
-    processor::{
-        initialize_rent_pda::{RENT_PDA, RENT_PDA_BUMP, RENT_PDA_SEED},
-        internal::token_vault::validate_vault_for_mint,
-        utils::read_mint_decimals,
-    },
+use crate::processor::{
+    initialize_rent_pda::{RENT_PDA, RENT_PDA_BUMP, RENT_PDA_SEED},
+    internal::token_vault::validate_vault_for_mint,
+    utils::read_mint_decimals,
 };
-use pinocchio::{
-    address::address_eq,
-    cpi::{Seed, Signer},
-};
+use pinocchio::cpi::{Seed, Signer};
 use pinocchio_system::ID as SYSTEM_PROGRAM_ID;
 
 ///
@@ -47,42 +42,63 @@ pub fn process_execute_ready_queued_transfer(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
+    let [
+        vault_info, // force multi-line
+        mint_info,
+        vault_token_acc_info,
+        destination_owner_info,
+        destination_token_acc_info,
+        rent_pda_info,
+        token_program_info,
+        associated_token_program_info,
+        system_program_info,
+        source_program,
+        escrow_authority,
+        escrow_signer,
+    ] = require_n_accounts!(accounts, 12);
+
     let args = ExecuteQueuedTransferArgs::try_from_bytes(instruction_data)?;
-    let [vault_info, mint_info, vault_token_acc_info, destination_owner_info, destination_token_acc_info, rent_pda_info, token_program_info, associated_token_program_info, system_program_info, source_program, escrow_authority, escrow_signer] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
 
     // Note that accounts [source_program, escrow_authority, escrow_signer] are appended by DLP's
     // CallHandlerV2 instruction.
-    if !address_eq(source_program.address(), &crate::ID) {
-        return Err(ProgramError::IncorrectAuthority);
-    }
+    require_eq_keys!(
+        source_program.address(),
+        &crate::ID,
+        ProgramError::IncorrectAuthority
+    );
 
-    assert_signer!(escrow_signer);
+    require!(
+        escrow_signer.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
 
     let expected_escrow =
         ephemeral_balance_pda_from_payer(escrow_authority.address(), args.escrow_index());
-    if !address_eq(&expected_escrow, escrow_signer.address()) {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &expected_escrow,
+        escrow_signer.address(),
+        ProgramError::InvalidSeeds
+    );
 
     if args.should_create_destination_ata_idempotent() {
-        assert_owner!(rent_pda_info, &SYSTEM_PROGRAM_ID);
-        if !address_eq(&RENT_PDA, rent_pda_info.address()) {
-            return Err(ProgramError::InvalidSeeds);
-        }
-        if rent_pda_info.data_len() != 0 {
-            return Err(ProgramError::InvalidAccountData);
-        }
-        if !address_eq(
-            associated_token_program_info.address(),
-            &pinocchio_associated_token_account::ID,
-        ) || !address_eq(system_program_info.address(), &SYSTEM_PROGRAM_ID)
-        {
-            return Err(ProgramError::InvalidAccountData);
-        }
+        require!(
+            rent_pda_info.owned_by(&SYSTEM_PROGRAM_ID),
+            ProgramError::InvalidAccountOwner
+        );
+        require_eq_keys!(
+            &RENT_PDA,
+            rent_pda_info.address(),
+            ProgramError::InvalidSeeds
+        );
+        require!(
+            rent_pda_info.data_len() == 0,
+            ProgramError::InvalidAccountData
+        );
+        require!(
+            associated_token_program_info.address() == &pinocchio_associated_token_account::ID
+                && system_program_info.address() == &SYSTEM_PROGRAM_ID,
+            ProgramError::InvalidAccountData
+        );
 
         let rent_bump_seed = [RENT_PDA_BUMP];
         let rent_signer_seed = [Seed::from(RENT_PDA_SEED), Seed::from(&rent_bump_seed)];
@@ -149,9 +165,10 @@ impl ExecuteQueuedTransferArgs<'_> {
 
     #[inline]
     pub fn try_from_bytes(bytes: &[u8]) -> Result<ExecuteQueuedTransferArgs<'_>, ProgramError> {
-        if bytes.len() != Self::LEN && bytes.len() != Self::LEN_WITH_CLIENT_REF_ID {
-            return Err(ProgramError::InvalidInstructionData);
-        }
+        require!(
+            bytes.len() == Self::LEN || bytes.len() == Self::LEN_WITH_CLIENT_REF_ID,
+            ProgramError::InvalidInstructionData
+        );
 
         Ok(ExecuteQueuedTransferArgs {
             raw: bytes.as_ptr(),

--- a/e-token/src/processor/initialize_ephemeral_ata.rs
+++ b/e-token/src/processor/initialize_ephemeral_ata.rs
@@ -1,4 +1,4 @@
-use ephemeral_spl_api::require_n_accounts_with_ignored;
+use ephemeral_spl_api::require_n_accounts;
 use pinocchio::{AccountView, ProgramResult};
 
 use crate::processor::internal::ephemeral_ata::initialize_ephemeral_ata_with_sponsor;
@@ -25,7 +25,8 @@ pub fn process_initialize_ephemeral_ata(
         payer_info,
         user_info,
         mint_info,
-    ] = require_n_accounts_with_ignored!(accounts, 4);
+        _system_program,
+    ] = require_n_accounts!(accounts, 5);
 
     initialize_ephemeral_ata_with_sponsor(
         ephemeral_ata_info,

--- a/e-token/src/processor/initialize_ephemeral_ata.rs
+++ b/e-token/src/processor/initialize_ephemeral_ata.rs
@@ -1,4 +1,5 @@
-use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+use ephemeral_spl_api::require_n_accounts_with_ignored;
+use pinocchio::{AccountView, ProgramResult};
 
 use crate::processor::internal::ephemeral_ata::initialize_ephemeral_ata_with_sponsor;
 
@@ -19,9 +20,12 @@ pub fn process_initialize_ephemeral_ata(
     accounts: &[AccountView],
     _instruction_data: &[u8],
 ) -> ProgramResult {
-    let [ephemeral_ata_info, payer_info, user_info, mint_info, ..] = accounts else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    let [
+        ephemeral_ata_info, // force multi-line
+        payer_info,
+        user_info,
+        mint_info,
+    ] = require_n_accounts_with_ignored!(accounts, 4);
 
     initialize_ephemeral_ata_with_sponsor(
         ephemeral_ata_info,

--- a/e-token/src/processor/initialize_global_vault.rs
+++ b/e-token/src/processor/initialize_global_vault.rs
@@ -1,8 +1,9 @@
 use crate::processor::internal::ephemeral_ata::initialize_ephemeral_ata_with_sponsor;
 use ephemeral_spl_api::state::RawType;
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use pinocchio::cpi::Signer;
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
-use pinocchio::{address::address_eq, cpi::Signer};
 use pinocchio_system::instructions::{CreateAccount, Transfer};
 use {
     ephemeral_spl_api::state::global_vault::GlobalVault,
@@ -34,21 +35,29 @@ pub fn process_initialize_global_vault(
     accounts: &[AccountView],
     _instruction_data: &[u8],
 ) -> ProgramResult {
-    let [vault_info, payer_info, mint_info, vault_ephemeral_ata_info, vault_token_acc_info, token_program_info, associated_token_program_info, system_program_info, ..] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    let [
+        vault_info, // force multi-line
+        payer_info,
+        mint_info,
+        vault_ephemeral_ata_info,
+        vault_token_acc_info,
+        token_program_info,
+        associated_token_program_info,
+        system_program_info,
+    ] = require_n_accounts_with_ignored!(accounts, 8);
 
-    if !pinocchio_associated_token_account::check_id(associated_token_program_info.address()) {
-        return Err(ProgramError::IncorrectProgramId);
-    }
+    require!(
+        pinocchio_associated_token_account::check_id(associated_token_program_info.address()),
+        ProgramError::IncorrectProgramId
+    );
 
     let program_id = crate::ID;
     let (vault_derived_pda, vault_bump) = GlobalVault::find_pda(mint_info.address());
-    if !address_eq(&vault_derived_pda, vault_info.address()) {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &vault_derived_pda,
+        vault_info.address(),
+        ProgramError::InvalidSeeds
+    );
 
     let bump = [vault_bump];
     let seed = GlobalVault::signer_seeds(mint_info.address(), &bump);
@@ -57,6 +66,12 @@ pub fn process_initialize_global_vault(
 
     if vault_info.owned_by(&program_id) {
         let vault_data_len = vault_info.data_len();
+        require!(
+            vault_data_len == GlobalVault::LEN
+                || vault_data_len == LEGACY_GLOBAL_VAULT_LEN
+                || vault_data_len == GLOBAL_VAULT_V0_LEN,
+            ProgramError::InvalidAccountData
+        );
         if vault_data_len == GlobalVault::LEN {
             // Already on current layout.
         } else if vault_data_len == LEGACY_GLOBAL_VAULT_LEN || vault_data_len == GLOBAL_VAULT_V0_LEN
@@ -67,9 +82,11 @@ pub fn process_initialize_global_vault(
                 let legacy_data = unsafe { vault_info.borrow_unchecked() };
                 unsafe { *(legacy_data.as_ptr() as *const pinocchio::Address) }
             };
-            if !address_eq(&legacy_mint, mint_info.address()) {
-                return Err(ProgramError::InvalidAccountData);
-            }
+            require_eq_keys!(
+                &legacy_mint,
+                mint_info.address(),
+                ProgramError::InvalidAccountData
+            );
 
             let current_lamports = vault_info.lamports();
             if current_lamports < required_lamports {
@@ -82,8 +99,6 @@ pub fn process_initialize_global_vault(
             }
 
             vault_info.resize(GlobalVault::LEN)?;
-        } else {
-            return Err(ProgramError::InvalidAccountData);
         }
     } else {
         CreateAccount {

--- a/e-token/src/processor/initialize_global_vault.rs
+++ b/e-token/src/processor/initialize_global_vault.rs
@@ -1,6 +1,6 @@
 use crate::processor::internal::ephemeral_ata::initialize_ephemeral_ata_with_sponsor;
 use ephemeral_spl_api::state::RawType;
-use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
 use pinocchio::cpi::Signer;
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
@@ -44,7 +44,7 @@ pub fn process_initialize_global_vault(
         token_program_info,
         associated_token_program_info,
         system_program_info,
-    ] = require_n_accounts_with_ignored!(accounts, 8);
+    ] = require_n_accounts!(accounts, 8);
 
     require!(
         pinocchio_associated_token_account::check_id(associated_token_program_info.address()),

--- a/e-token/src/processor/initialize_rent_pda.rs
+++ b/e-token/src/processor/initialize_rent_pda.rs
@@ -5,7 +5,7 @@ use pinocchio::Address;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 use pinocchio_system::instructions::CreateAccount;
 
-use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
 
 pub const RENT_PDA_SEED: &[u8] = b"rent";
 const RENT_PDA_AND_BUMP: ([u8; 32], u8) =
@@ -33,7 +33,7 @@ pub fn process_initialize_rent_pda(
         payer_info, // force multi-line
         rent_pda_info,
         _system_program_info,
-    ] = require_n_accounts_with_ignored!(accounts, 3);
+    ] = require_n_accounts!(accounts, 3);
 
     require!(
         instruction_data.is_empty(),

--- a/e-token/src/processor/initialize_rent_pda.rs
+++ b/e-token/src/processor/initialize_rent_pda.rs
@@ -1,10 +1,11 @@
-use pinocchio::address::address_eq;
 use pinocchio::cpi::{Seed, Signer};
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
 use pinocchio::Address;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 use pinocchio_system::instructions::CreateAccount;
+
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
 
 pub const RENT_PDA_SEED: &[u8] = b"rent";
 const RENT_PDA_AND_BUMP: ([u8; 32], u8) =
@@ -28,29 +29,36 @@ pub fn process_initialize_rent_pda(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    if !instruction_data.is_empty() {
-        return Err(ProgramError::InvalidInstructionData);
-    }
+    let [
+        payer_info, // force multi-line
+        rent_pda_info,
+        _system_program_info,
+    ] = require_n_accounts_with_ignored!(accounts, 3);
 
-    let [payer_info, rent_pda_info, _system_program_info, ..] = accounts else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    require!(
+        instruction_data.is_empty(),
+        ProgramError::InvalidInstructionData
+    );
 
     let required_lamports = Rent::get()?.try_minimum_balance(0)?;
-    if !address_eq(rent_pda_info.address(), &RENT_PDA) {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &RENT_PDA,
+        rent_pda_info.address(),
+        ProgramError::InvalidSeeds
+    );
 
     if is_valid_initialized_rent_pda(rent_pda_info, required_lamports) {
         return Ok(());
     }
 
-    if rent_pda_info.lamports() > 0 {
-        return Err(ProgramError::InvalidAccountData);
-    }
-    if !payer_info.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
+    require!(
+        rent_pda_info.lamports() == 0,
+        ProgramError::InvalidAccountData
+    );
+    require!(
+        payer_info.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
 
     let bump_seed = [RENT_PDA_BUMP];
     let signer_seeds = [Seed::from(RENT_PDA_SEED), Seed::from(&bump_seed)];

--- a/e-token/src/processor/initialize_shuttle_ephemeral_ata.rs
+++ b/e-token/src/processor/initialize_shuttle_ephemeral_ata.rs
@@ -1,5 +1,5 @@
 use core::marker::PhantomData;
-use ephemeral_spl_api::{require, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_n_accounts};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
 use crate::processor::internal::ephemeral_ata::initialize_shuttle_ephemeral_ata_with_sponsor;
@@ -36,7 +36,7 @@ pub fn process_initialize_shuttle_ephemeral_ata(
         token_program_info,
         _associated_token_program_info,
         system_program_info,
-    ] = require_n_accounts_with_ignored!(accounts, 9);
+    ] = require_n_accounts!(accounts, 9);
 
     let args = InitializeShuttleEphemeralAta::try_from_bytes(instruction_data)?;
 

--- a/e-token/src/processor/initialize_shuttle_ephemeral_ata.rs
+++ b/e-token/src/processor/initialize_shuttle_ephemeral_ata.rs
@@ -1,4 +1,5 @@
 use core::marker::PhantomData;
+use ephemeral_spl_api::{require, require_n_accounts_with_ignored};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
 use crate::processor::internal::ephemeral_ata::initialize_shuttle_ephemeral_ata_with_sponsor;
@@ -25,17 +26,24 @@ pub fn process_initialize_shuttle_ephemeral_ata(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
+    let [
+        payer_info, // force multi-line
+        shuttle_info,
+        shuttle_eata_info,
+        shuttle_wallet_ata_info,
+        owner_info,
+        mint_info,
+        token_program_info,
+        _associated_token_program_info,
+        system_program_info,
+    ] = require_n_accounts_with_ignored!(accounts, 9);
+
     let args = InitializeShuttleEphemeralAta::try_from_bytes(instruction_data)?;
 
-    let [payer_info, shuttle_info, shuttle_eata_info, shuttle_wallet_ata_info, owner_info, mint_info, token_program_info, _associated_token_program_info, system_program_info, ..] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
-
-    if !payer_info.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
+    require!(
+        payer_info.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
 
     initialize_shuttle_ephemeral_ata_with_sponsor(
         payer_info,
@@ -71,9 +79,7 @@ pub struct InitializeShuttleEphemeralAta<'a> {
 impl InitializeShuttleEphemeralAta<'_> {
     #[inline]
     pub fn try_from_bytes(bytes: &[u8]) -> Result<InitializeShuttleEphemeralAta<'_>, ProgramError> {
-        if bytes.len() < 4 {
-            return Err(ProgramError::InvalidInstructionData);
-        }
+        require!(bytes.len() >= 4, ProgramError::InvalidInstructionData);
 
         Ok(InitializeShuttleEphemeralAta {
             raw: bytes.as_ptr(),

--- a/e-token/src/processor/initialize_transfer_queue.rs
+++ b/e-token/src/processor/initialize_transfer_queue.rs
@@ -4,10 +4,11 @@ use ephemeral_rollups_pinocchio::acl::{
     pda::permission_pda_from_permissioned_account, types::MembersArgs,
 };
 use ephemeral_spl_api::consts::TRANSFER_QUEUE_INITIAL_BUFFER_LAMPORTS;
+use ephemeral_spl_api::require_n_accounts;
 use ephemeral_spl_api::state::transfer_queue::{
     capacity_from_data_len, header_len, init_queue, item_len, queue_views_checked, TransferQueue,
 };
-use pinocchio::address::address_eq;
+use ephemeral_spl_api::{require, require_eq_keys};
 use pinocchio::cpi::Signer;
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
@@ -39,13 +40,17 @@ pub fn process_initialize_transfer_queue(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let args = InitializeTransferQueueArgs::try_from_bytes(instruction_data)?;
+    let [
+        payer_info, // force multi-line
+        queue_info,
+        queue_permission_info,
+        mint_info,
+        validator_info,
+        system_program_info,
+        permission_program_info,
+    ] = require_n_accounts!(accounts, 7);
 
-    let [payer_info, queue_info, queue_permission_info, mint_info, validator_info, system_program_info, permission_program_info, ..] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    let args = InitializeTransferQueueArgs::try_from_bytes(instruction_data)?;
 
     let (requested_items, queue_size) = if let Some(items) = args.requested_items() {
         (items, header_len() + item_len() * items as usize)
@@ -55,29 +60,36 @@ pub fn process_initialize_transfer_queue(
             DEFAULT_TRANSFER_QUEUE_SIZE_BYTES as usize,
         )
     };
-    if requested_items == 0 {
-        return Err(ProgramError::InvalidInstructionData);
-    };
+    require!(requested_items != 0, ProgramError::InvalidInstructionData);
 
     let program_id = crate::ID;
     let (derived_queue, bump) =
         TransferQueue::find_pda(mint_info.address(), validator_info.address());
-    if !address_eq(&derived_queue, queue_info.address()) {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &derived_queue,
+        queue_info.address(),
+        ProgramError::InvalidSeeds
+    );
 
     // permission_program_info is needed by CreatePermissionCpiBuilder
-    if !address_eq(permission_program_info.address(), &PERMISSION_PROGRAM_ID) {
-        return Err(ProgramError::IncorrectProgramId);
-    }
+    require_eq_keys!(
+        &PERMISSION_PROGRAM_ID,
+        permission_program_info.address(),
+        ProgramError::IncorrectProgramId
+    );
+
     let expected_permission = permission_pda_from_permissioned_account(queue_info.address());
-    if !address_eq(&expected_permission, queue_permission_info.address()) {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &expected_permission,
+        queue_permission_info.address(),
+        ProgramError::InvalidSeeds
+    );
+
     let queue_permission_exists = queue_permission_info.lamports() > 0;
-    if queue_permission_exists && !queue_permission_info.owned_by(&PERMISSION_PROGRAM_ID) {
-        return Err(ProgramError::IncorrectProgramId);
-    }
+    require!(
+        !queue_permission_exists || queue_permission_info.owned_by(&PERMISSION_PROGRAM_ID),
+        ProgramError::IncorrectProgramId
+    );
 
     let rent = Rent::get()?;
     let target_lamports = rent
@@ -86,12 +98,11 @@ pub fn process_initialize_transfer_queue(
         .ok_or(ProgramError::ArithmeticOverflow)?;
 
     if !queue_info.owned_by(&program_id) {
-        if queue_info.lamports() > 0 {
-            return Err(ProgramError::IllegalOwner);
-        }
-        if !payer_info.is_signer() {
-            return Err(ProgramError::MissingRequiredSignature);
-        }
+        require!(queue_info.lamports() == 0, ProgramError::IllegalOwner);
+        require!(
+            payer_info.is_signer(),
+            ProgramError::MissingRequiredSignature
+        );
 
         let bump_seed = [bump];
         let signer_seeds =
@@ -109,9 +120,10 @@ pub fn process_initialize_transfer_queue(
     }
 
     if !queue_permission_exists {
-        if !payer_info.is_signer() {
-            return Err(ProgramError::MissingRequiredSignature);
-        }
+        require!(
+            payer_info.is_signer(),
+            ProgramError::MissingRequiredSignature
+        );
         CreatePermissionCpiBuilder::new(
             queue_info,
             queue_permission_info,
@@ -139,20 +151,21 @@ pub fn process_initialize_transfer_queue(
     }
 
     let data_len = queue_info.data_len();
-    if capacity_from_data_len(data_len) == 0 {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require!(
+        capacity_from_data_len(data_len) != 0,
+        ProgramError::InvalidAccountData
+    );
 
     let data = unsafe { queue_info.borrow_unchecked_mut() };
     init_queue(data, bump, *mint_info.address(), *validator_info.address())?;
 
     let (header, _) = queue_views_checked(data)?;
-    if header.bump != bump
-        || !address_eq(&header.mint, mint_info.address())
-        || !address_eq(&header.validator, validator_info.address())
-    {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require!(
+        header.bump == bump
+            && header.mint == *mint_info.address()
+            && header.validator == *validator_info.address(),
+        ProgramError::InvalidAccountData
+    );
 
     Ok(())
 }
@@ -175,9 +188,10 @@ pub struct InitializeTransferQueueArgs<'a> {
 impl InitializeTransferQueueArgs<'_> {
     #[inline]
     pub fn try_from_bytes(bytes: &[u8]) -> Result<InitializeTransferQueueArgs<'_>, ProgramError> {
-        if !bytes.is_empty() && bytes.len() != 4 {
-            return Err(ProgramError::InvalidInstructionData);
-        }
+        require!(
+            bytes.is_empty() || bytes.len() == 4,
+            ProgramError::InvalidInstructionData
+        );
 
         Ok(InitializeTransferQueueArgs {
             raw: bytes.as_ptr(),

--- a/e-token/src/processor/internal/ephemeral_ata.rs
+++ b/e-token/src/processor/internal/ephemeral_ata.rs
@@ -1,4 +1,5 @@
 use ephemeral_spl_api::state::{load_initialized, load_mut, RawType};
+use ephemeral_spl_api::{require, require_eq_keys};
 use pinocchio::cpi::Signer;
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
@@ -23,9 +24,11 @@ pub(crate) fn initialize_ephemeral_ata_with_sponsor(
 ) -> ProgramResult {
     // Validate PDA derivation up front, even for idempotent re-initialization.
     let (derived_pda, eata_bump) = EphemeralAta::find_pda(user_info.address(), mint_info.address());
-    if derived_pda != *ephemeral_ata_info.address() {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &derived_pda,
+        ephemeral_ata_info.address(),
+        ProgramError::InvalidSeeds
+    );
 
     // Make init idempotent even if the account is currently delegated (owner changed).
     if let Ok(ephemeral_ata) =
@@ -75,9 +78,10 @@ pub(crate) fn initialize_ephemeral_ata_with_sponsor(
     }
 
     // Any other pre-existing account at this PDA is invalid for initialization.
-    if ephemeral_ata_info.lamports() > 0 {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require!(
+        ephemeral_ata_info.lamports() == 0,
+        ProgramError::InvalidAccountData
+    );
 
     let bump = [eata_bump];
     let seed = EphemeralAta::signer_seeds(user_info.address(), mint_info.address(), &bump);
@@ -130,9 +134,11 @@ pub(crate) fn initialize_shuttle_ephemeral_ata_with_sponsor(
     let shuttle_id_seed = shuttle_id.to_le_bytes();
     let (derived_shuttle_pda, shuttle_bump) =
         ShuttleMetadata::find_pda(owner_info.address(), mint_info.address(), shuttle_id);
-    if derived_shuttle_pda != *shuttle_info.address() {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &derived_shuttle_pda,
+        shuttle_info.address(),
+        ProgramError::InvalidSeeds
+    );
 
     let shuttle_is_owned_by_program = unsafe { shuttle_info.owner().eq(&crate::ID) };
 
@@ -198,12 +204,12 @@ pub(crate) fn initialize_shuttle_ephemeral_ata_with_sponsor(
 
         let shuttle =
             load_initialized::<ShuttleMetadata>(unsafe { shuttle_info.borrow_unchecked() })?;
-        if shuttle.id != shuttle_id
-            || shuttle.owner != *owner_info.address()
-            || shuttle.payer != *refund_recipient_info.address()
-        {
-            return Err(ProgramError::InvalidAccountData);
-        }
+        require!(
+            shuttle.id == shuttle_id
+                && shuttle.owner == *owner_info.address()
+                && shuttle.payer == *refund_recipient_info.address(),
+            ProgramError::InvalidAccountData
+        );
     }
 
     initialize_ephemeral_ata_with_sponsor(

--- a/e-token/src/processor/internal/lamports_pda.rs
+++ b/e-token/src/processor/internal/lamports_pda.rs
@@ -1,3 +1,4 @@
+use ephemeral_spl_api::require;
 use pinocchio::{error::ProgramError, Address};
 
 pub(crate) const LAMPORTS_PDA_SEED: &[u8] = b"lamports";
@@ -22,9 +23,10 @@ pub(crate) fn derive_lamports_pda(
 pub(crate) fn parse_amount_and_salt(
     instruction_data: &[u8],
 ) -> Result<(u64, [u8; 32]), ProgramError> {
-    if instruction_data.len() != 40 {
-        return Err(ProgramError::InvalidInstructionData);
-    }
+    require!(
+        instruction_data.len() == 40,
+        ProgramError::InvalidInstructionData
+    );
 
     let mut amount = [0u8; 8];
     amount.copy_from_slice(&instruction_data[..8]);

--- a/e-token/src/processor/internal/shuttle_delegation.rs
+++ b/e-token/src/processor/internal/shuttle_delegation.rs
@@ -16,7 +16,7 @@ use ephemeral_spl_api::state::{
     ephemeral_ata::EphemeralAta, load_initialized, load_mut_initialized,
     shuttle_ephemeral_ata::ShuttleMetadata,
 };
-use ephemeral_spl_api::{require, require_eq_keys};
+use ephemeral_spl_api::{require, require_eq_keys, require_owned_by};
 use pinocchio::{
     cpi::{invoke_signed_with_bounds, Seed, Signer},
     error::ProgramError,
@@ -221,10 +221,7 @@ pub(crate) fn prepare_sponsored_shuttle_delegation(
         ProgramError::MissingRequiredSignature
     );
 
-    require!(
-        rent_pda_info.owned_by(&pinocchio_system::ID),
-        ProgramError::InvalidAccountOwner
-    );
+    require_owned_by!(rent_pda_info, &pinocchio_system::ID);
 
     #[cfg(feature = "logging")]
     {
@@ -298,14 +295,8 @@ pub(crate) fn prepare_sponsored_shuttle_delegation(
         });
     }
 
-    require!(
-        shuttle_info.owned_by(&crate::ID),
-        ProgramError::InvalidAccountOwner
-    );
-    require!(
-        shuttle_eata_info.owned_by(&crate::ID),
-        ProgramError::InvalidAccountOwner
-    );
+    require_owned_by!(shuttle_info, &crate::ID);
+    require_owned_by!(shuttle_eata_info, &crate::ID);
 
     let shuttle = load_initialized::<ShuttleMetadata>(unsafe { shuttle_info.borrow_unchecked() })?;
     require!(

--- a/e-token/src/processor/internal/shuttle_delegation.rs
+++ b/e-token/src/processor/internal/shuttle_delegation.rs
@@ -16,6 +16,7 @@ use ephemeral_spl_api::state::{
     ephemeral_ata::EphemeralAta, load_initialized, load_mut_initialized,
     shuttle_ephemeral_ata::ShuttleMetadata,
 };
+use ephemeral_spl_api::{require, require_eq_keys};
 use pinocchio::{
     cpi::{invoke_signed_with_bounds, Seed, Signer},
     error::ProgramError,
@@ -26,13 +27,10 @@ use pinocchio_system::instructions::{Assign, CreateAccount, Transfer};
 use solana_instruction::{AccountMeta, Instruction};
 use solana_pubkey::Pubkey;
 
-use crate::{
-    assert_owner,
-    processor::{
-        initialize_rent_pda::{RENT_PDA, RENT_PDA_BUMP},
-        internal::ephemeral_ata::initialize_shuttle_ephemeral_ata_with_sponsor,
-        internal::token_vault::transfer_to_vault_for_mint,
-    },
+use crate::processor::{
+    initialize_rent_pda::{RENT_PDA, RENT_PDA_BUMP},
+    internal::ephemeral_ata::initialize_shuttle_ephemeral_ata_with_sponsor,
+    internal::token_vault::transfer_to_vault_for_mint,
 };
 
 pub(crate) struct DepositAndDelegateShuttleAccounts<'a> {
@@ -87,9 +85,10 @@ pub struct DepositAndDelegateShuttleArgs<'a> {
 impl DepositAndDelegateShuttleArgs<'_> {
     #[inline]
     pub fn try_from_bytes(bytes: &[u8]) -> Result<DepositAndDelegateShuttleArgs<'_>, ProgramError> {
-        if bytes.len() != 12 && bytes.len() != 44 {
-            return Err(ProgramError::InvalidInstructionData);
-        }
+        require!(
+            bytes.len() == 12 || bytes.len() == 44,
+            ProgramError::InvalidInstructionData
+        );
 
         Ok(DepositAndDelegateShuttleArgs {
             raw: bytes.as_ptr(),
@@ -217,11 +216,15 @@ pub(crate) fn prepare_sponsored_shuttle_delegation(
     shuttle_id: u32,
     extra_setup_lamports: u64,
 ) -> Result<PreparedShuttleDelegation, ProgramError> {
-    if !payer_info.is_signer() || !owner_info.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
+    require!(
+        payer_info.is_signer() && owner_info.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
 
-    assert_owner!(rent_pda_info, &pinocchio_system::ID);
+    require!(
+        rent_pda_info.owned_by(&pinocchio_system::ID),
+        ProgramError::InvalidAccountOwner
+    );
 
     #[cfg(feature = "logging")]
     {
@@ -243,12 +246,15 @@ pub(crate) fn prepare_sponsored_shuttle_delegation(
         );
     }
 
-    if &RENT_PDA != rent_pda_info.address() {
-        return Err(ProgramError::InvalidSeeds);
-    }
-    if rent_pda_info.data_len() != 0 {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require_eq_keys!(
+        &RENT_PDA,
+        rent_pda_info.address(),
+        ProgramError::InvalidSeeds
+    );
+    require!(
+        rent_pda_info.data_len() == 0,
+        ProgramError::InvalidAccountData
+    );
 
     let setup_lamports = ephemeral_spl_api::consts::SPONSORED_SHUTTLE_DELEGATION_SETUP_LAMPORTS
         .checked_add(extra_setup_lamports)
@@ -292,26 +298,33 @@ pub(crate) fn prepare_sponsored_shuttle_delegation(
         });
     }
 
-    assert_owner!(shuttle_info, &crate::ID);
-    assert_owner!(shuttle_eata_info, &crate::ID);
+    require!(
+        shuttle_info.owned_by(&crate::ID),
+        ProgramError::InvalidAccountOwner
+    );
+    require!(
+        shuttle_eata_info.owned_by(&crate::ID),
+        ProgramError::InvalidAccountOwner
+    );
 
     let shuttle = load_initialized::<ShuttleMetadata>(unsafe { shuttle_info.borrow_unchecked() })?;
-    if shuttle.owner != *owner_info.address() || shuttle.payer != *rent_pda_info.address() {
-        return Err(ProgramError::IncorrectAuthority);
-    }
+    require!(
+        shuttle.owner == *owner_info.address() && shuttle.payer == *rent_pda_info.address(),
+        ProgramError::IncorrectAuthority
+    );
 
     let (mint, bump) = {
         let shuttle_eata =
             load_initialized::<EphemeralAta>(unsafe { shuttle_eata_info.borrow_unchecked() })?;
-        if shuttle_eata.owner != *shuttle_info.address() {
-            return Err(ProgramError::InvalidAccountData);
-        }
+        require_eq_keys!(
+            &shuttle_eata.owner,
+            shuttle_info.address(),
+            ProgramError::InvalidAccountData
+        );
         (shuttle_eata.mint, shuttle_eata.bump)
     };
 
-    if mint != *mint_info.address() {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require_eq_keys!(&mint, mint_info.address(), ProgramError::InvalidAccountData);
 
     let derived_shuttle_eata = EphemeralAta::derive_pda(shuttle_info.address(), &mint, bump)?;
     if derived_shuttle_eata != *shuttle_eata_info.address() {
@@ -325,8 +338,12 @@ pub(crate) fn prepare_sponsored_shuttle_delegation(
                 actual.as_str(),
             );
         }
-        return Err(ProgramError::InvalidSeeds);
     }
+    require_eq_keys!(
+        &derived_shuttle_eata,
+        shuttle_eata_info.address(),
+        ProgramError::InvalidSeeds
+    );
 
     Ok(PreparedShuttleDelegation {
         mint,
@@ -566,17 +583,19 @@ fn cpi_delegate_with_actions_from_sponsor(
     action_signer_accounts: &[&AccountView],
     signers: &[Signer<'_, '_>],
 ) -> ProgramResult {
-    if action_signer_accounts.len() != actions.signers.len() {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    }
+    require!(
+        action_signer_accounts.len() == actions.signers.len(),
+        ProgramError::NotEnoughAccountKeys
+    );
     const MAX_DELEGATE_WITH_ACTIONS_ACCOUNTS: usize = 7 + MAX_POST_DELEGATION_SIGNERS;
     const UNINIT_ACCOUNT: MaybeUninit<InstructionAccount> =
         MaybeUninit::<InstructionAccount>::uninit();
     let mut account_metas = [UNINIT_ACCOUNT; MAX_DELEGATE_WITH_ACTIONS_ACCOUNTS];
     let num_accounts = 7 + action_signer_accounts.len();
-    if num_accounts > MAX_DELEGATE_WITH_ACTIONS_ACCOUNTS {
-        return Err(ProgramError::InvalidArgument);
-    }
+    require!(
+        num_accounts <= MAX_DELEGATE_WITH_ACTIONS_ACCOUNTS,
+        ProgramError::InvalidArgument
+    );
 
     unsafe {
         account_metas

--- a/e-token/src/processor/internal/token_vault.rs
+++ b/e-token/src/processor/internal/token_vault.rs
@@ -1,5 +1,7 @@
-use crate::{assert_owner, assert_signer, processor::utils::read_mint_decimals};
-use ephemeral_spl_api::{error::EphemeralSplError, state::load_initialized};
+use crate::processor::utils::read_mint_decimals;
+use ephemeral_spl_api::{
+    error::EphemeralSplError, require, require_eq_keys, state::load_initialized,
+};
 use pinocchio::cpi::Signer;
 
 use {
@@ -21,15 +23,18 @@ pub(crate) fn transfer_to_vault_for_mint(
     expected_mint: &Address,
     amount: u64,
 ) -> ProgramResult {
-    assert_owner!(vault_info, &crate::ID);
+    require!(
+        vault_info.owned_by(&crate::ID),
+        ProgramError::InvalidAccountOwner
+    );
 
     let vault = load_initialized::<GlobalVault>(unsafe { vault_info.borrow_unchecked() })?;
-    if vault.mint != *mint_info.address()
-        || vault.token_account != *vault_token_acc.address()
-        || vault.mint != *expected_mint
-    {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require!(
+        vault.mint == *mint_info.address()
+            && vault.token_account == *vault_token_acc.address()
+            && vault.mint == *expected_mint,
+        ProgramError::InvalidAccountData
+    );
 
     let decimals = read_mint_decimals(mint_info, token_program_info)?;
 
@@ -59,28 +64,38 @@ pub(crate) fn withdraw_ephemeral_ata_tokens(
     amount: u64,
 ) -> ProgramResult {
     if require_owner_signature {
-        assert_signer!(owner);
+        require!(owner.is_signer(), ProgramError::MissingRequiredSignature);
     }
 
     // Validate EphemeralAta account (writable)
-    assert_owner!(ephemeral_ata_info, &crate::ID);
+    require!(
+        ephemeral_ata_info.owned_by(&crate::ID),
+        ProgramError::InvalidAccountOwner
+    );
     let mut ephemeral_ata =
         load_ephemeral_ata_compat_mut(unsafe { ephemeral_ata_info.borrow_unchecked_mut() })?;
 
     // Validate vault ownership before reading raw data.
-    assert_owner!(vault_info, &crate::ID);
+    require!(
+        vault_info.owned_by(&crate::ID),
+        ProgramError::InvalidAccountOwner
+    );
 
     // Validate Vault data account
     let vault = load_initialized::<GlobalVault>(unsafe { vault_info.borrow_unchecked() })?;
 
-    // Check eata consistency
-    if ephemeral_ata.mint() != mint_info.address()
-        || vault.mint != *mint_info.address()
-        || ephemeral_ata.owner() != owner.address()
-        || vault.token_account != *vault_source_token_acc.address()
-    {
-        return Err(EphemeralSplError::EphemeralAtaMismatch.into());
-    }
+    require!(
+        ephemeral_ata.owner() == owner.address(),
+        EphemeralSplError::EphemeralAtaMismatch
+    );
+    require!(
+        ephemeral_ata.mint() == mint_info.address() && vault.mint == *mint_info.address(),
+        EphemeralSplError::MintMismatch
+    );
+    require!(
+        vault.token_account == *vault_source_token_acc.address(),
+        EphemeralSplError::VaultTokenAccountMismatch
+    );
 
     // Parse the base mint layout shared by both legacy SPL Token and Token-2022.
     let decimals = read_mint_decimals(mint_info, token_program_info)?;
@@ -117,17 +132,23 @@ pub(crate) fn validate_vault_for_mint(
     mint_info: &AccountView,
     vault_token_acc_info: &AccountView,
 ) -> Result<u8, ProgramError> {
-    assert_owner!(vault_info, &crate::ID);
+    require!(
+        vault_info.owned_by(&crate::ID),
+        ProgramError::InvalidAccountOwner
+    );
 
     let vault = load_initialized::<GlobalVault>(unsafe { vault_info.borrow_unchecked() })?;
     let derived_vault = GlobalVault::derive_pda(mint_info.address(), vault.bump)?;
-    if derived_vault != *vault_info.address() {
-        return Err(ProgramError::InvalidSeeds);
-    }
-    if vault.mint != *mint_info.address() || vault.token_account != *vault_token_acc_info.address()
-    {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require_eq_keys!(
+        &derived_vault,
+        vault_info.address(),
+        ProgramError::InvalidSeeds
+    );
+    require!(
+        vault.mint == *mint_info.address()
+            && vault.token_account == *vault_token_acc_info.address(),
+        ProgramError::InvalidAccountData
+    );
 
     Ok(vault.bump)
 }

--- a/e-token/src/processor/internal/transfer_queue_refill.rs
+++ b/e-token/src/processor/internal/transfer_queue_refill.rs
@@ -3,10 +3,11 @@ use ephemeral_spl_api::state::{
     transfer_queue::{queue_views_checked, QUEUE_SEED},
     transfer_queue_refill::derive_transfer_queue_refill_state_address,
 };
+use ephemeral_spl_api::{require, require_eq_keys};
 use pinocchio::sysvars::{rent::Rent, Sysvar};
 use pinocchio::{error::ProgramError, AccountView, Address};
 
-use crate::{assert_owner, processor::initialize_rent_pda::RENT_PDA};
+use crate::processor::initialize_rent_pda::RENT_PDA;
 
 pub(crate) const MARK_TRANSFER_QUEUE_REFILL_PENDING_ESCROW_INDEX: u8 = 1;
 // This path may need to create the refill-state PDA on first use, so it needs
@@ -28,9 +29,10 @@ pub(crate) fn queue_refill_state_address(queue: &Address) -> Address {
 
 pub(crate) fn validate_queue_account(queue_info: &AccountView) -> Result<(), ProgramError> {
     let delegation_program = ephemeral_spl_api::program::DELEGATION_PROGRAM_ID;
-    if !queue_info.owned_by(&crate::ID) && !queue_info.owned_by(&delegation_program) {
-        return Err(ProgramError::IllegalOwner);
-    }
+    require!(
+        queue_info.owned_by(&crate::ID) || queue_info.owned_by(&delegation_program),
+        ProgramError::IllegalOwner
+    );
 
     let queue_data = unsafe { queue_info.borrow_unchecked() };
     let (header, _) = queue_views_checked(queue_data)?;
@@ -45,21 +47,29 @@ pub(crate) fn validate_queue_account(queue_info: &AccountView) -> Result<(), Pro
         &crate::ID,
     )
     .map_err(|_| ProgramError::InvalidAccountData)?;
-    if derived_queue != *queue_info.address() {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &derived_queue,
+        queue_info.address(),
+        ProgramError::InvalidSeeds
+    );
 
     Ok(())
 }
 
 pub(crate) fn validate_rent_pda(rent_pda_info: &AccountView) -> Result<(), ProgramError> {
-    assert_owner!(rent_pda_info, &pinocchio_system::ID);
-    if RENT_PDA != *rent_pda_info.address() {
-        return Err(ProgramError::InvalidSeeds);
-    }
-    if rent_pda_info.data_len() != 0 {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require!(
+        rent_pda_info.owned_by(&pinocchio_system::ID),
+        ProgramError::InvalidAccountOwner
+    );
+    require_eq_keys!(
+        &RENT_PDA,
+        rent_pda_info.address(),
+        ProgramError::InvalidSeeds
+    );
+    require!(
+        rent_pda_info.data_len() == 0,
+        ProgramError::InvalidAccountData
+    );
 
     Ok(())
 }
@@ -69,9 +79,11 @@ pub(crate) fn validate_queue_refill_state_address(
     queue: &Address,
 ) -> Result<(Address, u8), ProgramError> {
     let (expected_refill_state, bump) = derive_transfer_queue_refill_state_address(queue);
-    if expected_refill_state != *refill_state_info.address() {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &expected_refill_state,
+        refill_state_info.address(),
+        ProgramError::InvalidSeeds
+    );
 
     Ok((expected_refill_state, bump))
 }

--- a/e-token/src/processor/mark_transfer_queue_refill_pending.rs
+++ b/e-token/src/processor/mark_transfer_queue_refill_pending.rs
@@ -4,21 +4,16 @@ use ephemeral_rollups_pinocchio::pda::ephemeral_balance_pda_from_payer;
 use ephemeral_spl_api::state::transfer_queue_refill::{
     TransferQueueRefillState, QUEUE_REFILL_STATE_SEED,
 };
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
+use pinocchio::cpi::{Seed, Signer};
 use pinocchio::sysvars::{rent::Rent, Sysvar};
-use pinocchio::{
-    address::address_eq,
-    cpi::{Seed, Signer},
-};
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
 use pinocchio_system::instructions::{Allocate, Assign, CreateAccount, Transfer};
 
-use crate::{
-    assert_owner, assert_signer,
-    processor::{
-        initialize_rent_pda::{RENT_PDA_BUMP, RENT_PDA_SEED},
-        internal::transfer_queue_refill::{
-            validate_queue_account, validate_queue_refill_state_address, validate_rent_pda,
-        },
+use crate::processor::{
+    initialize_rent_pda::{RENT_PDA_BUMP, RENT_PDA_SEED},
+    internal::transfer_queue_refill::{
+        validate_queue_account, validate_queue_refill_state_address, validate_rent_pda,
     },
 };
 
@@ -41,26 +36,39 @@ pub fn process_mark_transfer_queue_refill_pending(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let escrow_index = parse_escrow_index(instruction_data)?;
-    let [rent_pda_info, refill_state_info, system_program_info, source_program, escrow_authority, escrow_signer] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    let [
+        rent_pda_info, // force multi-line
+        refill_state_info,
+        system_program_info,
+        source_program,
+        escrow_authority,
+        escrow_signer,
+    ] = require_n_accounts!(accounts, 6);
 
-    if system_program_info.address() != &pinocchio_system::ID {
-        return Err(ProgramError::IncorrectProgramId);
-    }
-    if !address_eq(source_program.address(), &crate::ID) {
-        return Err(ProgramError::IncorrectAuthority);
-    }
-    assert_signer!(escrow_signer);
+    let escrow_index = parse_escrow_index(instruction_data)?;
+
+    require_eq_keys!(
+        system_program_info.address(),
+        &pinocchio_system::ID,
+        ProgramError::IncorrectProgramId
+    );
+    require_eq_keys!(
+        source_program.address(),
+        &crate::ID,
+        ProgramError::IncorrectAuthority
+    );
+    require!(
+        escrow_signer.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
 
     let expected_escrow =
         ephemeral_balance_pda_from_payer(escrow_authority.address(), escrow_index);
-    if expected_escrow != *escrow_signer.address() {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &expected_escrow,
+        escrow_signer.address(),
+        ProgramError::InvalidSeeds
+    );
 
     validate_queue_account(escrow_authority)?;
     let (_, refill_state_bump) =
@@ -75,9 +83,10 @@ pub fn process_mark_transfer_queue_refill_pending(
 
 #[inline(always)]
 fn parse_escrow_index(instruction_data: &[u8]) -> Result<u8, ProgramError> {
-    if instruction_data.len() != 1 {
-        return Err(ProgramError::InvalidInstructionData);
-    }
+    require!(
+        instruction_data.len() == 1,
+        ProgramError::InvalidInstructionData
+    );
 
     Ok(instruction_data[0])
 }
@@ -138,6 +147,9 @@ fn ensure_queue_refill_state_exists(
         .invoke_signed(&[refill_state_signer])?;
     }
 
-    assert_owner!(refill_state_info, &crate::ID);
+    require!(
+        refill_state_info.owned_by(&crate::ID),
+        ProgramError::InvalidAccountOwner
+    );
     Ok(())
 }

--- a/e-token/src/processor/merge_shuttle_into_ephemeral_ata.rs
+++ b/e-token/src/processor/merge_shuttle_into_ephemeral_ata.rs
@@ -1,6 +1,6 @@
 use ephemeral_spl_api::state::load_initialized;
 use ephemeral_spl_api::state::shuttle_ephemeral_ata::ShuttleMetadata;
-use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
 use pinocchio::cpi::Signer;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
@@ -32,7 +32,7 @@ pub fn process_merge_shuttle_into_ephemeral_ata(
         shuttle_wallet_ata_info,
         mint_info,
         token_program_info,
-    ] = require_n_accounts_with_ignored!(accounts, 6);
+    ] = require_n_accounts!(accounts, 6);
 
     require!(
         owner_info.is_signer(),

--- a/e-token/src/processor/merge_shuttle_into_ephemeral_ata.rs
+++ b/e-token/src/processor/merge_shuttle_into_ephemeral_ata.rs
@@ -1,10 +1,9 @@
 use ephemeral_spl_api::state::load_initialized;
 use ephemeral_spl_api::state::shuttle_ephemeral_ata::ShuttleMetadata;
-use pinocchio::address::address_eq;
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
 use pinocchio::cpi::Signer;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
-use crate::assert_owner;
 use crate::processor::utils::{read_mint_decimals, validate_token_account};
 
 ///
@@ -26,26 +25,41 @@ pub fn process_merge_shuttle_into_ephemeral_ata(
     accounts: &[AccountView],
     _instruction_data: &[u8],
 ) -> ProgramResult {
-    let [owner_info, destination_token_info, shuttle_info, shuttle_wallet_ata_info, mint_info, token_program_info, ..] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    let [
+        owner_info, // force multi-line
+        destination_token_info,
+        shuttle_info,
+        shuttle_wallet_ata_info,
+        mint_info,
+        token_program_info,
+    ] = require_n_accounts_with_ignored!(accounts, 6);
 
-    if !owner_info.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
+    require!(
+        owner_info.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
 
-    assert_owner!(shuttle_info, &crate::ID);
-    assert_owner!(shuttle_wallet_ata_info, token_program_info.address());
-    assert_owner!(destination_token_info, token_program_info.address());
+    require!(
+        shuttle_info.owned_by(&crate::ID),
+        ProgramError::InvalidAccountOwner
+    );
+    require!(
+        shuttle_wallet_ata_info.owned_by(token_program_info.address()),
+        ProgramError::InvalidAccountOwner
+    );
+    require!(
+        destination_token_info.owned_by(token_program_info.address()),
+        ProgramError::InvalidAccountOwner
+    );
 
     let (shuttle_owner, shuttle_id, bump) = {
         let shuttle =
             load_initialized::<ShuttleMetadata>(unsafe { shuttle_info.borrow_unchecked() })?;
-        if shuttle.owner != *owner_info.address() {
-            return Err(ProgramError::IncorrectAuthority);
-        }
+        require_eq_keys!(
+            &shuttle.owner,
+            owner_info.address(),
+            ProgramError::IncorrectAuthority
+        );
         #[allow(clippy::clone_on_copy)]
         let owner = shuttle.owner.clone();
         (owner, shuttle.id, shuttle.bump)
@@ -54,9 +68,11 @@ pub fn process_merge_shuttle_into_ephemeral_ata(
     let shuttle_id_seed = shuttle_id.to_le_bytes();
     let derived_shuttle =
         ShuttleMetadata::derive_pda(&shuttle_owner, mint_info.address(), shuttle_id, bump)?;
-    if !address_eq(&derived_shuttle, shuttle_info.address()) {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &derived_shuttle,
+        shuttle_info.address(),
+        ProgramError::InvalidSeeds
+    );
 
     let shuttle_amount = {
         let shuttle_ata = validate_token_account(

--- a/e-token/src/processor/pending_transfer_queue_refill.rs
+++ b/e-token/src/processor/pending_transfer_queue_refill.rs
@@ -1,9 +1,7 @@
 use ephemeral_spl_api::instruction::SPONSORED_LAMPORTS_TRANSFER;
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use pinocchio::cpi::{invoke_signed_with_bounds, Seed, Signer};
 use pinocchio::instruction::{InstructionAccount, InstructionView};
-use pinocchio::{
-    address::address_eq,
-    cpi::{invoke_signed_with_bounds, Seed, Signer},
-};
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
 
 use crate::processor::{
@@ -43,32 +41,39 @@ pub fn process_pending_transfer_queue_refill(
     accounts: &[AccountView],
     _instruction_data: &[u8],
 ) -> ProgramResult {
-    let [refill_state_info, rest @ ..] = accounts else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    let [
+        refill_state_info, // force multi-line
+        queue_info,
+        rent_pda_info,
+        lamports_pda_info,
+        owner_program_info,
+        buffer_acc,
+        delegation_record,
+        delegation_metadata,
+        delegation_program_info,
+        system_program_info,
+        queue_delegation_record_info,
+    ] = require_n_accounts_with_ignored!(accounts, 11);
 
     // Exit early if refill_state_info does not exist (refill was not requested)
     if refill_state_info.lamports() == 0 || !refill_state_info.owned_by(&crate::ID) {
         return Ok(());
     }
-
-    let [queue_info, rent_pda_info, lamports_pda_info, owner_program_info, buffer_acc, delegation_record, delegation_metadata, delegation_program_info, system_program_info, queue_delegation_record_info, ..] =
-        rest
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
-
     validate_queue_refill_state_address(refill_state_info, queue_info.address())?;
     validate_rent_pda(rent_pda_info)?;
 
     let (_, refill_lamports) = refill_transfer_queue_amounts(queue_info.data_len())?;
     let (refill_lamports_pda, _, refill_salt) = queue_refill_lamports_pda(queue_info.address());
-    if refill_lamports_pda != *lamports_pda_info.address() {
-        return Err(ProgramError::InvalidSeeds);
-    }
-    if !address_eq(owner_program_info.address(), &crate::ID) {
-        return Err(ProgramError::IncorrectProgramId);
-    }
+    require_eq_keys!(
+        &refill_lamports_pda,
+        lamports_pda_info.address(),
+        ProgramError::InvalidSeeds
+    );
+    require_eq_keys!(
+        owner_program_info.address(),
+        &crate::ID,
+        ProgramError::IncorrectProgramId
+    );
 
     trigger_queue_refill_via_sponsored_transfer(
         owner_program_info,
@@ -162,9 +167,10 @@ fn close_program_account_to_recipient(
     account: &AccountView,
     recipient: &AccountView,
 ) -> ProgramResult {
-    if *recipient.address() == *account.address() {
-        return Err(ProgramError::InvalidArgument);
-    }
+    require!(
+        recipient.address() != account.address(),
+        ProgramError::InvalidArgument
+    );
 
     let lamports_to_refund = account.lamports();
     let updated_recipient_lamports = recipient

--- a/e-token/src/processor/pending_transfer_queue_refill.rs
+++ b/e-token/src/processor/pending_transfer_queue_refill.rs
@@ -1,5 +1,5 @@
 use ephemeral_spl_api::instruction::SPONSORED_LAMPORTS_TRANSFER;
-use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
 use pinocchio::cpi::{invoke_signed_with_bounds, Seed, Signer};
 use pinocchio::instruction::{InstructionAccount, InstructionView};
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
@@ -53,7 +53,7 @@ pub fn process_pending_transfer_queue_refill(
         delegation_program_info,
         system_program_info,
         queue_delegation_record_info,
-    ] = require_n_accounts_with_ignored!(accounts, 11);
+    ] = require_n_accounts!(accounts, 11);
 
     // Exit early if refill_state_info does not exist (refill was not requested)
     if refill_state_info.lamports() == 0 || !refill_state_info.owned_by(&crate::ID) {

--- a/e-token/src/processor/reset_ephemeral_ata_permission.rs
+++ b/e-token/src/processor/reset_ephemeral_ata_permission.rs
@@ -6,7 +6,7 @@ use ephemeral_rollups_pinocchio::acl::{
 };
 use ephemeral_spl_api::{require, require_eq_keys};
 use ephemeral_spl_api::{
-    require_n_accounts_with_ignored,
+    require_n_accounts,
     state::{ephemeral_ata::EphemeralAta, load_initialized},
 };
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
@@ -33,7 +33,7 @@ pub fn process_reset_ephemeral_ata_permission(
         permission_info,
         owner_info,
         permission_program,
-    ] = require_n_accounts_with_ignored!(accounts, 4);
+    ] = require_n_accounts!(accounts, 4);
 
     let args = ResetEphemeralAtaPermission::try_from_bytes(instruction_data)?;
 

--- a/e-token/src/processor/reset_ephemeral_ata_permission.rs
+++ b/e-token/src/processor/reset_ephemeral_ata_permission.rs
@@ -4,8 +4,12 @@ use ephemeral_rollups_pinocchio::acl::{
     instruction::UpdatePermissionCpiBuilder,
     types::{Member, MemberFlags, MembersArgs},
 };
-use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
-use pinocchio::{address::address_eq, error::ProgramError, AccountView, ProgramResult};
+use ephemeral_spl_api::{require, require_eq_keys};
+use ephemeral_spl_api::{
+    require_n_accounts_with_ignored,
+    state::{ephemeral_ata::EphemeralAta, load_initialized},
+};
+use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
 ///
 /// Executes on:
@@ -24,30 +28,39 @@ pub fn process_reset_ephemeral_ata_permission(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
+    let [
+        ephemeral_ata_info, // force multi-line
+        permission_info,
+        owner_info,
+        permission_program,
+    ] = require_n_accounts_with_ignored!(accounts, 4);
+
     let args = ResetEphemeralAtaPermission::try_from_bytes(instruction_data)?;
 
-    let [ephemeral_ata_info, permission_info, owner_info, permission_program, ..] = accounts else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    require!(
+        owner_info.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
 
-    if !owner_info.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
-
-    if !address_eq(permission_program.address(), &PERMISSION_PROGRAM_ID) {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require_eq_keys!(
+        &PERMISSION_PROGRAM_ID,
+        permission_program.address(),
+        ProgramError::InvalidAccountData
+    );
 
     let ephemeral_ata =
         load_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked() })?;
 
-    if !address_eq(&ephemeral_ata.owner, owner_info.address()) {
-        return Err(ProgramError::IncorrectAuthority);
-    }
+    require_eq_keys!(
+        &ephemeral_ata.owner,
+        owner_info.address(),
+        ProgramError::IncorrectAuthority
+    );
 
-    if permission_info.lamports() == 0 {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require!(
+        permission_info.lamports() != 0,
+        ProgramError::InvalidAccountData
+    );
 
     let mut members_flag = MemberFlags::from_acl_flag_byte(args.flag_byte());
     members_flag.set(MemberFlags::AUTHORITY);
@@ -89,9 +102,7 @@ pub struct ResetEphemeralAtaPermission<'a> {
 impl ResetEphemeralAtaPermission<'_> {
     #[inline]
     pub fn try_from_bytes(bytes: &[u8]) -> Result<ResetEphemeralAtaPermission<'_>, ProgramError> {
-        if bytes.is_empty() {
-            return Err(ProgramError::InvalidInstructionData);
-        }
+        require!(!bytes.is_empty(), ProgramError::InvalidInstructionData);
 
         Ok(ResetEphemeralAtaPermission {
             raw: bytes.as_ptr(),

--- a/e-token/src/processor/sponsored_lamports_transfer.rs
+++ b/e-token/src/processor/sponsored_lamports_transfer.rs
@@ -5,7 +5,7 @@ use ephemeral_rollups_pinocchio::{
     consts::{DELEGATION_PROGRAM_ID, MAGIC_CONTEXT_ID, MAGIC_PROGRAM_ID},
     types::DelegateConfig,
 };
-use pinocchio::address::address_eq;
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
 use pinocchio::cpi::{Seed, Signer};
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
@@ -14,13 +14,10 @@ use pinocchio_system::instructions::{CreateAccount, Transfer};
 use solana_instruction::{AccountMeta, Instruction};
 use solana_pubkey::Pubkey;
 
-use crate::{
-    assert_owner, assert_signer,
-    processor::{
-        initialize_rent_pda::{RENT_PDA, RENT_PDA_BUMP, RENT_PDA_SEED},
-        internal::lamports_pda::{derive_lamports_pda, parse_amount_and_salt, LAMPORTS_PDA_SEED},
-        internal::shuttle_delegation::delegate_account_with_actions_from_sponsor,
-    },
+use crate::processor::{
+    initialize_rent_pda::{RENT_PDA, RENT_PDA_BUMP, RENT_PDA_SEED},
+    internal::lamports_pda::{derive_lamports_pda, parse_amount_and_salt, LAMPORTS_PDA_SEED},
+    internal::shuttle_delegation::delegate_account_with_actions_from_sponsor,
 };
 
 ///
@@ -47,41 +44,65 @@ pub fn process_sponsored_lamports_transfer(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
+    let [
+        payer_info, // force multi-line
+        rent_pda_info,
+        lamports_pda_info,
+        owner_program,
+        buffer_acc,
+        delegation_record,
+        delegation_metadata,
+        _delegation_program,
+        system_program,
+        destination_info,
+        destination_delegation_record_info,
+    ] = require_n_accounts_with_ignored!(accounts, 11);
+
     let (amount, salt) = parse_amount_and_salt(instruction_data)?;
-    let [payer_info, rent_pda_info, lamports_pda_info, owner_program, buffer_acc, delegation_record, delegation_metadata, _delegation_program, system_program, destination_info, destination_delegation_record_info, ..] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
 
-    if amount == 0 {
-        return Err(ProgramError::InvalidArgument);
-    }
-    assert_signer!(payer_info);
-    assert_owner!(rent_pda_info, &pinocchio_system::ID);
-    assert_owner!(destination_info, &DELEGATION_PROGRAM_ID);
+    require!(amount != 0, ProgramError::InvalidArgument);
+    require!(
+        payer_info.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
+    require!(
+        rent_pda_info.owned_by(&pinocchio_system::ID),
+        ProgramError::InvalidAccountOwner
+    );
+    require!(
+        destination_info.owned_by(&DELEGATION_PROGRAM_ID),
+        ProgramError::InvalidAccountOwner
+    );
 
-    if !address_eq(owner_program.address(), &crate::ID) {
-        return Err(ProgramError::IncorrectProgramId);
-    }
+    require_eq_keys!(
+        owner_program.address(),
+        &crate::ID,
+        ProgramError::IncorrectProgramId
+    );
 
-    if RENT_PDA != *rent_pda_info.address() {
-        return Err(ProgramError::InvalidSeeds);
-    }
-    if rent_pda_info.data_len() != 0 {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require_eq_keys!(
+        &RENT_PDA,
+        rent_pda_info.address(),
+        ProgramError::InvalidSeeds
+    );
+    require!(
+        rent_pda_info.data_len() == 0,
+        ProgramError::InvalidAccountData
+    );
 
     let validator =
         read_destination_validator(destination_info, destination_delegation_record_info)?;
     let (derived_lamports_pda, lamports_pda_bump) =
         derive_lamports_pda(payer_info.address(), destination_info.address(), &salt);
-    if derived_lamports_pda != *lamports_pda_info.address() {
-        return Err(ProgramError::InvalidSeeds);
-    }
-    if lamports_pda_info.lamports() > 0 {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require_eq_keys!(
+        &derived_lamports_pda,
+        lamports_pda_info.address(),
+        ProgramError::InvalidSeeds
+    );
+    require!(
+        lamports_pda_info.lamports() == 0,
+        ProgramError::InvalidAccountData
+    );
 
     Transfer {
         from: payer_info,

--- a/e-token/src/processor/sponsored_lamports_transfer.rs
+++ b/e-token/src/processor/sponsored_lamports_transfer.rs
@@ -5,7 +5,7 @@ use ephemeral_rollups_pinocchio::{
     consts::{DELEGATION_PROGRAM_ID, MAGIC_CONTEXT_ID, MAGIC_PROGRAM_ID},
     types::DelegateConfig,
 };
-use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
 use pinocchio::cpi::{Seed, Signer};
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
@@ -56,7 +56,7 @@ pub fn process_sponsored_lamports_transfer(
         system_program,
         destination_info,
         destination_delegation_record_info,
-    ] = require_n_accounts_with_ignored!(accounts, 11);
+    ] = require_n_accounts!(accounts, 11);
 
     let (amount, salt) = parse_amount_and_salt(instruction_data)?;
 

--- a/e-token/src/processor/transfer_lamports_pda.rs
+++ b/e-token/src/processor/transfer_lamports_pda.rs
@@ -1,4 +1,4 @@
-use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
@@ -25,7 +25,7 @@ pub fn process_transfer_lamports_pda(
         payer_info, // force multi-line
         lamports_pda_info,
         destination_info,
-    ] = require_n_accounts_with_ignored!(accounts, 3);
+    ] = require_n_accounts!(accounts, 3);
 
     let (amount, salt) = parse_amount_and_salt(instruction_data)?;
 

--- a/e-token/src/processor/transfer_lamports_pda.rs
+++ b/e-token/src/processor/transfer_lamports_pda.rs
@@ -1,11 +1,9 @@
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
-use crate::{
-    assert_owner, assert_signer,
-    processor::internal::lamports_pda::{derive_lamports_pda, parse_amount_and_salt},
-};
+use crate::processor::internal::lamports_pda::{derive_lamports_pda, parse_amount_and_salt};
 
 ///
 /// Executes on:
@@ -23,31 +21,44 @@ pub fn process_transfer_lamports_pda(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
+    let [
+        payer_info, // force multi-line
+        lamports_pda_info,
+        destination_info,
+    ] = require_n_accounts_with_ignored!(accounts, 3);
+
     let (amount, salt) = parse_amount_and_salt(instruction_data)?;
-    let [payer_info, lamports_pda_info, destination_info, ..] = accounts else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
 
-    assert_signer!(payer_info);
-    assert_owner!(lamports_pda_info, &crate::ID);
+    require!(
+        payer_info.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
+    require!(
+        lamports_pda_info.owned_by(&crate::ID),
+        ProgramError::InvalidAccountOwner
+    );
 
-    if lamports_pda_info.data_len() != 0 {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require!(
+        lamports_pda_info.data_len() == 0,
+        ProgramError::InvalidAccountData
+    );
 
     let (derived_lamports_pda, _) =
         derive_lamports_pda(payer_info.address(), destination_info.address(), &salt);
-    if derived_lamports_pda != *lamports_pda_info.address() {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &derived_lamports_pda,
+        lamports_pda_info.address(),
+        ProgramError::InvalidSeeds
+    );
 
     let expected_balance = Rent::get()?
         .try_minimum_balance(0)?
         .checked_add(amount)
         .ok_or(ProgramError::InvalidArgument)?;
-    if lamports_pda_info.lamports() < expected_balance {
-        return Err(ProgramError::InvalidArgument);
-    }
+    require!(
+        lamports_pda_info.lamports() >= expected_balance,
+        ProgramError::InvalidArgument
+    );
 
     transfer_lamports(lamports_pda_info, destination_info, amount)
 }
@@ -57,9 +68,10 @@ fn transfer_lamports(
     destination: &AccountView,
     amount: u64,
 ) -> ProgramResult {
-    if *source.address() == *destination.address() {
-        return Err(ProgramError::InvalidArgument);
-    }
+    require!(
+        source.address() != destination.address(),
+        ProgramError::InvalidArgument
+    );
 
     let updated_source_lamports = source
         .lamports()

--- a/e-token/src/processor/transfer_queue_tick.rs
+++ b/e-token/src/processor/transfer_queue_tick.rs
@@ -6,32 +6,25 @@ use ephemeral_rollups_pinocchio::{
     intent_bundle::{ActionArgs, CallHandler, MagicIntentBundleBuilder, ShortAccountMeta},
     spl::consts::TOKEN_PROGRAM_ID,
 };
-use ephemeral_spl_api::instruction::internal::{
-    EXECUTE_READY_QUEUED_TRANSFER, MARK_TRANSFER_QUEUE_REFILL_PENDING,
-};
 use ephemeral_spl_api::state::transfer_queue::{
     queue_peek_from_data, queue_pop_from_data, queue_views_checked, QueuedTransfer, QUEUE_SEED,
 };
-use pinocchio::{
-    address::address_eq,
-    cpi::{Seed, Signer},
+use ephemeral_spl_api::{
+    instruction::internal::{EXECUTE_READY_QUEUED_TRANSFER, MARK_TRANSFER_QUEUE_REFILL_PENDING},
+    require_n_accounts_with_ignored,
 };
+use ephemeral_spl_api::{require, require_eq_keys};
+use pinocchio::cpi::{Seed, Signer};
+use pinocchio::sysvars::{clock::Clock, Sysvar};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
-use pinocchio::{
-    sysvars::{clock::Clock, Sysvar},
-    Address,
-};
 use pinocchio_system::ID as SYSTEM_PROGRAM_ID;
 
-use crate::{
-    assert_owner,
-    processor::{
-        initialize_rent_pda::RENT_PDA,
-        internal::transfer_queue_refill::{
-            queue_refill_state_address, refill_transfer_queue_amounts,
-            MARK_TRANSFER_QUEUE_REFILL_PENDING_COMPUTE_UNITS,
-            MARK_TRANSFER_QUEUE_REFILL_PENDING_ESCROW_INDEX,
-        },
+use crate::processor::{
+    initialize_rent_pda::RENT_PDA,
+    internal::transfer_queue_refill::{
+        queue_refill_state_address, refill_transfer_queue_amounts,
+        MARK_TRANSFER_QUEUE_REFILL_PENDING_COMPUTE_UNITS,
+        MARK_TRANSFER_QUEUE_REFILL_PENDING_ESCROW_INDEX,
     },
 };
 
@@ -75,11 +68,30 @@ pub fn process_transfer_queue_tick(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    if !instruction_data.is_empty() {
-        return Err(ProgramError::InvalidInstructionData);
-    }
+    require!(
+        instruction_data.is_empty(),
+        ProgramError::InvalidInstructionData
+    );
 
-    let tick_accounts = parse_tick_accounts(accounts)?;
+    let [
+        queue_info, // force multi-line
+        magic_fee_vault_info,
+        magic_context_info,
+        magic_program_info,
+    ] = require_n_accounts_with_ignored!(accounts, 4);
+
+    require_eq_keys!(
+        magic_program_info.address(),
+        &ephemeral_rollups_pinocchio::consts::MAGIC_PROGRAM_ID,
+        ProgramError::IncorrectProgramId
+    );
+
+    let tick_accounts = TickAccounts {
+        queue_info,
+        magic_fee_vault_info,
+        magic_context_info,
+        magic_program_info,
+    };
     let program_id = crate::ID;
     let clock = Clock::get()?;
     let queue_state = read_queue_tick_state(tick_accounts.queue_info, &program_id)?;
@@ -112,28 +124,6 @@ fn derive_associated_token_address(
 }
 
 #[inline(always)]
-fn parse_tick_accounts(accounts: &[AccountView]) -> Result<TickAccounts<'_>, ProgramError> {
-    let [queue_info, magic_fee_vault_info, magic_context_info, magic_program_info, ..] = accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
-
-    if !address_eq(
-        magic_program_info.address(),
-        &ephemeral_rollups_pinocchio::consts::MAGIC_PROGRAM_ID,
-    ) {
-        return Err(ProgramError::IncorrectProgramId);
-    }
-
-    Ok(TickAccounts {
-        queue_info,
-        magic_fee_vault_info,
-        magic_context_info,
-        magic_program_info,
-    })
-}
-
-#[inline(always)]
 fn read_queue_tick_state(
     queue_info: &AccountView,
     program_id: &ephemeral_spl_api::Address,
@@ -148,9 +138,11 @@ fn read_queue_tick_state(
         &[QUEUE_SEED, mint.as_ref(), validator.as_ref()],
         program_id,
     );
-    if !address_eq(&derived_queue, queue_info.address()) {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &derived_queue,
+        queue_info.address(),
+        ProgramError::InvalidSeeds
+    );
 
     Ok(QueueTickState {
         mint,
@@ -245,7 +237,10 @@ fn schedule_execute_ready_transfer(
     queued_transfer: &QueuedTransfer,
     program_id: &ephemeral_spl_api::Address,
 ) -> ProgramResult {
-    assert_owner!(tick_accounts.queue_info, program_id);
+    require!(
+        tick_accounts.queue_info.owned_by(program_id),
+        ProgramError::InvalidAccountOwner
+    );
 
     #[cfg(feature = "logging")]
     pinocchio_log::log!(
@@ -339,15 +334,13 @@ fn invoke_queue_standalone_action(
     ];
     let signers = [Signer::from(&signer_seeds)];
     let mut intent_bundle_data = [0_u8; MAGIC_INTENT_BUNDLE_DATA_LEN];
-    let derived_magic_fee_vault = Address::from(
-        magic_fee_vault_pda_from_validator(&queue_state.validator.to_bytes().into()).to_bytes(),
+    let derived_magic_fee_vault =
+        magic_fee_vault_pda_from_validator(&queue_state.validator.to_bytes().into());
+    require!(
+        derived_magic_fee_vault.to_bytes()
+            == tick_accounts.magic_fee_vault_info.address().to_bytes(),
+        ProgramError::InvalidSeeds
     );
-    if !address_eq(
-        &derived_magic_fee_vault,
-        tick_accounts.magic_fee_vault_info.address(),
-    ) {
-        return Err(ProgramError::InvalidSeeds);
-    }
 
     MagicIntentBundleBuilder::new(
         tick_accounts.queue_info.clone(),
@@ -368,9 +361,10 @@ fn pop_executed_transfer(
     // do not wait for actual payout. It is by design.
     let data = unsafe { queue_info.borrow_unchecked_mut() };
     let popped_transfer = queue_pop_from_data(data)?.ok_or(ProgramError::InvalidAccountData)?;
-    if popped_transfer.task_id != queued_transfer.task_id {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require!(
+        popped_transfer.task_id == queued_transfer.task_id,
+        ProgramError::InvalidAccountData
+    );
 
     #[cfg(feature = "logging")]
     {

--- a/e-token/src/processor/transfer_queue_tick.rs
+++ b/e-token/src/processor/transfer_queue_tick.rs
@@ -11,7 +11,7 @@ use ephemeral_spl_api::state::transfer_queue::{
 };
 use ephemeral_spl_api::{
     instruction::internal::{EXECUTE_READY_QUEUED_TRANSFER, MARK_TRANSFER_QUEUE_REFILL_PENDING},
-    require_n_accounts_with_ignored,
+    require_n_accounts,
 };
 use ephemeral_spl_api::{require, require_eq_keys};
 use pinocchio::cpi::{Seed, Signer};
@@ -78,7 +78,7 @@ pub fn process_transfer_queue_tick(
         magic_fee_vault_info,
         magic_context_info,
         magic_program_info,
-    ] = require_n_accounts_with_ignored!(accounts, 4);
+    ] = require_n_accounts!(accounts, 4);
 
     require_eq_keys!(
         magic_program_info.address(),

--- a/e-token/src/processor/undelegate_and_close_shuttle_to_owner.rs
+++ b/e-token/src/processor/undelegate_and_close_shuttle_to_owner.rs
@@ -6,7 +6,7 @@ use ephemeral_spl_api::instruction::internal::SETTLE_AND_CLOSE_SHUTTLE_INTENT;
 use ephemeral_spl_api::state::{
     ephemeral_ata::EphemeralAta, load_initialized, shuttle_ephemeral_ata::ShuttleMetadata,
 };
-use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
 
 const DEFAULT_ESCROW_INDEX: u8 = u8::MAX;
@@ -44,7 +44,7 @@ pub fn process_undelegate_and_close_shuttle_to_owner(
         token_program_info,
         magic_context,
         magic_program,
-    ] = require_n_accounts_with_ignored!(accounts, 9);
+    ] = require_n_accounts!(accounts, 9);
 
     let escrow_index = parse_escrow_index(instruction_data)?;
 

--- a/e-token/src/processor/undelegate_and_close_shuttle_to_owner.rs
+++ b/e-token/src/processor/undelegate_and_close_shuttle_to_owner.rs
@@ -1,3 +1,4 @@
+use crate::processor::utils::{get_associated_token_address, validate_token_account};
 use ephemeral_rollups_pinocchio::intent_bundle::{
     ActionArgs, CallHandler, MagicIntentBundleBuilder, ShortAccountMeta,
 };
@@ -5,11 +6,8 @@ use ephemeral_spl_api::instruction::internal::SETTLE_AND_CLOSE_SHUTTLE_INTENT;
 use ephemeral_spl_api::state::{
     ephemeral_ata::EphemeralAta, load_initialized, shuttle_ephemeral_ata::ShuttleMetadata,
 };
-use pinocchio::address::address_eq;
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
-
-use crate::assert_owner;
-use crate::processor::utils::{get_associated_token_address, validate_token_account};
 
 const DEFAULT_ESCROW_INDEX: u8 = u8::MAX;
 const INTENT_BUNDLE_DATA_BUF_SIZE: usize = 1536;
@@ -36,13 +34,19 @@ pub fn process_undelegate_and_close_shuttle_to_owner(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let escrow_index = parse_escrow_index(instruction_data)?;
+    let [
+        executor, // force multi-line
+        rent_reimbursement,
+        shuttle_info,
+        shuttle_ephemeral_ata_info,
+        shuttle_wallet_ata_info,
+        refund_token_info,
+        token_program_info,
+        magic_context,
+        magic_program,
+    ] = require_n_accounts_with_ignored!(accounts, 9);
 
-    let [executor, rent_reimbursement, shuttle_info, shuttle_ephemeral_ata_info, shuttle_wallet_ata_info, refund_token_info, token_program_info, magic_context, magic_program, ..] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    let escrow_index = parse_escrow_index(instruction_data)?;
 
     // TODO (snawaz):  unauthorized third-party cleanup/cancellation is possible.
     //
@@ -50,24 +54,29 @@ pub fn process_undelegate_and_close_shuttle_to_owner(
     // force undelegate-and-close shuttle of other users and force shuttle into refund/cleanup.
     //
     // enforce: executor == shuttle.owner
-    if !executor.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
+    require!(executor.is_signer(), ProgramError::MissingRequiredSignature);
 
-    assert_owner!(shuttle_info, &crate::ID);
+    require!(
+        shuttle_info.owned_by(&crate::ID),
+        ProgramError::InvalidAccountOwner
+    );
 
     let shuttle = load_initialized::<ShuttleMetadata>(unsafe { shuttle_info.borrow_unchecked() })?;
-    if shuttle.payer != *rent_reimbursement.address() {
-        return Err(ProgramError::IncorrectAuthority);
-    }
+    require_eq_keys!(
+        &shuttle.payer,
+        rent_reimbursement.address(),
+        ProgramError::IncorrectAuthority
+    );
 
     let mint = {
         let shuttle_ephemeral_ata = load_initialized::<EphemeralAta>(unsafe {
             shuttle_ephemeral_ata_info.borrow_unchecked()
         })?;
-        if !address_eq(&shuttle_ephemeral_ata.owner, shuttle_info.address()) {
-            return Err(ProgramError::InvalidAccountData);
-        }
+        require_eq_keys!(
+            &shuttle_ephemeral_ata.owner,
+            shuttle_info.address(),
+            ProgramError::InvalidAccountData
+        );
         #[allow(clippy::clone_on_copy)]
         let mint = shuttle_ephemeral_ata.mint.clone();
         mint
@@ -77,21 +86,19 @@ pub fn process_undelegate_and_close_shuttle_to_owner(
         &[shuttle_info.address().as_ref(), mint.as_ref()],
         &crate::ID,
     );
-    if !address_eq(
+    require_eq_keys!(
         &derived_shuttle_ephemeral_ata,
         shuttle_ephemeral_ata_info.address(),
-    ) {
-        return Err(ProgramError::InvalidSeeds);
-    }
+        ProgramError::InvalidSeeds
+    );
 
     let expected_shuttle_wallet_ata =
         get_associated_token_address(shuttle_info.address(), &mint, token_program_info.address());
-    if !address_eq(
+    require_eq_keys!(
         &expected_shuttle_wallet_ata,
         shuttle_wallet_ata_info.address(),
-    ) {
-        return Err(ProgramError::InvalidAccountData);
-    }
+        ProgramError::InvalidAccountData
+    );
 
     validate_token_account(
         shuttle_wallet_ata_info,
@@ -126,9 +133,10 @@ fn parse_escrow_index(instruction_data: &[u8]) -> Result<u8, ProgramError> {
     if instruction_data.is_empty() {
         return Ok(DEFAULT_ESCROW_INDEX);
     }
-    if instruction_data.len() != 1 {
-        return Err(ProgramError::InvalidInstructionData);
-    }
+    require!(
+        instruction_data.len() == 1,
+        ProgramError::InvalidInstructionData
+    );
     Ok(instruction_data[0])
 }
 

--- a/e-token/src/processor/undelegate_ephemeral_ata.rs
+++ b/e-token/src/processor/undelegate_ephemeral_ata.rs
@@ -1,5 +1,5 @@
 use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
-use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
 use crate::processor::utils::validate_token_account;
@@ -43,7 +43,7 @@ pub fn process_undelegate_ephemeral_ata(
         ephemeral_ata_info,
         magic_context,
         magic_program,
-    ] = require_n_accounts_with_ignored!(accounts, 5);
+    ] = require_n_accounts!(accounts, 5);
 
     // Ensure the payer signed the transaction
     require!(payer.is_signer(), ProgramError::MissingRequiredSignature);

--- a/e-token/src/processor/undelegate_ephemeral_ata.rs
+++ b/e-token/src/processor/undelegate_ephemeral_ata.rs
@@ -1,5 +1,6 @@
 use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
-use pinocchio::{address::address_eq, error::ProgramError, AccountView, ProgramResult};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
 use crate::processor::utils::validate_token_account;
 
@@ -36,14 +37,16 @@ pub fn process_undelegate_ephemeral_ata(
     accounts: &[AccountView],
     _instruction_data: &[u8],
 ) -> ProgramResult {
-    let [payer, ata_info, ephemeral_ata_info, magic_context, magic_program, ..] = accounts else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    let [
+        payer, // force multi-line
+        ata_info,
+        ephemeral_ata_info,
+        magic_context,
+        magic_program,
+    ] = require_n_accounts_with_ignored!(accounts, 5);
 
     // Ensure the payer signed the transaction
-    if !payer.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
+    require!(payer.is_signer(), ProgramError::MissingRequiredSignature);
 
     // Read the Ephemeral ATA to get the mint and verify the PDA derivation for this payer.
     // Scope the borrow so it's released before any CPI.
@@ -58,9 +61,11 @@ pub fn process_undelegate_ephemeral_ata(
     // Derive PDA: seeds = [payer, mint], program id = e-token program id (ephemeral_spl_api::program::ID)
     let derived_pda = EphemeralAta::derive_pda(payer.address(), &mint, bump)?;
 
-    if !address_eq(&derived_pda, ephemeral_ata_info.address()) {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &derived_pda,
+        ephemeral_ata_info.address(),
+        ProgramError::InvalidSeeds
+    );
 
     // Validate that the provided ATA account is a valid SPL token account for [payer, mint].
     validate_token_account(ata_info, &mint, Some(payer.address()), None)?;

--- a/e-token/src/processor/undelegate_ephemeral_ata_permission.rs
+++ b/e-token/src/processor/undelegate_ephemeral_ata_permission.rs
@@ -2,9 +2,8 @@ use ephemeral_rollups_pinocchio::acl::{
     consts::PERMISSION_PROGRAM_ID, instruction::commit_and_undelegate_permission,
 };
 use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
-use pinocchio::{address::address_eq, error::ProgramError, AccountView, ProgramResult};
-
-use crate::assert_signer;
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
 ///
 /// Executes on:
@@ -24,24 +23,34 @@ pub fn process_undelegate_ephemeral_ata_permission(
     accounts: &[AccountView],
     _instruction_data: &[u8],
 ) -> ProgramResult {
-    let [payer_info, ephemeral_ata_info, permission_info, permission_program, magic_program, magic_context, ..] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    let [
+        payer_info, // force multi-line
+        ephemeral_ata_info,
+        permission_info,
+        permission_program,
+        magic_program,
+        magic_context,
+    ] = require_n_accounts_with_ignored!(accounts, 6);
 
-    assert_signer!(payer_info);
+    require!(
+        payer_info.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
 
-    if !address_eq(permission_program.address(), &PERMISSION_PROGRAM_ID) {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require_eq_keys!(
+        &PERMISSION_PROGRAM_ID,
+        permission_program.address(),
+        ProgramError::InvalidAccountData
+    );
 
     let ephemeral_ata =
         load_initialized::<EphemeralAta>(unsafe { ephemeral_ata_info.borrow_unchecked() })?;
 
-    if !address_eq(&ephemeral_ata.owner, payer_info.address()) {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require_eq_keys!(
+        &ephemeral_ata.owner,
+        payer_info.address(),
+        ProgramError::InvalidAccountData
+    );
 
     commit_and_undelegate_permission(
         &[

--- a/e-token/src/processor/undelegate_ephemeral_ata_permission.rs
+++ b/e-token/src/processor/undelegate_ephemeral_ata_permission.rs
@@ -2,7 +2,7 @@ use ephemeral_rollups_pinocchio::acl::{
     consts::PERMISSION_PROGRAM_ID, instruction::commit_and_undelegate_permission,
 };
 use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
-use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
 ///
@@ -30,7 +30,7 @@ pub fn process_undelegate_ephemeral_ata_permission(
         permission_program,
         magic_program,
         magic_context,
-    ] = require_n_accounts_with_ignored!(accounts, 6);
+    ] = require_n_accounts!(accounts, 6);
 
     require!(
         payer_info.is_signer(),

--- a/e-token/src/processor/undelegate_lamports_pda.rs
+++ b/e-token/src/processor/undelegate_lamports_pda.rs
@@ -1,7 +1,7 @@
 use ephemeral_rollups_pinocchio::intent_bundle::{
     ActionArgs, CallHandler, MagicIntentBundleBuilder, ShortAccountMeta,
 };
-use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
@@ -38,7 +38,7 @@ pub fn process_undelegate_lamports_pda(
         destination_info,
         magic_context,
         magic_program,
-    ] = require_n_accounts_with_ignored!(accounts, 6);
+    ] = require_n_accounts!(accounts, 6);
 
     let salt = parse_salt(instruction_data)?;
 

--- a/e-token/src/processor/undelegate_lamports_pda.rs
+++ b/e-token/src/processor/undelegate_lamports_pda.rs
@@ -1,11 +1,12 @@
 use ephemeral_rollups_pinocchio::intent_bundle::{
     ActionArgs, CallHandler, MagicIntentBundleBuilder, ShortAccountMeta,
 };
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts_with_ignored};
 use pinocchio::sysvars::rent::Rent;
 use pinocchio::sysvars::Sysvar;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
-use crate::{assert_owner, assert_signer, processor::internal::lamports_pda::derive_lamports_pda};
+use crate::processor::internal::lamports_pda::derive_lamports_pda;
 
 const DEFAULT_ESCROW_INDEX: u8 = u8::MAX;
 const INTENT_BUNDLE_DATA_BUF_SIZE: usize = 512;
@@ -30,29 +31,43 @@ pub fn process_undelegate_lamports_pda(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
+    let [
+        payer_info, // force multi-line
+        rent_pda_info,
+        lamports_pda_info,
+        destination_info,
+        magic_context,
+        magic_program,
+    ] = require_n_accounts_with_ignored!(accounts, 6);
+
     let salt = parse_salt(instruction_data)?;
-    let [payer_info, rent_pda_info, lamports_pda_info, destination_info, magic_context, magic_program, ..] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
 
-    assert_signer!(payer_info);
-    assert_owner!(lamports_pda_info, &crate::ID);
+    require!(
+        payer_info.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
+    require!(
+        lamports_pda_info.owned_by(&crate::ID),
+        ProgramError::InvalidAccountOwner
+    );
 
-    if lamports_pda_info.data_len() != 0 {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require!(
+        lamports_pda_info.data_len() == 0,
+        ProgramError::InvalidAccountData
+    );
 
     let (derived_lamports_pda, _) =
         derive_lamports_pda(payer_info.address(), destination_info.address(), &salt);
-    if derived_lamports_pda != *lamports_pda_info.address() {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    require_eq_keys!(
+        &derived_lamports_pda,
+        lamports_pda_info.address(),
+        ProgramError::InvalidSeeds
+    );
 
-    if lamports_pda_info.lamports() < Rent::get()?.try_minimum_balance(0)? {
-        return Err(ProgramError::InvalidArgument);
-    }
+    require!(
+        lamports_pda_info.lamports() >= Rent::get()?.try_minimum_balance(0)?,
+        ProgramError::InvalidArgument
+    );
 
     let close_handler_data = close_lamports_handler_data(DEFAULT_ESCROW_INDEX, &salt);
     let close_handler_accounts = [
@@ -102,9 +117,10 @@ fn close_lamports_handler_data(escrow_index: u8, salt: &[u8; 32]) -> [u8; 34] {
 }
 
 fn parse_salt(instruction_data: &[u8]) -> Result<[u8; 32], ProgramError> {
-    if instruction_data.len() != 32 {
-        return Err(ProgramError::InvalidInstructionData);
-    }
+    require!(
+        instruction_data.len() == 32,
+        ProgramError::InvalidInstructionData
+    );
 
     let mut salt = [0u8; 32];
     salt.copy_from_slice(instruction_data);

--- a/e-token/src/processor/undelegation_callback.rs
+++ b/e-token/src/processor/undelegation_callback.rs
@@ -1,4 +1,5 @@
-use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+use ephemeral_spl_api::require_n_accounts_with_ignored;
+use pinocchio::{AccountView, ProgramResult};
 
 ///
 /// Executes on:
@@ -16,9 +17,12 @@ pub fn process_undelegation_callback(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let [delegated_acc, buffer_acc, payer, _system_program, ..] = accounts else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    let [
+        delegated_acc, // force multi-line
+        buffer_acc,
+        payer,
+        _system_program,
+    ] = require_n_accounts_with_ignored!(accounts, 4);
 
     ephemeral_rollups_pinocchio::instruction::undelegate(
         delegated_acc,

--- a/e-token/src/processor/undelegation_callback.rs
+++ b/e-token/src/processor/undelegation_callback.rs
@@ -1,4 +1,4 @@
-use ephemeral_spl_api::require_n_accounts_with_ignored;
+use ephemeral_spl_api::require_n_accounts;
 use pinocchio::{AccountView, ProgramResult};
 
 ///
@@ -22,7 +22,7 @@ pub fn process_undelegation_callback(
         buffer_acc,
         payer,
         _system_program,
-    ] = require_n_accounts_with_ignored!(accounts, 4);
+    ] = require_n_accounts!(accounts, 4);
 
     ephemeral_rollups_pinocchio::instruction::undelegate(
         delegated_acc,

--- a/e-token/src/processor/utils/token.rs
+++ b/e-token/src/processor/utils/token.rs
@@ -1,7 +1,6 @@
+use ephemeral_spl_api::require;
 use pinocchio::{address::address_eq, error::ProgramError, AccountView, Address};
 use pinocchio_token_2022::state::{Mint, TokenAccount};
-
-use crate::assert_owner;
 
 #[inline(always)]
 pub(crate) fn read_mint_decimals(
@@ -9,30 +8,29 @@ pub(crate) fn read_mint_decimals(
     token_program_info: &AccountView,
 ) -> Result<u8, ProgramError> {
     let mint_data = unsafe { mint_info.borrow_unchecked() };
-    if mint_data.len() < Mint::BASE_LEN {
-        return Err(ProgramError::InvalidAccountData);
-    }
-    if !mint_info.owned_by(token_program_info.address()) {
-        return Err(ProgramError::InvalidAccountOwner);
-    }
+    require!(
+        mint_data.len() >= Mint::BASE_LEN,
+        ProgramError::InvalidAccountData
+    );
+    require!(
+        mint_info.owned_by(token_program_info.address()),
+        ProgramError::InvalidAccountOwner
+    );
     let mint = unsafe { Mint::from_bytes_unchecked(mint_data) };
-    if !mint.is_initialized() {
-        return Err(ProgramError::UninitializedAccount);
-    }
+    require!(mint.is_initialized(), ProgramError::UninitializedAccount);
     Ok(mint.decimals())
 }
 
 #[inline(always)]
 pub fn read_token_account(account: &AccountView) -> Result<&TokenAccount, ProgramError> {
     let token_data = unsafe { account.borrow_unchecked() };
-    if token_data.len() < TokenAccount::BASE_LEN {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require!(
+        token_data.len() >= TokenAccount::BASE_LEN,
+        ProgramError::InvalidAccountData
+    );
 
     let token = unsafe { TokenAccount::from_bytes_unchecked(token_data) };
-    if !token.is_initialized() {
-        return Err(ProgramError::UninitializedAccount);
-    }
+    require!(token.is_initialized(), ProgramError::UninitializedAccount);
 
     Ok(token)
 }
@@ -45,17 +43,22 @@ pub(crate) fn validate_token_account<'a>(
     expected_token_program: Option<&Address>,
 ) -> Result<&'a TokenAccount, ProgramError> {
     if let Some(token_program) = expected_token_program {
-        assert_owner!(ata_info, token_program);
+        require!(
+            ata_info.owned_by(token_program),
+            ProgramError::InvalidAccountOwner
+        );
     }
 
     let token = read_token_account(ata_info)?;
-    if !address_eq(token.mint(), expected_mint) {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require!(
+        address_eq(token.mint(), expected_mint),
+        ProgramError::InvalidAccountData
+    );
     if let Some(expected_owner) = expected_owner {
-        if !address_eq(token.owner(), expected_owner) {
-            return Err(ProgramError::IllegalOwner);
-        }
+        require!(
+            address_eq(token.owner(), expected_owner),
+            ProgramError::IllegalOwner
+        );
     }
 
     Ok(token)

--- a/e-token/src/processor/withdraw_spl_tokens.rs
+++ b/e-token/src/processor/withdraw_spl_tokens.rs
@@ -1,4 +1,5 @@
 use core::marker::PhantomData;
+use ephemeral_spl_api::{require, require_n_accounts_with_ignored};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
 use crate::processor::internal::token_vault::withdraw_ephemeral_ata_tokens;
@@ -23,13 +24,17 @@ pub fn process_withdraw_spl_tokens(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let args = WithdrawArgs::try_from_bytes(instruction_data)?;
+    let [
+        owner, // force multi-line
+        ephemeral_ata_info,
+        vault_info,
+        mint_info,
+        vault_source_token_acc,
+        user_dest_token_acc,
+        token_program_info,
+    ] = require_n_accounts_with_ignored!(accounts, 7);
 
-    let [owner, ephemeral_ata_info, vault_info, mint_info, vault_source_token_acc, user_dest_token_acc, token_program_info, ..] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    let args = WithdrawArgs::try_from_bytes(instruction_data)?;
 
     withdraw_ephemeral_ata_tokens(
         owner,
@@ -61,9 +66,7 @@ pub struct WithdrawArgs<'a> {
 impl WithdrawArgs<'_> {
     #[inline]
     pub fn try_from_bytes(bytes: &[u8]) -> Result<WithdrawArgs<'_>, ProgramError> {
-        if bytes.len() != 8 {
-            return Err(ProgramError::InvalidInstructionData);
-        }
+        require!(bytes.len() == 8, ProgramError::InvalidInstructionData);
         Ok(WithdrawArgs {
             raw: bytes.as_ptr(),
             _data: PhantomData,

--- a/e-token/src/processor/withdraw_spl_tokens.rs
+++ b/e-token/src/processor/withdraw_spl_tokens.rs
@@ -1,5 +1,5 @@
 use core::marker::PhantomData;
-use ephemeral_spl_api::{require, require_n_accounts_with_ignored};
+use ephemeral_spl_api::{require, require_n_accounts};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
 use crate::processor::internal::token_vault::withdraw_ephemeral_ata_tokens;
@@ -32,7 +32,7 @@ pub fn process_withdraw_spl_tokens(
         vault_source_token_acc,
         user_dest_token_acc,
         token_program_info,
-    ] = require_n_accounts_with_ignored!(accounts, 7);
+    ] = require_n_accounts!(accounts, 7);
 
     let args = WithdrawArgs::try_from_bytes(instruction_data)?;
 

--- a/e-token/src/processor/withdraw_through_delegated_shuttle_with_merge.rs
+++ b/e-token/src/processor/withdraw_through_delegated_shuttle_with_merge.rs
@@ -1,4 +1,5 @@
 use dlp_api::compact::ClearText;
+use ephemeral_spl_api::require_n_accounts_with_ignored;
 use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 use solana_instruction::{AccountMeta, Instruction};
@@ -63,8 +64,43 @@ pub fn process_withdraw_through_delegated_shuttle_with_merge(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
+    let [
+        payer_info, // force multi-line
+        rent_pda_info,
+        shuttle_info,
+        shuttle_eata_info,
+        shuttle_wallet_ata_info,
+        owner_info,
+        owner_program,
+        buffer_acc,
+        delegation_record,
+        delegation_metadata,
+        _delegation_program,
+        _associated_token_program,
+        system_program,
+        owner_token_info,
+        mint_info,
+        token_program_info,
+    ] = require_n_accounts_with_ignored!(accounts, 16);
+
     let args = DepositAndDelegateShuttleArgs::try_from_bytes(instruction_data)?;
-    let accounts = parse_withdraw_through_delegated_shuttle_accounts(accounts)?;
+
+    let accounts = WithdrawThroughDelegatedShuttleAccounts {
+        payer_info,
+        rent_pda_info,
+        shuttle_info,
+        shuttle_eata_info,
+        shuttle_wallet_ata_info,
+        owner_info,
+        owner_program,
+        buffer_acc,
+        delegation_record,
+        delegation_metadata,
+        system_program,
+        owner_token_info,
+        mint_info,
+        token_program_info,
+    };
 
     let prepared = prepare_sponsored_shuttle_delegation(
         accounts.payer_info,
@@ -140,33 +176,6 @@ pub fn process_withdraw_through_delegated_shuttle_with_merge(
         shuttle_eata.bump,
         post_actions.cleartext(),
     )
-}
-
-fn parse_withdraw_through_delegated_shuttle_accounts(
-    accounts: &[AccountView],
-) -> Result<WithdrawThroughDelegatedShuttleAccounts<'_>, ProgramError> {
-    let [payer_info, rent_pda_info, shuttle_info, shuttle_eata_info, shuttle_wallet_ata_info, owner_info, owner_program, buffer_acc, delegation_record, delegation_metadata, _delegation_program, _associated_token_program, system_program, owner_token_info, mint_info, token_program_info, ..] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
-
-    Ok(WithdrawThroughDelegatedShuttleAccounts {
-        payer_info,
-        rent_pda_info,
-        shuttle_info,
-        shuttle_eata_info,
-        shuttle_wallet_ata_info,
-        owner_info,
-        owner_program,
-        buffer_acc,
-        delegation_record,
-        delegation_metadata,
-        system_program,
-        owner_token_info,
-        mint_info,
-        token_program_info,
-    })
 }
 
 fn transfer_owner_tokens_into_shuttle_action(

--- a/e-token/src/processor/withdraw_through_delegated_shuttle_with_merge.rs
+++ b/e-token/src/processor/withdraw_through_delegated_shuttle_with_merge.rs
@@ -1,5 +1,5 @@
 use dlp_api::compact::ClearText;
-use ephemeral_spl_api::require_n_accounts_with_ignored;
+use ephemeral_spl_api::require_n_accounts;
 use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load};
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 use solana_instruction::{AccountMeta, Instruction};
@@ -81,7 +81,7 @@ pub fn process_withdraw_through_delegated_shuttle_with_merge(
         owner_token_info,
         mint_info,
         token_program_info,
-    ] = require_n_accounts_with_ignored!(accounts, 16);
+    ] = require_n_accounts!(accounts, 16);
 
     let args = DepositAndDelegateShuttleArgs::try_from_bytes(instruction_data)?;
 


### PR DESCRIPTION
- **No breaking changes**
- Standardized requires macros that not only logs values automatically **but the failing expression as well** which will be very useful in debugging. 
- Enforce uniformity, such as accounts destructuring is always the first line in each processor. 

Question:

- ~Are we passing more accounts than needed by processors?~ 
  - ~Based on the existing code, I had to use `require_n_accounts_with_ignored!()` but I want to use the stricter form `require_n_accounts!()`~.