### PR TITLE
feat: support bool in variable_offset_layout

### DIFF
--- a/data-layout/src/lib.rs
+++ b/data-layout/src/lib.rs
@@ -192,6 +192,14 @@ pub fn fixed_offset_layout(attr: TokenStream, item: TokenStream) -> TokenStream 
 ///         more implicit options later may force the layout to stop being
 ///         representable as `option = implicit`.
 ///
+/// Supported field kinds:
+///
+///   - Plain `bool` and `Option<bool>` are supported.
+///     They are encoded as a single backing `u8` byte where `0` means
+///     `false` and any non-zero byte decodes as `true`.
+///   - `Vec<bool>` is intentionally not supported by `variable_offset_layout`
+///     because its current view API exposes borrowed slices for Vec fields.
+///
 /// Field attributes:
 ///   - #[flexible = 1|2]
 ///

--- a/data-layout/src/variable_layout.rs
+++ b/data-layout/src/variable_layout.rs
@@ -131,8 +131,15 @@ pub(crate) fn expand_variable_offset_layout(
     let implicit_len_validation =
         implicit_len_validation(struct_name, min_datalen, &fields.named, &field_layouts)?;
 
-    let public_len_const = public_len_const(min_datalen_expr.clone(), min_datalen, max_datalen_expr.clone(), max_datalen, &field_layouts)?;
-    let data_len_validation = data_len_validation(struct_name, min_datalen, max_datalen, &field_layouts)?;
+    let public_len_const = public_len_const(
+        min_datalen_expr.clone(),
+        min_datalen,
+        max_datalen_expr.clone(),
+        max_datalen,
+        &field_layouts,
+    )?;
+    let data_len_validation =
+        data_len_validation(struct_name, min_datalen, max_datalen, &field_layouts)?;
 
     Ok(quote! {
         #emitted_input
@@ -273,6 +280,7 @@ enum AccessMode {
 
 #[derive(Clone)]
 enum FixedValueKind {
+    Bool { ty: Type },
     Integer { ty: Type, size: usize, align: usize },
     Array { ty: Type, size: usize, align: usize },
 }
@@ -280,18 +288,20 @@ enum FixedValueKind {
 impl FixedValueKind {
     fn ty(&self) -> &Type {
         match self {
-            Self::Integer { ty, .. } | Self::Array { ty, .. } => ty,
+            Self::Bool { ty } | Self::Integer { ty, .. } | Self::Array { ty, .. } => ty,
         }
     }
 
     fn size(&self) -> usize {
         match self {
+            Self::Bool { .. } => 1,
             Self::Integer { size, .. } | Self::Array { size, .. } => *size,
         }
     }
 
     fn align(&self) -> usize {
         match self {
+            Self::Bool { .. } => 1,
             Self::Integer { align, .. } | Self::Array { align, .. } => *align,
         }
     }
@@ -499,23 +509,23 @@ impl FieldLayout {
                     OptionalKind::Implicit(bit_index) => {
                         let bit_index = usize_lit(*bit_index);
                         quote! {
-                        if #struct_name::__implicit_option_present_for_len(bytes.len(), #bit_index) {
-                            let data_offset = offset;
-                            #alignment_check
-                            let end = data_offset + #value_size;
-                            if end > bytes.len() {
-                                pinocchio_log::log!(
-                                    "Truncated payload for field {}: need {} bytes, have {}",
-                                    #field_name,
-                                    end,
-                                    bytes.len(),
-                                );
-                                return Err(pinocchio::error::ProgramError::InvalidInstructionData);
+                            if #struct_name::__implicit_option_present_for_len(bytes.len(), #bit_index) {
+                                let data_offset = offset;
+                                #alignment_check
+                                let end = data_offset + #value_size;
+                                if end > bytes.len() {
+                                    pinocchio_log::log!(
+                                        "Truncated payload for field {}: need {} bytes, have {}",
+                                        #field_name,
+                                        end,
+                                        bytes.len(),
+                                    );
+                                    return Err(pinocchio::error::ProgramError::InvalidInstructionData);
+                                }
+                                offset = end;
                             }
-                            offset = end;
                         }
                     }
-                    },
                 }
             }
             Self::Vec { elem, flexible } => {
@@ -584,28 +594,54 @@ impl FieldLayout {
             Self::Value { value, optional } => {
                 let value_size = usize_lit(value.size());
                 match optional {
-                    OptionalKind::No => quote! {
-                        bytes[offset..offset + #value_size]
-                            .copy_from_slice(bytemuck::bytes_of(&self.#field_ident));
-                        offset += #value_size;
-                    },
-                    OptionalKind::Tagged => quote! {
-                        if let core::option::Option::Some(value) = &self.#field_ident {
-                            bytes[offset] = 1;
-                            bytes[offset + 1..offset + 1 + #value_size]
-                                .copy_from_slice(bytemuck::bytes_of(value));
-                            offset += 1 + #value_size;
-                        } else {
-                            bytes[offset] = 0;
+                    OptionalKind::No => match value {
+                        FixedValueKind::Bool { .. } => quote! {
+                            bytes[offset] = u8::from(self.#field_ident);
                             offset += 1;
-                        }
-                    },
-                    OptionalKind::Implicit(_) => quote! {
-                        if let core::option::Option::Some(value) = &self.#field_ident {
+                        },
+                        _ => quote! {
                             bytes[offset..offset + #value_size]
-                                .copy_from_slice(bytemuck::bytes_of(value));
+                                .copy_from_slice(bytemuck::bytes_of(&self.#field_ident));
                             offset += #value_size;
-                        }
+                        },
+                    },
+                    OptionalKind::Tagged => match value {
+                        FixedValueKind::Bool { .. } => quote! {
+                            if let core::option::Option::Some(value) = &self.#field_ident {
+                                bytes[offset] = 1;
+                                bytes[offset + 1] = u8::from(*value);
+                                offset += 2;
+                            } else {
+                                bytes[offset] = 0;
+                                offset += 1;
+                            }
+                        },
+                        _ => quote! {
+                            if let core::option::Option::Some(value) = &self.#field_ident {
+                                bytes[offset] = 1;
+                                bytes[offset + 1..offset + 1 + #value_size]
+                                    .copy_from_slice(bytemuck::bytes_of(value));
+                                offset += 1 + #value_size;
+                            } else {
+                                bytes[offset] = 0;
+                                offset += 1;
+                            }
+                        },
+                    },
+                    OptionalKind::Implicit(_) => match value {
+                        FixedValueKind::Bool { .. } => quote! {
+                            if let core::option::Option::Some(value) = &self.#field_ident {
+                                bytes[offset] = u8::from(*value);
+                                offset += 1;
+                            }
+                        },
+                        _ => quote! {
+                            if let core::option::Option::Some(value) = &self.#field_ident {
+                                bytes[offset..offset + #value_size]
+                                    .copy_from_slice(bytemuck::bytes_of(value));
+                                offset += #value_size;
+                            }
+                        },
                     },
                 }
             }
@@ -916,22 +952,22 @@ impl FieldLayout {
                     (OptionalKind::Implicit(bit_index), AccessMode::Copy) => {
                         let bit_index = usize_lit(bit_index);
                         Ok(quote! {
-                        pub fn #field_ident(&self) -> core::option::Option<#ty> {
-                            let offset = #offset_expr;
-                            #struct_name::__implicit_option_present_for_len(self.bytes.len(), #bit_index)
-                                .then(|| #return_expr)
-                        }
-                    })
+                            pub fn #field_ident(&self) -> core::option::Option<#ty> {
+                                let offset = #offset_expr;
+                                #struct_name::__implicit_option_present_for_len(self.bytes.len(), #bit_index)
+                                    .then(|| #return_expr)
+                            }
+                        })
                     }
                     (OptionalKind::Implicit(bit_index), AccessMode::Ref) => {
                         let bit_index = usize_lit(bit_index);
                         Ok(quote! {
-                        pub fn #field_ident(&self) -> core::option::Option<&#ty> {
-                            let offset = #offset_expr;
-                            #struct_name::__implicit_option_present_for_len(self.bytes.len(), #bit_index)
-                                .then(|| #return_expr)
-                        }
-                    })
+                            pub fn #field_ident(&self) -> core::option::Option<&#ty> {
+                                let offset = #offset_expr;
+                                #struct_name::__implicit_option_present_for_len(self.bytes.len(), #bit_index)
+                                    .then(|| #return_expr)
+                            }
+                        })
                     }
                 }
             }
@@ -979,6 +1015,12 @@ fn parse_field_layout(
     let attribute = parse_field_attr(field)?;
 
     if let Some(elem_ty) = vec_inner(ty)? {
+        if is_bool(elem_ty) {
+            return Err(syn::Error::new_spanned(
+                field,
+                "Vec<bool> is not supported by variable_offset_layout",
+            ));
+        }
         let attribute = attribute.ok_or_else(|| {
             syn::Error::new_spanned(
                 field,
@@ -1049,6 +1091,10 @@ fn parse_field_layout(
 }
 
 fn parse_value_kind(ty: &Type) -> syn::Result<FixedValueKind> {
+    if is_bool(ty) {
+        return Ok(FixedValueKind::Bool { ty: ty.clone() });
+    }
+
     if let Some((size, align)) = integer_size_and_align(ty) {
         return Ok(FixedValueKind::Integer {
             ty: ty.clone(),
@@ -1892,6 +1938,15 @@ fn is_string(ty: &Type) -> bool {
         && type_path.path.segments[0].ident == "String"
 }
 
+fn is_bool(ty: &Type) -> bool {
+    let Type::Path(type_path) = ty else {
+        return false;
+    };
+    type_path.qself.is_none()
+        && type_path.path.segments.len() == 1
+        && type_path.path.segments[0].ident == "bool"
+}
+
 fn usize_lit(value: usize) -> LitInt {
     LitInt::new(&value.to_string(), Span::call_site())
 }
@@ -1915,7 +1970,7 @@ fn fixed_array_size_and_align(ty: &Type) -> syn::Result<(usize, usize)> {
     let Type::Array(array) = ty else {
         return Err(syn::Error::new_spanned(
             ty,
-            "variable_offset_layout fields must be integer primitives or fixed-size arrays",
+            "variable_offset_layout fields must be bool, integer primitives, or fixed-size arrays of integer primitives",
         ));
     };
 
@@ -1944,6 +1999,7 @@ fn read_copy_expr(
     bytes_expr: proc_macro2::TokenStream,
 ) -> syn::Result<proc_macro2::TokenStream> {
     match value {
+        FixedValueKind::Bool { .. } => Ok(quote!((#bytes_expr)[0] != 0)),
         FixedValueKind::Integer { ty, .. } => parse_integer_expr(ty, bytes_expr),
         FixedValueKind::Array { ty, .. } => Ok(quote! {
             unsafe { core::ptr::read_unaligned((#bytes_expr).as_ptr().cast::<#ty>()) }
@@ -1958,7 +2014,7 @@ fn parse_integer_expr(
     let Some(name) = integer_primitive_name(ty) else {
         return Err(syn::Error::new_spanned(
             ty,
-            "field must be an integer primitive",
+            "field must be an integer primitive or bool",
         ));
     };
     let ty_tokens = ty.to_token_stream();
@@ -2332,6 +2388,21 @@ mod tests {
             .to_string();
         assert!(error.contains("field `values` cannot expose a slice view"));
         assert!(error.contains("element 0 would start at offset 2"));
+    }
+
+    #[test]
+    fn variable_offset_layout_rejects_vec_bool() {
+        let item: syn::ItemStruct = parse_quote! {
+            struct Args {
+                #[flexible = 1]
+                values: Vec<bool>,
+            }
+        };
+
+        let error = expand_variable_offset_layout("buffer_offset = 0", &item)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("Vec<bool> is not supported by variable_offset_layout"));
     }
 
     #[test]

--- a/data-layout/tests/test_variable_layout.rs
+++ b/data-layout/tests/test_variable_layout.rs
@@ -316,6 +316,37 @@ fn variable_layout_buffer_offset_one_allows_unaligned_copy_only_views() {
     assert_eq!(view.counter(), 7);
 }
 
+#[variable_offset_layout(buffer_offset = 0)]
+struct BoolArgs {
+    enabled: bool,
+    sponsored: Option<bool>,
+    amount: u16,
+}
+
+#[test]
+fn variable_layout_supports_bool_and_tagged_option_bool() {
+    assert_eq!(BoolArgs::DATA_LENS, [4, 5]);
+
+    let none_bytes = [2, 0, 9, 0].to_vec();
+    let none_view = BoolArgs::decode(&none_bytes).unwrap();
+    assert_eq!(none_view.enabled(), true);
+    assert_eq!(none_view.sponsored(), None);
+    assert_eq!(none_view.amount(), 9);
+
+    let some_bytes = [7, 1, 3, 9, 0].to_vec();
+    let some_view = BoolArgs::decode(&some_bytes).unwrap();
+    assert_eq!(some_view.enabled(), true);
+    assert_eq!(some_view.sponsored(), Some(true));
+    assert_eq!(some_view.amount(), 9);
+
+    let value = BoolArgs {
+        enabled: true,
+        sponsored: Some(true),
+        amount: 9,
+    };
+    assert_eq!(value.encode().unwrap(), vec![1, 1, 1, 9, 0]);
+}
+
 #[variable_offset_layout(buffer_offset = 0, option = implicit)]
 struct ImplicitOptionArgs {
     shuttle_id: u32,
@@ -489,4 +520,36 @@ fn variable_layout_supports_multiple_implicit_options_with_unique_subset_sums() 
     let both_view = MultiImplicitOptionArgs::decode(&both_encoded).unwrap();
     assert_eq!(both_view.flags(), Some(7));
     assert_eq!(both_view.client_ref_id(), Some(99));
+}
+
+#[variable_offset_layout(buffer_offset = 0, option = implicit)]
+struct ImplicitBoolArgs {
+    amount: u16,
+    gasless: Option<bool>,
+    split: u8,
+}
+
+#[test]
+fn variable_layout_supports_implicit_option_bool() {
+    assert_eq!(ImplicitBoolArgs::DATA_LENS, [3, 4]);
+
+    let none_value = ImplicitBoolArgs {
+        amount: 11,
+        gasless: None,
+        split: 2,
+    };
+    let some_value = ImplicitBoolArgs {
+        amount: 11,
+        gasless: Some(true),
+        split: 2,
+    };
+
+    assert_eq!(none_value.encode().unwrap(), vec![11, 0, 2]);
+    assert_eq!(some_value.encode().unwrap(), vec![11, 0, 1, 2]);
+
+    let some_nonzero_bytes = vec![11, 0, 9, 2];
+    let some_view = ImplicitBoolArgs::decode(&some_nonzero_bytes).unwrap();
+    assert_eq!(some_view.amount(), 11);
+    assert_eq!(some_view.gasless(), Some(true));
+    assert_eq!(some_view.split(), 2);
 }


### PR DESCRIPTION
This allows us to use `bool` field in our zero-copy types, with a backing `u8`, in well-defined manner.