### PR TITLE
chore/fix: review and minor enhancements of swaps instructions

### DIFF
--- a/e-token-api/src/instruction.rs
+++ b/e-token-api/src/instruction.rs
@@ -155,23 +155,9 @@ pub enum ESplInstruction {
     ///      lamports from the global rent PDA.
     ///      Instruction data:
     ///      []        no instruction args
-    ProcessPendingTransferQueueRefill = 28,
+    ExecutePendingTransferQueueRefill = 28,
 
-    /// 29 - ProcessScheduledPrivateTransfer: top-level callback fired by the
-    ///      Hydra scheduler. Permissionless, no signer metas (Hydra forbids
-    ///      them). Re-derives the stash PDA from [b"stash", user, mint] and
-    ///      self-CPIs into instruction 25 using `invoke_signed` so the PDA
-    ///      signs for both the `payer` and `owner` slots.
-    ///      Instruction data:
-    ///      [0..32]  user pubkey (stash PDA seed)
-    ///      [32]     stash PDA bump
-    ///      [33..37] shuttle_id (u32 LE)
-    ///      [37..]   len-prefixed optional validator pubkey
-    ///      [...]    len-prefixed encrypted destination owner pubkey
-    ///      [...]    len-prefixed encrypted packed suffix (same format as ix 25)
-    ProcessScheduledPrivateTransfer = 29,
-
-    /// 30 - SchedulePrivateTransfer: small user-signed ix that creates the
+    /// 29 - SchedulePrivateTransfer: small user-signed ix that creates the
     ///      stash PDA on first use, funds it + a Hydra crank from the global
     ///      rent PDA, and CPIs into `hydra::Create` with a one-shot crank that
     ///      will fire `PROCESS_SCHEDULED_PRIVATE_TRANSFER` as soon as possible.
@@ -202,7 +188,21 @@ pub enum ESplInstruction {
     ///      [47..]   len-prefixed optional validator pubkey (0 or 32)
     ///      [...]    len-prefixed encrypted destination owner pubkey
     ///      [...]    len-prefixed encrypted packed suffix (same format as ix 25)
-    SchedulePrivateTransfer = 30,
+    SchedulePrivateTransfer = 29,
+
+    /// 30 - ProcessScheduledPrivateTransfer: top-level callback fired by the
+    ///      Hydra scheduler. Permissionless, no signer metas (Hydra forbids
+    ///      them). Re-derives the stash PDA from [b"stash", user, mint] and
+    ///      self-CPIs into instruction 25 using `invoke_signed` so the PDA
+    ///      signs for both the `payer` and `owner` slots.
+    ///      Instruction data:
+    ///      [0..32]  user pubkey (stash PDA seed)
+    ///      [32]     stash PDA bump
+    ///      [33..37] shuttle_id (u32 LE)
+    ///      [37..]   len-prefixed optional validator pubkey
+    ///      [...]    len-prefixed encrypted destination owner pubkey
+    ///      [...]    len-prefixed encrypted packed suffix (same format as ix 25)
+    ExecuteScheduledPrivateTransfer = 30,
 }
 
 impl ESplInstruction {
@@ -261,9 +261,9 @@ impl TryFrom<u8> for ESplInstruction {
             25 => Ok(Self::DepositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransfer),
             26 => Ok(Self::WithdrawThroughDelegatedShuttleWithMerge),
             27 => Ok(Self::AllocateTransferQueue),
-            28 => Ok(Self::ProcessPendingTransferQueueRefill),
-            29 => Ok(Self::ProcessScheduledPrivateTransfer),
-            30 => Ok(Self::SchedulePrivateTransfer),
+            28 => Ok(Self::ExecutePendingTransferQueueRefill),
+            29 => Ok(Self::SchedulePrivateTransfer),
+            30 => Ok(Self::ExecuteScheduledPrivateTransfer),
             _ => Err(()),
         }
     }

--- a/e-token/src/entrypoint.rs
+++ b/e-token/src/entrypoint.rs
@@ -199,20 +199,18 @@ fn process_public_instruction(accounts: &[AccountView], instruction_data: &[u8])
 
             process_allocate_transfer_queue(accounts, data)
         }
-        ESplInstruction::ProcessPendingTransferQueueRefill => {
-            debug_log!("Instruction: ProcessPendingTransferQueueRefill");
+        ESplInstruction::ExecutePendingTransferQueueRefill => {
+            debug_log!("Instruction: ExecutePendingTransferQueueRefill");
 
-            process_pending_transfer_queue_refill(accounts, data)
+            process_execute_pending_transfer_queue_refill(accounts, data)
         }
-        ESplInstruction::ProcessScheduledPrivateTransfer => {
-            #[cfg(feature = "logging")]
-            pinocchio_log::log!("Instruction: ProcessScheduledPrivateTransfer");
+        ESplInstruction::ExecuteScheduledPrivateTransfer => {
+            debug_log!("Instruction: ExecuteScheduledPrivateTransfer");
 
-            process_scheduled_private_transfer(accounts, instruction_data)
+            process_execute_scheduled_private_transfer(accounts, instruction_data)
         }
         ESplInstruction::SchedulePrivateTransfer => {
-            #[cfg(feature = "logging")]
-            pinocchio_log::log!("Instruction: SchedulePrivateTransfer");
+            debug_log!("Instruction: SchedulePrivateTransfer");
 
             process_schedule_private_transfer(accounts, instruction_data)
         }

--- a/e-token/src/processor/execute_pending_transfer_queue_refill.rs
+++ b/e-token/src/processor/execute_pending_transfer_queue_refill.rs
@@ -37,7 +37,7 @@ const SPONSORED_LAMPORTS_TRANSFER_CPI_ACCOUNTS: usize = 11;
 /// Instruction Data: None
 ///
 #[inline(never)]
-pub fn process_pending_transfer_queue_refill(
+pub fn process_execute_pending_transfer_queue_refill(
     accounts: &[AccountView],
     _instruction_data: &[u8],
 ) -> ProgramResult {

--- a/e-token/src/processor/execute_scheduled_private_transfer.rs
+++ b/e-token/src/processor/execute_scheduled_private_transfer.rs
@@ -1,5 +1,9 @@
+use alloc::borrow::ToOwned;
+use alloc::vec;
 use alloc::vec::Vec;
 use core::mem::MaybeUninit;
+
+use data_layout::variable_offset_layout;
 use ephemeral_spl_api::instruction::ESplInstruction;
 
 use ephemeral_spl_api::state::stash::StashPda;
@@ -9,19 +13,15 @@ use pinocchio::instruction::{InstructionAccount, InstructionView};
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
 
 use crate::processor::initialize_rent_pda::RENT_PDA;
-use crate::processor::schedule_private_transfer::derive_hydra_seed;
+use crate::processor::internal::derive_hydra_seed;
 use crate::processor::utils::{is_supported_token_program, read_token_account};
+use crate::DepositAndDelegateShuttleWithPrivateTransferArgs;
 
 /// Number of metas forwarded to instruction 25.
 pub(crate) const SCHEDULED_PT_INNER_ACCOUNTS: usize = 19;
 
 /// Total accounts on this top-level instruction (ix 25 layout + Hydra crank).
 pub(crate) const SCHEDULED_PT_ACCOUNTS: usize = SCHEDULED_PT_INNER_ACCOUNTS + 1;
-
-/// Fixed prefix of `instruction_data` injected by `schedule_private_transfer`
-/// when it baked the Hydra-scheduled payload:
-/// `[user_pubkey: 32][stash_pda_bump: 1][shuttle_id: 4]`.
-const PREFIX_LEN: usize = 32 + 1 + 4;
 
 ///
 /// Executes on: BASE only. Top-level, triggered by Hydra.
@@ -61,52 +61,41 @@ const PREFIX_LEN: usize = 32 + 1 + 4;
 ///                                     and Solana's sysvar serializes the
 ///                                     tx-level writable union).
 ///
-/// Instruction data (after the entrypoint strips the discriminator):
-///
-///   00..32 : user pubkey (stash PDA seed)
-///   32..33 : stash PDA bump
-///   33..37 : shuttle_id (u32 LE)
-///   37.... : [len:u8][bytes] optional validator (0 or 32 bytes)
-///   ...... : [len:u8][bytes] encrypted destination
-///   ...... : [len:u8][bytes] encrypted data suffix
+/// Instruction Data: ExecuteScheduledPrivateTransferArgs
 ///
 #[inline(never)]
-pub fn process_scheduled_private_transfer(
+pub fn process_execute_scheduled_private_transfer(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let [stash_payer_info, rent_pda_info, shuttle_info, shuttle_eata_info, shuttle_wallet_ata_info, stash_owner_info, owner_program_info, buffer_info, delegation_record_info, delegation_metadata_info, delegation_program_info, associated_token_program_info, system_program_info, mint_info, token_program_info, global_vault_info, stash_ata_info, vault_token_info, queue_info, hydra_crank_info] =
-        require_n_accounts!(accounts, 20);
+    let [
+        stash_payer_info, // force multi-line
+        rent_pda_info,
+        shuttle_info,
+        shuttle_eata_info,
+        shuttle_wallet_ata_info,
+        stash_owner_info,
+        owner_program_info,
+        buffer_info,
+        delegation_record_info,
+        delegation_metadata_info,
+        delegation_program_info,
+        associated_token_program_info,
+        system_program_info,
+        mint_info,
+        token_program_info,
+        global_vault_info,
+        stash_ata_info,
+        vault_token_info,
+        queue_info,
+        hydra_crank_info
+    ] = require_n_accounts!(accounts, 20);
 
-    require!(
-        instruction_data.len() >= PREFIX_LEN,
-        ProgramError::InvalidInstructionData
-    );
-
-    // -------- parse prefix --------
-    let user = Address::new_from_array(
-        instruction_data[0..32]
-            .try_into()
-            .map_err(|_| ProgramError::InvalidInstructionData)?,
-    );
-    let stash_bump = instruction_data[32];
-    let shuttle_id_bytes = &instruction_data[33..37];
-    let tail = &instruction_data[37..];
-    let mut tail_cursor = 0;
-    let validator_bytes = read_vardata(tail, &mut tail_cursor)?;
-    read_vardata(tail, &mut tail_cursor)?;
-    read_vardata(tail, &mut tail_cursor)?;
-    require!(
-        tail_cursor == tail.len(),
-        ProgramError::InvalidInstructionData
-    );
-    require!(
-        validator_bytes.is_empty() || validator_bytes.len() == 32,
-        ProgramError::InvalidInstructionData
-    );
+    let args = ExecuteScheduledPrivateTransferArgs::decode(instruction_data)?;
 
     // -------- validate stash PDA derivation --------
-    let derived_stash = StashPda::derive_pda(&user, mint_info.address(), stash_bump)?;
+    let derived_stash =
+        StashPda::derive_pda(args.user_address(), mint_info.address(), args.stash_bump())?;
     require_eq_keys!(
         &derived_stash,
         stash_payer_info.address(),
@@ -131,10 +120,7 @@ pub fn process_scheduled_private_transfer(
         hydra_crank_info.owned_by(&Address::new_from_array(hydra_api::ID.to_bytes())),
         ProgramError::InvalidAccountOwner
     );
-    let shuttle_id_arr: [u8; 4] = shuttle_id_bytes
-        .try_into()
-        .map_err(|_| ProgramError::InvalidInstructionData)?;
-    let hydra_seed = derive_hydra_seed(stash_payer_info.address(), &shuttle_id_arr);
+    let hydra_seed = derive_hydra_seed(stash_payer_info.address(), args.shuttle_id());
     let (expected_crank, _) = hydra_api::state::find_crank_pda(&hydra_seed);
     require_eq_keys!(
         &expected_crank,
@@ -156,14 +142,17 @@ pub fn process_scheduled_private_transfer(
     require!(effective_amount != 0, ProgramError::InvalidAccountData);
 
     // -------- build ix 25 instruction data --------
-    //   [25][shuttle_id:4][amount:8][vardata tail]
-    let mut ix_data: Vec<u8> = Vec::with_capacity(1 + 4 + 8 + tail.len());
-    ix_data.push(
-        ESplInstruction::DepositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransfer as u8,
-    );
-    ix_data.extend_from_slice(shuttle_id_bytes);
-    ix_data.extend_from_slice(&effective_amount.to_le_bytes());
-    ix_data.extend_from_slice(tail);
+    let ix_data = ESplInstruction::DepositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransfer
+        .with_data(
+            &DepositAndDelegateShuttleWithPrivateTransferArgs {
+                shuttle_id: args.shuttle_id(),
+                amount: effective_amount,
+                validator: Some(args.validator().to_owned()),
+                encrypted_destination: args.encrypted_destination().to_owned(),
+                encrypted_data_suffix: args.encrypted_data_suffix().to_owned(),
+            }
+            .encode()?,
+        );
 
     // -------- build ix 25 account metas (19) --------
     let mut metas =
@@ -255,8 +244,9 @@ pub fn process_scheduled_private_transfer(
 
     // Single PDA signer authorizes both slot 0 (payer) and slot 5 (owner)
     // because they reference the same stash PDA.
-    let stash_bump_seed = [stash_bump];
-    let stash_signer_seeds = StashPda::signer_seeds(&user, mint_info.address(), &stash_bump_seed);
+    let stash_bump_seed = [args.stash_bump()];
+    let stash_signer_seeds =
+        StashPda::signer_seeds(&args.user_address(), mint_info.address(), &stash_bump_seed);
     let stash_signer = Signer::from(&stash_signer_seeds);
 
     let account_refs: [&AccountView; SCHEDULED_PT_INNER_ACCOUNTS] = [
@@ -288,15 +278,19 @@ pub fn process_scheduled_private_transfer(
     )
 }
 
-#[inline(always)]
-fn read_vardata<'a>(data: &'a [u8], cursor: &mut usize) -> Result<&'a [u8], ProgramError> {
-    require!(*cursor < data.len(), ProgramError::InvalidInstructionData);
-    let len = data[*cursor] as usize;
-    let start = *cursor + 1;
-    let end = start
-        .checked_add(len)
-        .ok_or(ProgramError::InvalidInstructionData)?;
-    require!(end <= data.len(), ProgramError::InvalidInstructionData);
-    *cursor = end;
-    Ok(&data[start..end])
+#[variable_offset_layout(buffer_offset = 1)]
+pub struct ExecuteScheduledPrivateTransferArgs {
+    pub user: [u8; 32],
+    pub stash_bump: u8,
+    pub shuttle_id: u32,
+    pub validator: [u8; 32],
+    pub encrypted_destination: [u8; 80],
+    #[flexible = 1]
+    pub encrypted_data_suffix: Vec<u8>,
+}
+
+impl ExecuteScheduledPrivateTransferArgsView<'_> {
+    fn user_address(&self) -> &Address {
+        unsafe { &*(self.user().as_ptr() as *const Address) }
+    }
 }

--- a/e-token/src/processor/internal/mod.rs
+++ b/e-token/src/processor/internal/mod.rs
@@ -6,3 +6,32 @@ pub(crate) mod transfer_queue_refill;
 
 pub use lamports_pda::AmountAndSaltArgs;
 pub use shuttle_delegation::DepositAndDelegateShuttleArgs;
+
+use pinocchio::{error::ProgramError, Address};
+
+/// seed is created by overwriting the first 4-bytes of stash_pda with shuttle_id bytes
+#[inline(always)]
+pub(crate) fn derive_hydra_seed(stash_pda: &Address, shuttle_id: u32) -> [u8; 32] {
+    let mut seed = *stash_pda.as_array();
+    seed[..4].copy_from_slice(&shuttle_id.to_le_bytes());
+    seed
+}
+
+#[inline(always)]
+pub(crate) fn derive_ata(
+    wallet: &Address,
+    token_program: &Address,
+    mint: &Address,
+    bump_seed: u8,
+) -> Result<Address, ProgramError> {
+    let pda = Address::create_program_address(
+        &[
+            wallet.as_ref(),
+            token_program.as_ref(),
+            mint.as_ref(),
+            &[bump_seed],
+        ],
+        &pinocchio_associated_token_account::ID,
+    )?;
+    Ok(pda)
+}

--- a/e-token/src/processor/mod.rs
+++ b/e-token/src/processor/mod.rs
@@ -12,7 +12,9 @@ pub mod deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transf
 pub mod deposit_and_queue_transfer;
 pub mod deposit_spl_tokens;
 pub mod ensure_transfer_queue_crank;
+pub mod execute_pending_transfer_queue_refill;
 pub mod execute_ready_queued_transfer;
+pub mod execute_scheduled_private_transfer;
 pub mod initialize_ephemeral_ata;
 pub mod initialize_global_vault;
 pub mod initialize_rent_pda;
@@ -21,8 +23,6 @@ pub mod initialize_transfer_queue;
 pub(crate) mod internal;
 pub mod mark_transfer_queue_refill_pending;
 pub mod merge_shuttle_into_ephemeral_ata;
-pub mod pending_transfer_queue_refill;
-pub mod process_scheduled_private_transfer;
 pub mod reset_ephemeral_ata_permission;
 pub mod schedule_private_transfer;
 pub mod sponsored_lamports_transfer;
@@ -60,9 +60,11 @@ pub use deposit_and_queue_transfer::{
 };
 pub use deposit_spl_tokens::process_deposit_spl_tokens;
 pub use ensure_transfer_queue_crank::process_ensure_transfer_queue_crank;
+pub use execute_pending_transfer_queue_refill::process_execute_pending_transfer_queue_refill;
 pub use execute_ready_queued_transfer::{
     process_execute_ready_queued_transfer, ExecuteQueuedTransferArgs,
 };
+pub use execute_scheduled_private_transfer::process_execute_scheduled_private_transfer;
 pub use initialize_ephemeral_ata::process_initialize_ephemeral_ata;
 pub use initialize_global_vault::process_initialize_global_vault;
 pub use initialize_rent_pda::process_initialize_rent_pda;
@@ -72,8 +74,6 @@ pub use initialize_transfer_queue::{
 };
 pub use mark_transfer_queue_refill_pending::process_mark_transfer_queue_refill_pending;
 pub use merge_shuttle_into_ephemeral_ata::process_merge_shuttle_into_ephemeral_ata;
-pub use pending_transfer_queue_refill::process_pending_transfer_queue_refill;
-pub use process_scheduled_private_transfer::process_scheduled_private_transfer;
 pub use reset_ephemeral_ata_permission::process_reset_ephemeral_ata_permission;
 pub use schedule_private_transfer::process_schedule_private_transfer;
 pub use sponsored_lamports_transfer::process_sponsored_lamports_transfer;

--- a/e-token/src/processor/schedule_private_transfer.rs
+++ b/e-token/src/processor/schedule_private_transfer.rs
@@ -1,5 +1,8 @@
+use alloc::borrow::ToOwned;
+use alloc::vec;
 use alloc::vec::Vec;
 
+use data_layout::variable_offset_layout;
 use ephemeral_rollups_pinocchio::consts::{
     BUFFER, DELEGATION_METADATA, DELEGATION_PROGRAM_ID, DELEGATION_RECORD,
 };
@@ -21,11 +24,12 @@ use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
 use pinocchio_system::instructions::Transfer;
 use solana_pubkey::Pubkey;
 
+use crate::processor::execute_scheduled_private_transfer::{
+    ExecuteScheduledPrivateTransferArgs, SCHEDULED_PT_ACCOUNTS,
+};
 use crate::processor::initialize_rent_pda::{RENT_PDA, RENT_PDA_BUMP, RENT_PDA_SEED};
-use crate::processor::process_scheduled_private_transfer::SCHEDULED_PT_ACCOUNTS;
+use crate::processor::internal::{derive_ata, derive_hydra_seed};
 use crate::processor::utils::is_supported_token_program;
-
-const FIXED_PREFIX_LEN: usize = 4 + 1 + 32 + 10;
 
 const SETUP_LAMPORTS: u64 = ephemeral_spl_api::consts::SPONSORED_SHUTTLE_DELEGATION_SETUP_LAMPORTS
     + ephemeral_spl_api::consts::SPONSORED_SHUTTLE_PRIVATE_TRANSFER_EXTRA_LAMPORTS;
@@ -52,17 +56,7 @@ const SETUP_LAMPORTS: u64 = ephemeral_spl_api::consts::SPONSORED_SHUTTLE_DELEGAT
 ///  5: []                  - Builtin : System program.
 ///  6: []                  - SPL     : Token program (Token / Token-2022) used as an ATA seed.
 ///
-/// Instruction data (47 B fixed prefix + 3 vardata):
-///
-///   00..04  shuttle_id (u32 LE)
-///   04      stash_pda_bump
-///   05..37  mint (32 B)
-///   37..47  10 bumps: shuttle, shuttle_eata, shuttle_wallet_ata, buffer,
-///           delegation_record, delegation_metadata, global_vault,
-///           vault_token, stash_ata, queue.
-///   47..    [len:u8] validator pubkey (0 or 32 bytes)
-///   ....    [len:u8] encrypted destination (pass-through to ix 25)
-///   ....    [len:u8] encrypted data suffix (pass-through to ix 25)
+/// Instruction Data: SchedulePrivateTransferArgs
 ///
 #[inline(never)]
 pub fn process_schedule_private_transfer(
@@ -79,55 +73,10 @@ pub fn process_schedule_private_transfer(
         token_program_info,
     ] = require_n_accounts!(accounts, 7);
 
-    require!(
-        instruction_data.len() >= FIXED_PREFIX_LEN,
-        ProgramError::InvalidInstructionData
-    );
+    let args = SchedulePrivateTransferArgs::decode(instruction_data)?;
 
-    let shuttle_id_bytes: [u8; 4] = instruction_data[0..4]
-        .try_into()
-        .map_err(|_| ProgramError::InvalidInstructionData)?;
-    let stash_bump = instruction_data[4];
-    let mint = Address::new_from_array(
-        instruction_data[5..37]
-            .try_into()
-            .map_err(|_| ProgramError::InvalidInstructionData)?,
-    );
-    let shuttle_bump = instruction_data[37];
-    let shuttle_eata_bump = instruction_data[38];
-    let shuttle_wallet_ata_bump = instruction_data[39];
-    let buffer_bump = instruction_data[40];
-    let delegation_record_bump = instruction_data[41];
-    let delegation_metadata_bump = instruction_data[42];
-    let global_vault_bump = instruction_data[43];
-    let vault_token_bump = instruction_data[44];
-    let stash_ata_bump = instruction_data[45];
-    let queue_bump = instruction_data[46];
-
-    let mut cursor = FIXED_PREFIX_LEN;
-    let validator_bytes = read_vardata(instruction_data, &mut cursor)?;
-    read_vardata(instruction_data, &mut cursor)?;
-    read_vardata(instruction_data, &mut cursor)?;
-    require!(
-        cursor == instruction_data.len(),
-        ProgramError::InvalidInstructionData
-    );
-
-    require!(
-        validator_bytes.is_empty() || validator_bytes.len() == 32,
-        ProgramError::InvalidInstructionData
-    );
-    let validator = if validator_bytes.is_empty() {
-        Address::default()
-    } else {
-        Address::new_from_array(
-            validator_bytes
-                .try_into()
-                .map_err(|_| ProgramError::InvalidInstructionData)?,
-        )
-    };
-
-    let derived_stash = StashPda::derive_pda(user_info.address(), &mint, stash_bump)?;
+    let derived_stash =
+        StashPda::derive_pda(user_info.address(), args.mint_address(), args.stash_bump())?;
     require_eq_keys!(
         &derived_stash,
         stash_pda_info.address(),
@@ -158,22 +107,27 @@ pub fn process_schedule_private_transfer(
 
     let shuttle = ShuttleMetadata::derive_pda(
         stash_pda_info.address(),
-        &mint,
-        u32::from_le_bytes(shuttle_id_bytes),
-        shuttle_bump,
+        args.mint_address(),
+        args.shuttle_id(),
+        args.shuttle_bump(),
     )?;
-    let shuttle_eata = EphemeralAta::derive_pda(&shuttle, &mint, shuttle_eata_bump)?;
-    let shuttle_wallet_ata =
-        derive_ata(&shuttle, &token_program_id, &mint, shuttle_wallet_ata_bump)?;
+    let shuttle_eata =
+        EphemeralAta::derive_pda(&shuttle, args.mint_address(), args.shuttle_eata_bump())?;
+    let shuttle_wallet_ata = derive_ata(
+        &shuttle,
+        &token_program_id,
+        args.mint_address(),
+        args.shuttle_wallet_ata_bump(),
+    )?;
     let buffer = Address::create_program_address(
-        &[BUFFER, shuttle_eata.as_ref(), &[buffer_bump]],
+        &[BUFFER, shuttle_eata.as_ref(), &[args.buffer_bump()]],
         &crate::ID,
     )?;
     let delegation_record = Address::create_program_address(
         &[
             DELEGATION_RECORD,
             shuttle_eata.as_ref(),
-            &[delegation_record_bump],
+            &[args.delegation_record_bump()],
         ],
         &DELEGATION_PROGRAM_ID,
     )?;
@@ -181,19 +135,28 @@ pub fn process_schedule_private_transfer(
         &[
             DELEGATION_METADATA,
             shuttle_eata.as_ref(),
-            &[delegation_metadata_bump],
+            &[args.delegation_metadata_bump()],
         ],
         &DELEGATION_PROGRAM_ID,
     )?;
-    let global_vault = GlobalVault::derive_pda(&mint, global_vault_bump)?;
-    let vault_token = derive_ata(&global_vault, &token_program_id, &mint, vault_token_bump)?;
+    let global_vault = GlobalVault::derive_pda(args.mint_address(), args.global_vault_bump())?;
+    let vault_token = derive_ata(
+        &global_vault,
+        &token_program_id,
+        args.mint_address(),
+        args.vault_token_bump(),
+    )?;
     let stash_ata = derive_ata(
         stash_pda_info.address(),
         &token_program_id,
-        &mint,
-        stash_ata_bump,
+        args.mint_address(),
+        args.stash_ata_bump(),
     )?;
-    let queue = TransferQueue::derive_pda(&mint, &validator, queue_bump)?;
+    let queue = TransferQueue::derive_pda(
+        &args.mint_address(),
+        args.validator_address(),
+        args.queue_bump(),
+    )?;
 
     // Slots 0..19 mirror ix 25's layout. Slot 5 aliases slot 0 (stash PDA)
     // and slot 19 aliases Trigger's crank account; the flag must match
@@ -212,7 +175,7 @@ pub fn process_schedule_private_transfer(
         (&DELEGATION_PROGRAM_ID, false),
         (&pinocchio_associated_token_account::ID, false),
         (system_program_info.address(), false),
-        (&mint, false),
+        (&args.mint_address(), false),
         (&token_program_id, false),
         (&global_vault, false),
         (&stash_ata, true),
@@ -221,17 +184,8 @@ pub fn process_schedule_private_transfer(
         (hydra_crank_pda_info.address(), true),
     ];
 
-    let vardata_tail = &instruction_data[FIXED_PREFIX_LEN..cursor];
-    let scheduled_data_len = 1 + 32 + 1 + 4 + vardata_tail.len();
-    let mut scheduled_data: Vec<u8> = Vec::with_capacity(scheduled_data_len);
-    scheduled_data.push(ESplInstruction::ProcessScheduledPrivateTransfer as u8);
-    scheduled_data.extend_from_slice(user_info.address().as_ref());
-    scheduled_data.push(stash_bump);
-    scheduled_data.extend_from_slice(&shuttle_id_bytes);
-    scheduled_data.extend_from_slice(vardata_tail);
-
     let hydra_program_id = Address::new_from_array(hydra_api::ID.to_bytes());
-    let hydra_seed = derive_hydra_seed(stash_pda_info.address(), &shuttle_id_bytes);
+    let hydra_seed = derive_hydra_seed(stash_pda_info.address(), args.shuttle_id());
     let (derived_crank_pda, _) = hydra_api::state::find_crank_pda(&hydra_seed);
     require_eq_keys!(
         &derived_crank_pda,
@@ -263,7 +217,17 @@ pub fn process_schedule_private_transfer(
             cu_limit: 0,
             scheduled_program_id: Pubkey::new_from_array(*crate::ID.as_array()),
             scheduled_metas: &sched_metas_vec,
-            scheduled_data: &scheduled_data,
+            scheduled_data: &ESplInstruction::ExecuteScheduledPrivateTransfer.with_data(
+                &ExecuteScheduledPrivateTransferArgs {
+                    user: user_info.address().to_bytes(),
+                    stash_bump: args.stash_bump(),
+                    shuttle_id: args.shuttle_id(),
+                    validator: args.validator().to_owned(),
+                    encrypted_destination: args.encrypted_destination().to_owned(),
+                    encrypted_data_suffix: args.encrypted_data_suffix().to_owned(),
+                }
+                .encode()?,
+            ),
         },
     );
 
@@ -292,41 +256,32 @@ pub fn process_schedule_private_transfer(
     Ok(())
 }
 
-#[inline(always)]
-pub(crate) fn derive_hydra_seed(stash_pda: &Address, shuttle_id_bytes: &[u8; 4]) -> [u8; 32] {
-    let mut seed = *stash_pda.as_array();
-    seed[..4].copy_from_slice(shuttle_id_bytes);
-    seed
+#[variable_offset_layout(buffer_offset = 1)]
+pub struct SchedulePrivateTransferArgs {
+    pub shuttle_id: u32,
+    pub stash_bump: u8,
+    pub mint: [u8; 32],
+    pub shuttle_bump: u8,
+    pub shuttle_eata_bump: u8,
+    pub shuttle_wallet_ata_bump: u8,
+    pub buffer_bump: u8,
+    pub delegation_record_bump: u8,
+    pub delegation_metadata_bump: u8,
+    pub global_vault_bump: u8,
+    pub vault_token_bump: u8,
+    pub stash_ata_bump: u8,
+    pub queue_bump: u8,
+    pub validator: [u8; 32],
+    pub encrypted_destination: [u8; 80],
+    #[flexible = 1]
+    pub encrypted_data_suffix: Vec<u8>,
 }
 
-#[inline(always)]
-fn derive_ata(
-    wallet: &Address,
-    token_program: &Address,
-    mint: &Address,
-    bump_seed: u8,
-) -> Result<Address, ProgramError> {
-    let pda = Address::create_program_address(
-        &[
-            wallet.as_ref(),
-            token_program.as_ref(),
-            mint.as_ref(),
-            &[bump_seed],
-        ],
-        &pinocchio_associated_token_account::ID,
-    )?;
-    Ok(pda)
-}
-
-#[inline(always)]
-fn read_vardata<'a>(data: &'a [u8], cursor: &mut usize) -> Result<&'a [u8], ProgramError> {
-    require!(*cursor < data.len(), ProgramError::InvalidInstructionData);
-    let len = data[*cursor] as usize;
-    let start = *cursor + 1;
-    let end = start
-        .checked_add(len)
-        .ok_or(ProgramError::InvalidInstructionData)?;
-    require!(end <= data.len(), ProgramError::InvalidInstructionData);
-    *cursor = end;
-    Ok(&data[start..end])
+impl SchedulePrivateTransferArgsView<'_> {
+    fn validator_address(&self) -> &Address {
+        unsafe { &*(self.validator().as_ptr() as *const Address) }
+    }
+    fn mint_address(&self) -> &Address {
+        unsafe { &*(self.mint().as_ptr() as *const Address) }
+    }
 }


### PR DESCRIPTION
- Use `variable_offset_layout` to define the instruction data types.
- Fix: In `process_schedule_private_transfer()`, `validator` is supposed to be an **optional** argument, but the way the instruction uses it, makes it **mandatory**. So this PR makes it mandatory and consequently, I made this mandatory in the next instruction as well.
- Reordered: `SchedulePrivateTransfer` gets `29` and `ProcessScheduledPrivateTransfer gets `30`. Also, renamed `ProcessScheduledPrivateTransfer` to `ExecuteScheduledPrivateTransfer` to have consistent _processors_ naming.

Compatible changes are made in SDK (TS) as well: https://github.com/magicblock-labs/ephemeral-rollups-sdk/pull/208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Remapped instruction discriminants for pending transfer queue refill and scheduled private transfer operations.
  * Refactored instruction argument parsing to use typed structures instead of manual byte parsing, improving type safety and validation logic.
  * Added internal helper functions for PDA derivation and hydra seed generation to support refactored instruction processors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->