### PR TITLE
feat: close stash ata

### DIFF
--- a/e-token-api/src/instruction.rs
+++ b/e-token-api/src/instruction.rs
@@ -207,12 +207,9 @@ pub enum ESplInstruction {
     ExecuteScheduledPrivateTransfer = 30,
 
     /// 31 - DepositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransferAndStashClose:
-    ///      identical wire to ix 25 with an extra fixed `stash_close_seeds: [u8; 33]`
-    ///      appended just before `encrypted_data_suffix`. Only emitted from inside
-    ///      the program by `ExecuteScheduledPrivateTransfer` (self-CPI). Signals that
-    ///      the source token account (a stash ATA) and its authority PDA must be
-    ///      closed and refunded to the rent PDA after the post-undelegate settlement
-    ///      runs. Layout of `stash_close_seeds`: `[user(32) | stash_bump(1)]`.
+    ///      ix 25 + a fixed `stash_close_seeds: [user(32) | stash_bump(1)]` appended
+    ///      before `encrypted_data_suffix`. Self-CPI'd by `ExecuteScheduledPrivateTransfer`.
+    ///      Triggers stash ATA + stash PDA refund to the rent PDA after settlement.
     DepositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransferAndStashClose = 31,
 }
 

--- a/e-token-api/src/instruction.rs
+++ b/e-token-api/src/instruction.rs
@@ -205,6 +205,15 @@ pub enum ESplInstruction {
     ///      [...]    len-prefixed encrypted destination owner pubkey
     ///      [...]    len-prefixed encrypted packed suffix (same format as ix 25)
     ExecuteScheduledPrivateTransfer = 30,
+
+    /// 31 - DepositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransferAndStashClose:
+    ///      identical wire to ix 25 with an extra fixed `stash_close_seeds: [u8; 33]`
+    ///      appended just before `encrypted_data_suffix`. Only emitted from inside
+    ///      the program by `ExecuteScheduledPrivateTransfer` (self-CPI). Signals that
+    ///      the source token account (a stash ATA) and its authority PDA must be
+    ///      closed and refunded to the rent PDA after the post-undelegate settlement
+    ///      runs. Layout of `stash_close_seeds`: `[user(32) | stash_bump(1)]`.
+    DepositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransferAndStashClose = 31,
 }
 
 impl ESplInstruction {
@@ -266,6 +275,9 @@ impl TryFrom<u8> for ESplInstruction {
             28 => Ok(Self::ExecutePendingTransferQueueRefill),
             29 => Ok(Self::SchedulePrivateTransfer),
             30 => Ok(Self::ExecuteScheduledPrivateTransfer),
+            31 => Ok(
+                Self::DepositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransferAndStashClose,
+            ),
             _ => Err(()),
         }
     }

--- a/e-token/src/entrypoint.rs
+++ b/e-token/src/entrypoint.rs
@@ -154,6 +154,15 @@ fn process_public_instruction(accounts: &[AccountView], instruction_data: &[u8])
                 accounts, data,
             )
         }
+        ESplInstruction::DepositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransferAndStashClose => {
+            debug_log!(
+                "Instruction: DepositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransferAndStashClose"
+            );
+
+            process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer_and_stash_close(
+                accounts, data,
+            )
+        }
         ESplInstruction::WithdrawThroughDelegatedShuttleWithMerge => {
             debug_log!("Instruction: WithdrawThroughDelegatedShuttleWithMerge");
 

--- a/e-token/src/lib.rs
+++ b/e-token/src/lib.rs
@@ -10,6 +10,7 @@ pub use ephemeral_spl_api::ID;
 
 pub use processor::{
     AmountAndSaltArgs, DelegateArgs, DelegateShuttleArgs, DepositAndDelegateShuttleArgs,
+    DepositAndDelegateShuttleWithPrivateTransferAndStashCloseArgs,
     DepositAndDelegateShuttleWithPrivateTransferArgs, DepositAndQueueTransferArgs,
     ExecuteQueuedTransferArgs, InitializeTransferQueueArgs,
 };

--- a/e-token/src/processor/close_shuttle_ata_intent.rs
+++ b/e-token/src/processor/close_shuttle_ata_intent.rs
@@ -264,10 +264,9 @@ fn close_empty_stash_after_settlement(
         ProgramError::InvalidSeeds
     );
 
-    // SAFETY: `&[u8; 32]` and `&Address` share the same in-memory layout.
-    let user_address: &Address = unsafe { &*(user.as_ptr() as *const Address) };
+    let user_address = Address::new_from_array(*user);
 
-    let derived_stash_pda = StashPda::derive_pda(user_address, mint_info.address(), stash_bump)?;
+    let derived_stash_pda = StashPda::derive_pda(&user_address, mint_info.address(), stash_bump)?;
     require_eq_keys!(
         &derived_stash_pda,
         stash_pda_info.address(),
@@ -294,7 +293,7 @@ fn close_empty_stash_after_settlement(
     require!(token_account.amount() == 0, ProgramError::InvalidArgument);
 
     let bump_seed = [stash_bump];
-    let stash_signer_seeds = StashPda::signer_seeds(user_address, mint_info.address(), &bump_seed);
+    let stash_signer_seeds = StashPda::signer_seeds(&user_address, mint_info.address(), &bump_seed);
     let stash_signer = Signer::from(&stash_signer_seeds);
 
     CloseAccount {

--- a/e-token/src/processor/close_shuttle_ata_intent.rs
+++ b/e-token/src/processor/close_shuttle_ata_intent.rs
@@ -1,15 +1,22 @@
+use crate::processor::initialize_rent_pda::RENT_PDA;
 use crate::processor::internal::token_vault::withdraw_ephemeral_ata_tokens;
-use crate::processor::utils::validate_token_account;
+use crate::processor::utils::{get_associated_token_address, validate_token_account};
 use ephemeral_spl_api::state::ephemeral_ata::EphemeralAta;
+use ephemeral_spl_api::state::stash::StashPda;
 use ephemeral_spl_api::state::{
     ephemeral_ata::read_ephemeral_ata_compat, load_initialized,
     shuttle_ephemeral_ata::ShuttleMetadata,
 };
 use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts, require_some};
 use pinocchio::cpi::Signer;
-use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
+use pinocchio_system::instructions::Transfer;
 use pinocchio_token_2022::instructions::CloseAccount;
 const DLP_EPHEMERAL_BALANCE_TAG: &[u8] = b"balance";
+
+/// Length of the optional close-stash payload appended to the ix data:
+/// 32 bytes user pubkey + 1 byte stash bump.
+const CLOSE_STASH_DATA_LEN: usize = 33;
 
 ///
 /// Executes on:
@@ -29,12 +36,25 @@ const DLP_EPHEMERAL_BALANCE_TAG: &[u8] = b"balance";
 /// 10: []                  - Any     : Escrow authority.
 /// 11: [signer]            - PDA     : Escrow signer PDA.
 ///
-/// Instruction Data: escrow_index (u8)
+/// Optional trailing accounts (only present when the source token account is a stash
+/// ATA scheduled for cleanup; signaled by 14-account variant + 34-byte ix data):
+///
+/// 12: [writable]          - PDA     : Stash PDA (authority of `destination_token_info`).
+/// 13: [writable]          - PDA     : Rent PDA (lamport sink for the closed stash).
+///
+/// Instruction Data: escrow_index (u8) optionally followed by 33 bytes
+/// `[user(32) | stash_bump(1)]` for the stash close path.
 ///
 pub fn process_close_shuttle_ata_intent(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
+    let close_stash = match accounts.len() {
+        12 => None,
+        14 => Some((&accounts[12], &accounts[13])),
+        _ => return Err(ProgramError::NotEnoughAccountKeys),
+    };
+    let head_accounts = &accounts[..12];
     let [
         rent_reimbursement_info, // force multi-line
         shuttle_info,
@@ -48,13 +68,20 @@ pub fn process_close_shuttle_ata_intent(
         source_program,
         escrow_authority,
         escrow_signer,
-    ] = require_n_accounts!(accounts, 12);
+    ] = require_n_accounts!(head_accounts, 12);
 
-    require!(
-        instruction_data.len() == 1,
-        ProgramError::InvalidInstructionData
-    );
-    let escrow_index = &instruction_data[0];
+    let (escrow_index, close_stash_seeds) = match (close_stash, instruction_data.len()) {
+        (None, 1) => (&instruction_data[0], None),
+        (Some(_), n) if n == 1 + CLOSE_STASH_DATA_LEN => (
+            &instruction_data[0],
+            Some((
+                <&[u8; 32]>::try_from(&instruction_data[1..33])
+                    .map_err(|_| ProgramError::InvalidInstructionData)?,
+                instruction_data[33],
+            )),
+        ),
+        _ => return Err(ProgramError::InvalidInstructionData),
+    };
 
     require_eq_keys!(
         source_program.address(),
@@ -211,6 +238,92 @@ pub fn process_close_shuttle_ata_intent(
 
     if shuttle_present {
         close_program_account_to_recipient(shuttle_info, rent_reimbursement_info)?;
+    }
+
+    if let (Some((stash_pda_info, rent_pda_info)), Some((user, stash_bump))) =
+        (close_stash, close_stash_seeds)
+    {
+        close_empty_stash_after_settlement(
+            stash_pda_info,
+            rent_pda_info,
+            destination_token_info,
+            mint_info,
+            token_program_info,
+            user,
+            stash_bump,
+        )?;
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+#[inline(never)]
+fn close_empty_stash_after_settlement(
+    stash_pda_info: &AccountView,
+    rent_pda_info: &AccountView,
+    destination_token_info: &AccountView,
+    mint_info: &AccountView,
+    token_program_info: &AccountView,
+    user: &[u8; 32],
+    stash_bump: u8,
+) -> ProgramResult {
+    require_eq_keys!(
+        rent_pda_info.address(),
+        &RENT_PDA,
+        ProgramError::InvalidSeeds
+    );
+
+    // SAFETY: `&[u8; 32]` and `&Address` share the same in-memory layout (32-byte array).
+    let user_address: &Address = unsafe { &*(user.as_ptr() as *const Address) };
+
+    let derived_stash_pda = StashPda::derive_pda(user_address, mint_info.address(), stash_bump)?;
+    require_eq_keys!(
+        &derived_stash_pda,
+        stash_pda_info.address(),
+        ProgramError::InvalidSeeds
+    );
+
+    let expected_stash_ata = get_associated_token_address(
+        stash_pda_info.address(),
+        mint_info.address(),
+        token_program_info.address(),
+    );
+    require_eq_keys!(
+        &expected_stash_ata,
+        destination_token_info.address(),
+        ProgramError::InvalidSeeds
+    );
+
+    // Stash ATA must be drained by the preceding merge + private-transfer actions.
+    let token_account = validate_token_account(
+        destination_token_info,
+        mint_info.address(),
+        Some(stash_pda_info.address()),
+        Some(token_program_info.address()),
+    )?;
+    require!(token_account.amount() == 0, ProgramError::InvalidArgument);
+
+    let bump_seed = [stash_bump];
+    let stash_signer_seeds = StashPda::signer_seeds(user_address, mint_info.address(), &bump_seed);
+    let stash_signer = Signer::from(&stash_signer_seeds);
+
+    CloseAccount {
+        account: destination_token_info,
+        destination: rent_pda_info,
+        authority: stash_pda_info,
+        token_program: token_program_info.address(),
+    }
+    .invoke_signed(core::slice::from_ref(&stash_signer))?;
+
+    let stash_lamports = stash_pda_info.lamports();
+    if stash_lamports > 0 {
+        Transfer {
+            from: stash_pda_info,
+            to: rent_pda_info,
+            lamports: stash_lamports,
+        }
+        .invoke_signed(core::slice::from_ref(&stash_signer))?;
     }
 
     Ok(())

--- a/e-token/src/processor/close_shuttle_ata_intent.rs
+++ b/e-token/src/processor/close_shuttle_ata_intent.rs
@@ -34,23 +34,18 @@ const CLOSE_STASH_DATA_LEN: usize = 33;
 /// 10: []                  - Any     : Escrow authority.
 /// 11: [signer]            - PDA     : Escrow signer PDA.
 ///
-/// Optional trailing accounts (14-account variant, scheduled flow only):
-/// 12: [writable]          - PDA     : Stash PDA (authority of `destination_token_info`).
-/// 13: [writable]          - PDA     : Rent PDA (lamport sink for the closed stash).
-///
 /// Instruction Data: escrow_index (u8), optionally followed by
-/// `[user(32) | stash_bump(1)]` for the stash close path.
+/// `[user(32) | stash_bump(1)]` for the stash close path. In that path the
+/// escrow authority is the stash PDA and account 0 is the rent sink.
 ///
 pub fn process_close_shuttle_ata_intent(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let close_stash = match accounts.len() {
-        12 => None,
-        14 => Some((&accounts[12], &accounts[13])),
+    let (head_accounts, source_program, escrow_authority, escrow_signer) = match accounts.len() {
+        12 => (&accounts[..9], &accounts[9], &accounts[10], &accounts[11]),
         _ => return Err(ProgramError::NotEnoughAccountKeys),
     };
-    let head_accounts = &accounts[..12];
     let [
         rent_reimbursement_info, // force multi-line
         shuttle_info,
@@ -61,14 +56,11 @@ pub fn process_close_shuttle_ata_intent(
         vault_info,
         vault_source_token_acc,
         token_program_info,
-        source_program,
-        escrow_authority,
-        escrow_signer,
-    ] = require_n_accounts!(head_accounts, 12);
+    ] = require_n_accounts!(head_accounts, 9);
 
-    let (escrow_index, close_stash_seeds) = match (close_stash, instruction_data.len()) {
-        (None, 1) => (&instruction_data[0], None),
-        (Some(_), n) if n == 1 + CLOSE_STASH_DATA_LEN => (
+    let (escrow_index, close_stash_seeds) = match instruction_data.len() {
+        1 => (&instruction_data[0], None),
+        n if n == 1 + CLOSE_STASH_DATA_LEN => (
             &instruction_data[0],
             Some((
                 <&[u8; 32]>::try_from(&instruction_data[1..33])
@@ -228,26 +220,28 @@ pub fn process_close_shuttle_ata_intent(
             shuttle_ephemeral_ata_info.address(),
             ProgramError::InvalidSeeds
         );
-
-        close_program_account_to_recipient(shuttle_ephemeral_ata_info, rent_reimbursement_info)?;
     }
 
-    if shuttle_present {
-        close_program_account_to_recipient(shuttle_info, rent_reimbursement_info)?;
-    }
-
-    if let (Some((stash_pda_info, rent_pda_info)), Some((user, stash_bump))) =
-        (close_stash, close_stash_seeds)
-    {
+    if let Some((user, stash_bump)) = close_stash_seeds {
         close_empty_stash_after_settlement(
-            stash_pda_info,
-            rent_pda_info,
+            escrow_authority,
+            rent_reimbursement_info,
             destination_token_info,
             mint_info,
             token_program_info,
             user,
             stash_bump,
         )?;
+    }
+
+    // Keep direct lamport/account closes last; the stash close path still needs
+    // token/system CPIs, and those must run before these local lamport edits.
+    if shuttle_ephemeral_present {
+        close_program_account_to_recipient(shuttle_ephemeral_ata_info, rent_reimbursement_info)?;
+    }
+
+    if shuttle_present {
+        close_program_account_to_recipient(shuttle_info, rent_reimbursement_info)?;
     }
 
     Ok(())

--- a/e-token/src/processor/close_shuttle_ata_intent.rs
+++ b/e-token/src/processor/close_shuttle_ata_intent.rs
@@ -14,8 +14,6 @@ use pinocchio_system::instructions::Transfer;
 use pinocchio_token_2022::instructions::CloseAccount;
 const DLP_EPHEMERAL_BALANCE_TAG: &[u8] = b"balance";
 
-/// Length of the optional close-stash payload appended to the ix data:
-/// 32 bytes user pubkey + 1 byte stash bump.
 const CLOSE_STASH_DATA_LEN: usize = 33;
 
 ///
@@ -36,13 +34,11 @@ const CLOSE_STASH_DATA_LEN: usize = 33;
 /// 10: []                  - Any     : Escrow authority.
 /// 11: [signer]            - PDA     : Escrow signer PDA.
 ///
-/// Optional trailing accounts (only present when the source token account is a stash
-/// ATA scheduled for cleanup; signaled by 14-account variant + 34-byte ix data):
-///
+/// Optional trailing accounts (14-account variant, scheduled flow only):
 /// 12: [writable]          - PDA     : Stash PDA (authority of `destination_token_info`).
 /// 13: [writable]          - PDA     : Rent PDA (lamport sink for the closed stash).
 ///
-/// Instruction Data: escrow_index (u8) optionally followed by 33 bytes
+/// Instruction Data: escrow_index (u8), optionally followed by
 /// `[user(32) | stash_bump(1)]` for the stash close path.
 ///
 pub fn process_close_shuttle_ata_intent(
@@ -274,7 +270,7 @@ fn close_empty_stash_after_settlement(
         ProgramError::InvalidSeeds
     );
 
-    // SAFETY: `&[u8; 32]` and `&Address` share the same in-memory layout (32-byte array).
+    // SAFETY: `&[u8; 32]` and `&Address` share the same in-memory layout.
     let user_address: &Address = unsafe { &*(user.as_ptr() as *const Address) };
 
     let derived_stash_pda = StashPda::derive_pda(user_address, mint_info.address(), stash_bump)?;
@@ -295,7 +291,6 @@ fn close_empty_stash_after_settlement(
         ProgramError::InvalidSeeds
     );
 
-    // Stash ATA must be drained by the preceding merge + private-transfer actions.
     let token_account = validate_token_account(
         destination_token_info,
         mint_info.address(),

--- a/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge.rs
+++ b/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge.rs
@@ -107,7 +107,7 @@ fn default_post_delegation_actions(
 ) -> Vec<Instruction> {
     alloc::vec![
         merge_shuttle_into_destination_action(accounts),
-        undelegate_and_close_shuttle_action(&accounts.common),
+        undelegate_and_close_shuttle_action(&accounts.common, None),
     ]
 }
 

--- a/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
+++ b/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
@@ -88,7 +88,7 @@ pub(crate) fn process_with_merge_and_private_transfer_inner(
     validator: Option<&[u8; 32]>,
     encrypted_destination: &[u8; 80],
     encrypted_data_suffix: &[u8],
-    close_stash: Option<CloseStashArgs<'_>>,
+    close_stash: Option<CloseStashArgs>,
 ) -> ProgramResult {
     let [
         payer_info, // force multi-line

--- a/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
+++ b/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
@@ -23,7 +23,7 @@ use crate::processor::{
     internal::shuttle_delegation::{
         merge_shuttle_into_token_account_action,
         process_deposit_and_delegate_shuttle_ephemeral_ata_with_post_actions,
-        undelegate_and_close_shuttle_action, DepositAndDelegateShuttleAccounts,
+        undelegate_and_close_shuttle_action, CloseStashArgs, DepositAndDelegateShuttleAccounts,
         DepositAndDelegateShuttleCommonArgs,
     },
     utils::read_mint_decimals,
@@ -64,6 +64,36 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
+    let args = DepositAndDelegateShuttleWithPrivateTransferArgs::decode(instruction_data)?;
+    process_with_merge_and_private_transfer_inner(
+        accounts,
+        args.shuttle_id(),
+        args.amount(),
+        args.exact_out(),
+        args.validator(),
+        args.encrypted_destination(),
+        args.encrypted_data_suffix(),
+        None,
+    )
+}
+
+/// Shared body for both the public ix 25 (`…WithMergeAndPrivateTransfer`) and the
+/// internal scheduled ix 31 (`…WithMergeAndPrivateTransferAndStashClose`).
+///
+/// `close_stash` is `Some` only on the scheduled path: it instructs the post-undelegate
+/// settlement to close the source stash ATA + drain the stash PDA back to the rent PDA.
+#[inline(always)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn process_with_merge_and_private_transfer_inner(
+    accounts: &[AccountView],
+    shuttle_id: u32,
+    amount: u64,
+    exact_out: bool,
+    validator: Option<&[u8; 32]>,
+    encrypted_destination: &[u8; 80],
+    encrypted_data_suffix: &[u8],
+    close_stash: Option<CloseStashArgs<'_>>,
+) -> ProgramResult {
     let [
         payer_info, // force multi-line
         rent_pda_info,
@@ -86,8 +116,7 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private
         queue_info,
     ] = require_n_accounts!(accounts, 19);
 
-    let args = DepositAndDelegateShuttleWithPrivateTransferArgs::decode(instruction_data)?;
-    require!(args.amount() != 0, ProgramError::InvalidInstructionData);
+    require!(amount != 0, ProgramError::InvalidInstructionData);
 
     let common_accounts = DepositAndDelegateShuttleAccounts {
         payer_info,
@@ -142,24 +171,24 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private
         );
     });
 
-    let (bump, validator) = {
+    let (bump, queue_validator) = {
         let data = unsafe { queue_info.borrow_unchecked() };
         let (header, _) = queue_views(data)?;
         (header.bump, header.validator)
     };
     let derived_queue =
-        TransferQueue::derive_pda(common_accounts.mint_info.address(), &validator, bump)?;
+        TransferQueue::derive_pda(common_accounts.mint_info.address(), &queue_validator, bump)?;
     require_eq_keys!(
         &derived_queue,
         queue_info.address(),
         ProgramError::InvalidSeeds
     );
 
-    let fee_amount = private_transfer_fee_amount(args.amount())?;
-    let private_transfer_amount = if args.exact_out() {
-        args.amount()
+    let fee_amount = private_transfer_fee_amount(amount)?;
+    let private_transfer_amount = if exact_out {
+        amount
     } else {
-        args.amount()
+        amount
             .checked_sub(fee_amount)
             .ok_or(ProgramError::InvalidInstructionData)?
     };
@@ -168,7 +197,7 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private
 
     debug_log!(
         "exact_out:  {}, fee_amount: {}, private_transfer_amount: {}",
-        args.exact_out(),
+        exact_out,
         fee_amount,
         private_transfer_amount
     );
@@ -182,7 +211,8 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private
         let private_transfer = private_transfer_action_encrypted(
             &common_accounts,
             queue_info,
-            &args,
+            encrypted_destination,
+            encrypted_data_suffix,
             private_transfer_amount,
         )?;
 
@@ -192,14 +222,18 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private
                 common_accounts.owner_source_token_info,
             ),
             private_transfer_fee_action(&common_accounts, fee_amount, mint_decimals),
-            undelegate_and_close_shuttle_action(&common_accounts),
+            undelegate_and_close_shuttle_action(&common_accounts, close_stash),
         ]
         .cleartext_with_insertable(private_transfer, 1)
     };
 
     process_deposit_and_delegate_shuttle_ephemeral_ata_with_post_actions(
         &common_accounts,
-        args.common_args(total_amount)?,
+        DepositAndDelegateShuttleCommonArgs {
+            shuttle_id,
+            total_amount,
+            validator,
+        },
         ephemeral_spl_api::consts::SPONSORED_SHUTTLE_PRIVATE_TRANSFER_EXTRA_LAMPORTS,
         actions,
     )
@@ -244,23 +278,11 @@ pub struct DepositAndDelegateShuttleWithPrivateTransferArgs {
     pub encrypted_data_suffix: Vec<u8>,
 }
 
-impl DepositAndDelegateShuttleWithPrivateTransferArgsView<'_> {
-    fn common_args(
-        &self,
-        total_amount: u64,
-    ) -> Result<DepositAndDelegateShuttleCommonArgs<'_>, ProgramError> {
-        Ok(DepositAndDelegateShuttleCommonArgs {
-            shuttle_id: self.shuttle_id(),
-            total_amount,
-            validator: self.validator(),
-        })
-    }
-}
-
 fn private_transfer_action_encrypted(
     common_accounts: &DepositAndDelegateShuttleAccounts<'_>,
     queue_info: &AccountView,
-    args: &DepositAndDelegateShuttleWithPrivateTransferArgsView<'_>,
+    encrypted_destination: &[u8; 80],
+    encrypted_data_suffix: &[u8],
     amount: u64,
 ) -> Result<PostDelegationActions, ProgramError> {
     Ok(PostDelegationActions {
@@ -276,9 +298,7 @@ fn private_transfer_action_encrypted(
                 common_accounts.owner_source_token_info.address().to_bytes()
             ), // 5
             MaybeEncryptedPubkey::ClearText(common_accounts.vault_token_info.address().to_bytes()), // 6
-            MaybeEncryptedPubkey::Encrypted(EncryptedBuffer::new(
-                args.encrypted_destination().into()
-            )), // 7
+            MaybeEncryptedPubkey::Encrypted(EncryptedBuffer::new(encrypted_destination.into())), // 7
             MaybeEncryptedPubkey::ClearText(
                 common_accounts.token_program_info.address().to_bytes()
             ), // 8
@@ -301,7 +321,7 @@ fn private_transfer_action_encrypted(
             ],
             data: MaybeEncryptedIxData {
                 prefix: ESplInstruction::DepositAndQueueTransfer.with_data(&amount.to_le_bytes()),
-                suffix: EncryptedBuffer::new(args.encrypted_data_suffix().into()),
+                suffix: EncryptedBuffer::new(encrypted_data_suffix.into()),
             },
         }],
     })

--- a/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
+++ b/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
@@ -77,11 +77,7 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private
     )
 }
 
-/// Shared body for both the public ix 25 (`…WithMergeAndPrivateTransfer`) and the
-/// internal scheduled ix 31 (`…WithMergeAndPrivateTransferAndStashClose`).
-///
-/// `close_stash` is `Some` only on the scheduled path: it instructs the post-undelegate
-/// settlement to close the source stash ATA + drain the stash PDA back to the rent PDA.
+/// Shared body for ix 25 (`close_stash = None`) and ix 31 (`close_stash = Some`).
 #[inline(always)]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn process_with_merge_and_private_transfer_inner(

--- a/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer_and_stash_close.rs
+++ b/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer_and_stash_close.rs
@@ -1,0 +1,90 @@
+use alloc::vec;
+use alloc::vec::Vec;
+use data_layout::variable_offset_layout;
+
+use ephemeral_spl_api::state::stash::StashPda;
+use ephemeral_spl_api::{require_eq_keys, require_n_accounts};
+use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
+
+use crate::processor::deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer::process_with_merge_and_private_transfer_inner;
+use crate::processor::internal::shuttle_delegation::CloseStashArgs;
+
+///
+/// Executes on: BASE only. Self-CPI'd by `ExecuteScheduledPrivateTransfer`.
+///
+/// Identical to `DepositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransfer`
+/// (ix 25), with one extra fixed `[u8; 33]` field appended to the args. Slot 0
+/// (`payer`) and slot 5 (`owner`) must be the stash PDA derived from
+/// `[b"stash", user, mint]`. The post-undelegate settlement closes the source
+/// stash ATA and drains the stash PDA back to the rent PDA.
+///
+/// Accounts (19): same layout as ix 25.
+///
+/// Instruction Data: `DepositAndDelegateShuttleWithPrivateTransferAndStashCloseArgs`
+///
+#[inline(never)]
+pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer_and_stash_close(
+    accounts: &[AccountView],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    let args =
+        DepositAndDelegateShuttleWithPrivateTransferAndStashCloseArgs::decode(instruction_data)?;
+
+    // Need slot 0 (payer = stash PDA) and slot 1 (rent_pda) up-front to validate the
+    // stash close seeds. The shared inner helper re-validates the rest of the account
+    // list after this guard runs.
+    let _ = require_n_accounts!(accounts, 19);
+    let payer_info = &accounts[0];
+    let rent_pda_info = &accounts[1];
+    let mint_info = &accounts[13];
+
+    let seeds = args.stash_close_seeds();
+    let mut user = [0u8; 32];
+    user.copy_from_slice(&seeds[0..32]);
+    let stash_bump = seeds[32];
+
+    // SAFETY: `&[u8; 32]` and `&Address` share the same in-memory layout.
+    let user_address: &Address = unsafe { &*(user.as_ptr() as *const Address) };
+
+    let derived_stash_pda = StashPda::derive_pda(user_address, mint_info.address(), stash_bump)?;
+    require_eq_keys!(
+        payer_info.address(),
+        &derived_stash_pda,
+        ProgramError::InvalidSeeds
+    );
+
+    let close_stash = CloseStashArgs {
+        stash_pda: payer_info.address(),
+        rent_pda: rent_pda_info.address(),
+        user,
+        stash_bump,
+    };
+
+    process_with_merge_and_private_transfer_inner(
+        accounts,
+        args.shuttle_id(),
+        args.amount(),
+        args.exact_out(),
+        args.validator(),
+        args.encrypted_destination(),
+        args.encrypted_data_suffix(),
+        Some(close_stash),
+    )
+}
+
+/// Wire-identical to `DepositAndDelegateShuttleWithPrivateTransferArgs` plus a
+/// fixed `stash_close_seeds: [u8; 33]` field inserted before
+/// `encrypted_data_suffix`. Layout of the new field:
+///   bytes [0..32] = user pubkey (the stash PDA seed)
+///   byte  [32]    = stash bump
+#[variable_offset_layout(buffer_offset = 1)]
+pub struct DepositAndDelegateShuttleWithPrivateTransferAndStashCloseArgs {
+    pub shuttle_id: u32,
+    pub amount: u64,
+    pub exact_out: bool,
+    pub encrypted_destination: [u8; 80],
+    pub validator: Option<[u8; 32]>,
+    pub stash_close_seeds: [u8; 33],
+    #[flexible = 1]
+    pub encrypted_data_suffix: Vec<u8>,
+}

--- a/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer_and_stash_close.rs
+++ b/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer_and_stash_close.rs
@@ -34,10 +34,8 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private
     user.copy_from_slice(&seeds[0..32]);
     let stash_bump = seeds[32];
 
-    // SAFETY: `&[u8; 32]` and `&Address` share the same in-memory layout.
-    let user_address: &Address = unsafe { &*(user.as_ptr() as *const Address) };
-
-    let derived_stash_pda = StashPda::derive_pda(user_address, mint_info.address(), stash_bump)?;
+    let user_address = Address::new_from_array(user);
+    let derived_stash_pda = StashPda::derive_pda(&user_address, mint_info.address(), stash_bump)?;
     require_eq_keys!(
         payer_info.address(),
         &derived_stash_pda,

--- a/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer_and_stash_close.rs
+++ b/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer_and_stash_close.rs
@@ -12,15 +12,9 @@ use crate::processor::internal::shuttle_delegation::CloseStashArgs;
 ///
 /// Executes on: BASE only. Self-CPI'd by `ExecuteScheduledPrivateTransfer`.
 ///
-/// Identical to `DepositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransfer`
-/// (ix 25), with one extra fixed `[u8; 33]` field appended to the args. Slot 0
-/// (`payer`) and slot 5 (`owner`) must be the stash PDA derived from
-/// `[b"stash", user, mint]`. The post-undelegate settlement closes the source
-/// stash ATA and drains the stash PDA back to the rent PDA.
-///
-/// Accounts (19): same layout as ix 25.
-///
-/// Instruction Data: `DepositAndDelegateShuttleWithPrivateTransferAndStashCloseArgs`
+/// Same accounts (19) and semantics as ix 25, with a fixed `[u8; 33]`
+/// `stash_close_seeds` appended to the args. The post-undelegate settlement
+/// closes the source stash ATA and refunds the stash PDA to the rent PDA.
 ///
 #[inline(never)]
 pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer_and_stash_close(
@@ -30,9 +24,6 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private
     let args =
         DepositAndDelegateShuttleWithPrivateTransferAndStashCloseArgs::decode(instruction_data)?;
 
-    // Need slot 0 (payer = stash PDA) and slot 1 (rent_pda) up-front to validate the
-    // stash close seeds. The shared inner helper re-validates the rest of the account
-    // list after this guard runs.
     let _ = require_n_accounts!(accounts, 19);
     let payer_info = &accounts[0];
     let rent_pda_info = &accounts[1];
@@ -72,11 +63,6 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private
     )
 }
 
-/// Wire-identical to `DepositAndDelegateShuttleWithPrivateTransferArgs` plus a
-/// fixed `stash_close_seeds: [u8; 33]` field inserted before
-/// `encrypted_data_suffix`. Layout of the new field:
-///   bytes [0..32] = user pubkey (the stash PDA seed)
-///   byte  [32]    = stash bump
 #[variable_offset_layout(buffer_offset = 1)]
 pub struct DepositAndDelegateShuttleWithPrivateTransferAndStashCloseArgs {
     pub shuttle_id: u32,

--- a/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer_and_stash_close.rs
+++ b/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer_and_stash_close.rs
@@ -26,7 +26,6 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private
 
     let _ = require_n_accounts!(accounts, 19);
     let payer_info = &accounts[0];
-    let rent_pda_info = &accounts[1];
     let mint_info = &accounts[13];
 
     let seeds = args.stash_close_seeds();
@@ -42,12 +41,7 @@ pub fn process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private
         ProgramError::InvalidSeeds
     );
 
-    let close_stash = CloseStashArgs {
-        stash_pda: payer_info.address(),
-        rent_pda: rent_pda_info.address(),
-        user,
-        stash_bump,
-    };
+    let close_stash = CloseStashArgs { user, stash_bump };
 
     process_with_merge_and_private_transfer_inner(
         accounts,

--- a/e-token/src/processor/execute_scheduled_private_transfer.rs
+++ b/e-token/src/processor/execute_scheduled_private_transfer.rs
@@ -21,12 +21,12 @@ use crate::processor::utils::{
     get_associated_token_address, is_supported_token_program, read_mint_decimals,
     validate_token_account,
 };
-use crate::DepositAndDelegateShuttleWithPrivateTransferArgs;
+use crate::DepositAndDelegateShuttleWithPrivateTransferAndStashCloseArgs;
 
-/// Number of metas forwarded to instruction 25.
+/// Number of metas forwarded to instruction 31.
 pub(crate) const SCHEDULED_PT_INNER_ACCOUNTS: usize = 19;
 
-/// Total accounts on this top-level instruction (ix 25 layout + user ATA + Hydra crank).
+/// Total accounts on this top-level instruction (ix 31 layout + user ATA + Hydra crank).
 pub(crate) const SCHEDULED_PT_ACCOUNTS: usize = SCHEDULED_PT_INNER_ACCOUNTS + 2;
 
 // Five minutes at an estimated 400 ms/slot.
@@ -37,20 +37,20 @@ const REFUND_TIMEOUT_SLOTS: u64 = 750;
 ///
 /// Hydra forbids signer metas in scheduled instructions, so every account
 /// here arrives non-signer. The processor re-derives the stash PDA from
-/// `[b"stash", user, mint]` and `invoke_signed`s into instruction 25 with
+/// `[b"stash", user, mint]` and `invoke_signed`s into instruction 31 with
 /// the stash PDA covering both the `payer` and `owner` signer slots.
 ///
-/// Accounts: slots 0..18 mirror instruction 25's layout verbatim so the
+/// Accounts: slots 0..18 mirror instruction 31's layout verbatim so the
 /// self-CPI can forward that prefix unchanged. Slot 20 is the Hydra crank
 /// PDA, the provenance witness — `crank.authority == RENT_PDA` and
 /// `crank.authority_signer == 1` proves ix 29 created the schedule.
 ///
-///  0: [writable]          - PDA     : Stash PDA (payer in ix 25).
+///  0: [writable]          - PDA     : Stash PDA (payer in ix 31).
 ///  1: [writable]          - PDA     : Rent PDA account.
 ///  2: [writable]          - PDA     : Shuttle metadata account.
 ///  3: [writable]          - PDA     : Shuttle EATA account.
 ///  4: [writable]          - SPL     : Shuttle wallet ATA account.
-///  5: []                  - PDA     : Stash PDA (owner in ix 25; same key as 0).
+///  5: []                  - PDA     : Stash PDA (owner in ix 31; same key as 0).
 ///  6: []                  - Program : Owner program (this program).
 ///  7: [writable]          - PDA     : Buffer account.
 ///  8: [writable]          - PDA     : Delegation record account.
@@ -61,7 +61,7 @@ const REFUND_TIMEOUT_SLOTS: u64 = 750;
 /// 13: []                  - SPL     : Mint account.
 /// 14: []                  - SPL     : Token program.
 /// 15: []                  - PDA     : Global vault account.
-/// 16: [writable]          - SPL     : Stash ATA (owner_source_token in ix 25).
+/// 16: [writable]          - SPL     : Stash ATA (owner_source_token in ix 31).
 /// 17: [writable]          - SPL     : Vault token account.
 /// 18: [writable]          - PDA     : Transfer queue account.
 /// 19: [writable]          - SPL     : User ATA for timeout refund.
@@ -219,21 +219,30 @@ pub fn process_execute_scheduled_private_transfer(
         return Ok(());
     }
 
-    // -------- build ix 25 instruction data --------
-    let ix_data = ESplInstruction::DepositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransfer
-        .with_data(
-            &DepositAndDelegateShuttleWithPrivateTransferArgs {
-                shuttle_id: args.shuttle_id(),
-                amount: effective_amount,
-                exact_out: false,
-                validator: Some(args.validator().to_owned()),
-                encrypted_destination: args.encrypted_destination().to_owned(),
-                encrypted_data_suffix: args.encrypted_data_suffix().to_owned(),
-            }
-            .encode()?,
-        );
+    // -------- build ix 31 instruction data --------
+    // Pack [user(32) | stash_bump(1)] so the post-undelegate handler can sign
+    // `[b"stash", user, mint, bump]` to close the stash ATA + drain the stash
+    // PDA back to the rent PDA after the merge + private-transfer actions.
+    let mut stash_close_seeds = [0u8; 33];
+    stash_close_seeds[0..32].copy_from_slice(args.user_address().as_ref());
+    stash_close_seeds[32] = args.stash_bump();
 
-    // -------- build ix 25 account metas (19) --------
+    let ix_data =
+        ESplInstruction::DepositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransferAndStashClose
+            .with_data(
+                &DepositAndDelegateShuttleWithPrivateTransferAndStashCloseArgs {
+                    shuttle_id: args.shuttle_id(),
+                    amount: effective_amount,
+                    exact_out: false,
+                    validator: Some(args.validator().to_owned()),
+                    encrypted_destination: args.encrypted_destination().to_owned(),
+                    stash_close_seeds,
+                    encrypted_data_suffix: args.encrypted_data_suffix().to_owned(),
+                }
+                .encode()?,
+            );
+
+    // -------- build ix 31 account metas (19) --------
     let mut metas =
         [const { MaybeUninit::<InstructionAccount>::uninit() }; SCHEDULED_PT_INNER_ACCOUNTS];
     unsafe {
@@ -352,16 +361,6 @@ pub fn process_execute_scheduled_private_transfer(
     )?;
 
     Ok(())
-
-    // TODO(GabrielePicco): this can't be closed as the merge otherwise does not work
-    // close_empty_stash_accounts(
-    //     stash_payer_info,
-    //     rent_pda_info,
-    //     stash_ata_info,
-    //     mint_info,
-    //     token_program_info,
-    //     &stash_signer,
-    // )
 }
 
 #[variable_offset_layout(buffer_offset = 1)]

--- a/e-token/src/processor/execute_scheduled_private_transfer.rs
+++ b/e-token/src/processor/execute_scheduled_private_transfer.rs
@@ -220,9 +220,6 @@ pub fn process_execute_scheduled_private_transfer(
     }
 
     // -------- build ix 31 instruction data --------
-    // Pack [user(32) | stash_bump(1)] so the post-undelegate handler can sign
-    // `[b"stash", user, mint, bump]` to close the stash ATA + drain the stash
-    // PDA back to the rent PDA after the merge + private-transfer actions.
     let mut stash_close_seeds = [0u8; 33];
     stash_close_seeds[0..32].copy_from_slice(args.user_address().as_ref());
     stash_close_seeds[32] = args.stash_bump();

--- a/e-token/src/processor/internal/shuttle_delegation.rs
+++ b/e-token/src/processor/internal/shuttle_delegation.rs
@@ -365,16 +365,14 @@ pub(crate) fn merge_shuttle_into_token_account_action(
 }
 
 #[derive(Clone, Copy)]
-pub(crate) struct CloseStashArgs<'a> {
-    pub(crate) stash_pda: &'a Address,
-    pub(crate) rent_pda: &'a Address,
+pub(crate) struct CloseStashArgs {
     pub(crate) user: [u8; 32],
     pub(crate) stash_bump: u8,
 }
 
 pub(crate) fn undelegate_and_close_shuttle_action(
     accounts: &DepositAndDelegateShuttleAccounts<'_>,
-    close_stash: Option<CloseStashArgs<'_>>,
+    close_stash: Option<CloseStashArgs>,
 ) -> Instruction {
     build_undelegate_and_close_shuttle_instruction(
         accounts.payer_info.address(),
@@ -396,9 +394,9 @@ pub(crate) fn build_undelegate_and_close_shuttle_instruction(
     shuttle_wallet_ata: &Address,
     refund_token: &Address,
     token_program: &Address,
-    close_stash: Option<CloseStashArgs<'_>>,
+    close_stash: Option<CloseStashArgs>,
 ) -> Instruction {
-    let mut accounts = alloc::vec![
+    let accounts = alloc::vec![
         AccountMeta::new(*payer, true),
         AccountMeta::new(*rent_pda, false),
         AccountMeta::new_readonly(*shuttle, false),
@@ -411,8 +409,6 @@ pub(crate) fn build_undelegate_and_close_shuttle_instruction(
     ];
     let mut data = ESplInstruction::UndelegateAndCloseShuttleToOwner.to_vec();
     if let Some(close) = close_stash {
-        accounts.push(AccountMeta::new(*close.stash_pda, false));
-        accounts.push(AccountMeta::new(*close.rent_pda, false));
         // Explicit escrow_index byte: the parser would otherwise consume `user[0]` as it.
         data.push(crate::processor::undelegate_and_close_shuttle_to_owner::DEFAULT_ESCROW_INDEX);
         data.extend_from_slice(&close.user);

--- a/e-token/src/processor/internal/shuttle_delegation.rs
+++ b/e-token/src/processor/internal/shuttle_delegation.rs
@@ -364,8 +364,24 @@ pub(crate) fn merge_shuttle_into_token_account_action(
     }
 }
 
+/// Optional payload telling `UndelegateAndCloseShuttleToOwner` to also close the
+/// source token account and refund its authority PDA after settlement.
+///
+/// `stash_pda` must be the authority of the source token account; `rent_pda` must
+/// be the canonical `RENT_PDA`. `(user, stash_bump)` are the seeds needed to sign
+/// `[b"stash", user, mint, bump]` for the SPL `CloseAccount` and the system
+/// `Transfer` that drains the stash PDA.
+#[derive(Clone, Copy)]
+pub(crate) struct CloseStashArgs<'a> {
+    pub(crate) stash_pda: &'a Address,
+    pub(crate) rent_pda: &'a Address,
+    pub(crate) user: [u8; 32],
+    pub(crate) stash_bump: u8,
+}
+
 pub(crate) fn undelegate_and_close_shuttle_action(
     accounts: &DepositAndDelegateShuttleAccounts<'_>,
+    close_stash: Option<CloseStashArgs<'_>>,
 ) -> Instruction {
     build_undelegate_and_close_shuttle_instruction(
         accounts.payer_info.address(),
@@ -375,6 +391,7 @@ pub(crate) fn undelegate_and_close_shuttle_action(
         accounts.shuttle_wallet_ata_info.address(),
         accounts.owner_source_token_info.address(),
         accounts.token_program_info.address(),
+        close_stash,
     )
 }
 
@@ -386,21 +403,30 @@ pub(crate) fn build_undelegate_and_close_shuttle_instruction(
     shuttle_wallet_ata: &Address,
     refund_token: &Address,
     token_program: &Address,
+    close_stash: Option<CloseStashArgs<'_>>,
 ) -> Instruction {
+    let mut accounts = alloc::vec![
+        AccountMeta::new(*payer, true),
+        AccountMeta::new(*rent_pda, false),
+        AccountMeta::new_readonly(*shuttle, false),
+        AccountMeta::new_readonly(*shuttle_eata, false),
+        AccountMeta::new(*shuttle_wallet_ata, false),
+        AccountMeta::new(*refund_token, false),
+        AccountMeta::new_readonly(*token_program, false),
+        AccountMeta::new(Pubkey::from(MAGIC_CONTEXT_ID.to_bytes()), false),
+        AccountMeta::new_readonly(Pubkey::from(MAGIC_PROGRAM_ID.to_bytes()), false),
+    ];
+    let mut data = ESplInstruction::UndelegateAndCloseShuttleToOwner.to_vec();
+    if let Some(close) = close_stash {
+        accounts.push(AccountMeta::new(*close.stash_pda, false));
+        accounts.push(AccountMeta::new(*close.rent_pda, false));
+        data.extend_from_slice(&close.user);
+        data.push(close.stash_bump);
+    }
     Instruction {
         program_id: crate::ID,
-        accounts: alloc::vec![
-            AccountMeta::new(*payer, true),
-            AccountMeta::new(*rent_pda, false),
-            AccountMeta::new_readonly(*shuttle, false),
-            AccountMeta::new_readonly(*shuttle_eata, false),
-            AccountMeta::new(*shuttle_wallet_ata, false),
-            AccountMeta::new(*refund_token, false),
-            AccountMeta::new_readonly(*token_program, false),
-            AccountMeta::new(Pubkey::from(MAGIC_CONTEXT_ID.to_bytes()), false),
-            AccountMeta::new_readonly(Pubkey::from(MAGIC_PROGRAM_ID.to_bytes()), false),
-        ],
-        data: ESplInstruction::UndelegateAndCloseShuttleToOwner.to_vec(),
+        accounts,
+        data,
     }
 }
 

--- a/e-token/src/processor/internal/shuttle_delegation.rs
+++ b/e-token/src/processor/internal/shuttle_delegation.rs
@@ -364,13 +364,6 @@ pub(crate) fn merge_shuttle_into_token_account_action(
     }
 }
 
-/// Optional payload telling `UndelegateAndCloseShuttleToOwner` to also close the
-/// source token account and refund its authority PDA after settlement.
-///
-/// `stash_pda` must be the authority of the source token account; `rent_pda` must
-/// be the canonical `RENT_PDA`. `(user, stash_bump)` are the seeds needed to sign
-/// `[b"stash", user, mint, bump]` for the SPL `CloseAccount` and the system
-/// `Transfer` that drains the stash PDA.
 #[derive(Clone, Copy)]
 pub(crate) struct CloseStashArgs<'a> {
     pub(crate) stash_pda: &'a Address,
@@ -420,6 +413,8 @@ pub(crate) fn build_undelegate_and_close_shuttle_instruction(
     if let Some(close) = close_stash {
         accounts.push(AccountMeta::new(*close.stash_pda, false));
         accounts.push(AccountMeta::new(*close.rent_pda, false));
+        // Explicit escrow_index byte: the parser would otherwise consume `user[0]` as it.
+        data.push(crate::processor::undelegate_and_close_shuttle_to_owner::DEFAULT_ESCROW_INDEX);
         data.extend_from_slice(&close.user);
         data.push(close.stash_bump);
     }

--- a/e-token/src/processor/mod.rs
+++ b/e-token/src/processor/mod.rs
@@ -9,6 +9,7 @@ pub mod delegate_shuttle_ephemeral_ata;
 pub mod delegate_transfer_queue;
 pub mod deposit_and_delegate_shuttle_ephemeral_ata_with_merge;
 pub mod deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer;
+pub mod deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer_and_stash_close;
 pub mod deposit_and_queue_transfer;
 pub mod deposit_spl_tokens;
 pub mod ensure_transfer_queue_crank;
@@ -54,6 +55,10 @@ pub use deposit_and_delegate_shuttle_ephemeral_ata_with_merge::process_deposit_a
 pub use deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer::{
     process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer,
     DepositAndDelegateShuttleWithPrivateTransferArgs,
+};
+pub use deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer_and_stash_close::{
+    process_deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer_and_stash_close,
+    DepositAndDelegateShuttleWithPrivateTransferAndStashCloseArgs,
 };
 pub use deposit_and_queue_transfer::{
     process_deposit_and_queue_transfer, DepositAndQueueTransferArgs,

--- a/e-token/src/processor/schedule_private_transfer.rs
+++ b/e-token/src/processor/schedule_private_transfer.rs
@@ -38,7 +38,7 @@ const SETUP_LAMPORTS: u64 = ephemeral_spl_api::consts::SPONSORED_SHUTTLE_DELEGAT
 /// Executes on: BASE only. User-signed.
 ///
 /// Appended to a swap transaction to schedule a private transfer
-/// (instruction 25 via Hydra) over whatever balance ends up in the stash
+/// (instruction 31 via Hydra) over whatever balance ends up in the stash
 /// ATA when the crank fires. Keeps the outer ix small: every account that
 /// would only be read for its pubkey is derived on-chain using the bumps
 /// supplied in the instruction data; hard-coded program IDs stand in for
@@ -160,7 +160,7 @@ pub fn process_schedule_private_transfer(
         args.queue_bump(),
     )?;
 
-    // Slots 0..18 mirror ix 25's layout. Slot 5 aliases slot 0 (stash PDA).
+    // Slots 0..18 mirror ix 31's layout. Slot 5 aliases slot 0 (stash PDA).
     // Slot 20 aliases Trigger's crank account; the flag must match Solana's
     // tx-level writable union, so it remains writable.
     let sched_metas: [(&Address, bool); SCHEDULED_PT_ACCOUNTS] = [

--- a/e-token/src/processor/undelegate_and_close_shuttle_to_owner.rs
+++ b/e-token/src/processor/undelegate_and_close_shuttle_to_owner.rs
@@ -15,9 +15,7 @@ const INTENT_BUNDLE_DATA_BUF_SIZE: usize = 1536;
 const CLOSE_SHUTTLE_ATA_COMPUTE_UNITS: u32 = 100_000;
 const CLOSE_STASH_DATA_LEN: usize = 33;
 
-struct CloseStashForward<'a> {
-    stash_pda: &'a AccountView,
-    rent_pda: &'a AccountView,
+struct CloseStashForward {
     user: [u8; 32],
     stash_bump: u8,
 }
@@ -37,23 +35,18 @@ struct CloseStashForward<'a> {
 ///  7: [writable]          - Any     : Magic context account.
 ///  8: []                  - Program : Magic program.
 ///
-/// Optional trailing accounts (11-account variant, scheduled flow only):
-///  9: [writable]          - PDA     : Stash PDA (authority of `refund_token_info`).
-/// 10: [writable]          - PDA     : Rent PDA (lamport sink for the closed stash).
-///
 /// Instruction Data: optional escrow_index (u8), optionally followed by
-/// `[user(32) | stash_bump(1)]` for the stash close path.
+/// `[user(32) | stash_bump(1)]` for the stash close path. In that path the
+/// executor is the stash PDA and account 1 is the rent sink.
 ///
 pub fn process_undelegate_and_close_shuttle_to_owner(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let close_stash_accounts = match accounts.len() {
-        9 => None,
-        11 => Some((&accounts[9], &accounts[10])),
+    let head_accounts = match accounts.len() {
+        9 | 11 => &accounts[..9],
         _ => return Err(ProgramError::NotEnoughAccountKeys),
     };
-    let head_accounts = &accounts[..9];
     let [
         executor, // force multi-line
         rent_reimbursement,
@@ -66,16 +59,21 @@ pub fn process_undelegate_and_close_shuttle_to_owner(
         magic_program,
     ] = require_n_accounts!(head_accounts, 9);
 
-    let (escrow_index, close_stash_seeds) =
-        parse_instruction_data(instruction_data, close_stash_accounts.is_some())?;
-    let close_stash = close_stash_accounts.zip(close_stash_seeds).map(
-        |((stash_pda, rent_pda), (user, stash_bump))| CloseStashForward {
-            stash_pda,
-            rent_pda,
-            user,
-            stash_bump,
-        },
-    );
+    let (escrow_index, close_stash_seeds) = parse_instruction_data(instruction_data)?;
+    if close_stash_seeds.is_some() && accounts.len() == 11 {
+        require_eq_keys!(
+            accounts[9].address(),
+            executor.address(),
+            ProgramError::InvalidSeeds
+        );
+        require_eq_keys!(
+            accounts[10].address(),
+            rent_reimbursement.address(),
+            ProgramError::InvalidSeeds
+        );
+    }
+    let close_stash =
+        close_stash_seeds.map(|(user, stash_bump)| CloseStashForward { user, stash_bump });
 
     // TODO (snawaz):  unauthorized third-party cleanup/cancellation is possible.
     //
@@ -161,15 +159,14 @@ pub fn process_undelegate_and_close_shuttle_to_owner(
 #[inline(always)]
 fn parse_instruction_data(
     instruction_data: &[u8],
-    expect_close_stash: bool,
 ) -> Result<(u8, Option<([u8; 32], u8)>), ProgramError> {
     let (escrow_index, tail) = match instruction_data.split_first() {
         None => (DEFAULT_ESCROW_INDEX, &[][..]),
         Some((first, rest)) => (*first, rest),
     };
-    let close_stash = match (expect_close_stash, tail.len()) {
-        (false, 0) => None,
-        (true, n) if n == CLOSE_STASH_DATA_LEN => {
+    let close_stash = match tail.len() {
+        0 => None,
+        n if n == CLOSE_STASH_DATA_LEN => {
             let mut user = [0u8; 32];
             user.copy_from_slice(&tail[0..32]);
             Some((user, tail[32]))
@@ -193,7 +190,7 @@ fn schedule_shuttle_close_after_undelegate(
     magic_context: &AccountView,
     magic_program: &AccountView,
     escrow_index: u8,
-    close_stash: Option<&CloseStashForward<'_>>,
+    close_stash: Option<&CloseStashForward>,
 ) -> ProgramResult {
     let (vault_info, _) =
         ephemeral_spl_api::Address::find_program_address(&[mint.as_ref()], &crate::ID);
@@ -205,7 +202,7 @@ fn schedule_shuttle_close_after_undelegate(
         close_handler_data.extend_from_slice(&close.user);
         close_handler_data.push(close.stash_bump);
     }
-    let mut close_handler_accounts = alloc::vec![
+    let close_handler_accounts = alloc::vec![
         ShortAccountMeta {
             pubkey: *rent_reimbursement.address(),
             is_writable: true,
@@ -243,16 +240,6 @@ fn schedule_shuttle_close_after_undelegate(
             is_writable: false,
         },
     ];
-    if let Some(close) = close_stash {
-        close_handler_accounts.push(ShortAccountMeta {
-            pubkey: *close.stash_pda.address(),
-            is_writable: true,
-        });
-        close_handler_accounts.push(ShortAccountMeta {
-            pubkey: *close.rent_pda.address(),
-            is_writable: true,
-        });
-    }
     let close_handler = [CallHandler {
         destination_program: crate::ID,
         escrow_authority: executor.clone(),

--- a/e-token/src/processor/undelegate_and_close_shuttle_to_owner.rs
+++ b/e-token/src/processor/undelegate_and_close_shuttle_to_owner.rs
@@ -14,6 +14,19 @@ const DEFAULT_ESCROW_INDEX: u8 = u8::MAX;
 const INTENT_BUNDLE_DATA_BUF_SIZE: usize = 1536;
 const CLOSE_SHUTTLE_ATA_COMPUTE_UNITS: u32 = 100_000;
 
+/// Length of the optional close-stash payload appended to the ix data:
+/// 32 bytes user pubkey + 1 byte stash bump.
+const CLOSE_STASH_DATA_LEN: usize = 33;
+
+/// Optional accounts/data forwarded into the post-undelegate close handler when the
+/// scheduled flow needs the source stash ATA + stash PDA refunded to the rent PDA.
+struct CloseStashForward<'a> {
+    stash_pda: &'a AccountView,
+    rent_pda: &'a AccountView,
+    user: [u8; 32],
+    stash_bump: u8,
+}
+
 ///
 /// Executes on:
 ///
@@ -29,12 +42,25 @@ const CLOSE_SHUTTLE_ATA_COMPUTE_UNITS: u32 = 100_000;
 ///  7: [writable]          - Any     : Magic context account.
 ///  8: []                  - Program : Magic program.
 ///
-/// Instruction Data: optional escrow_index (u8)
+/// Optional trailing accounts (only when the source token account is a stash ATA
+/// scheduled for cleanup; signaled by 11-account variant + extended ix data):
+///
+///  9: [writable]          - PDA     : Stash PDA (authority of `refund_token_info`).
+/// 10: [writable]          - PDA     : Rent PDA (lamport sink for the closed stash).
+///
+/// Instruction Data: optional escrow_index (u8) optionally followed by 33 bytes
+/// `[user(32) | stash_bump(1)]` for the stash close path.
 ///
 pub fn process_undelegate_and_close_shuttle_to_owner(
     accounts: &[AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
+    let close_stash_accounts = match accounts.len() {
+        9 => None,
+        11 => Some((&accounts[9], &accounts[10])),
+        _ => return Err(ProgramError::NotEnoughAccountKeys),
+    };
+    let head_accounts = &accounts[..9];
     let [
         executor, // force multi-line
         rent_reimbursement,
@@ -45,9 +71,18 @@ pub fn process_undelegate_and_close_shuttle_to_owner(
         token_program_info,
         magic_context,
         magic_program,
-    ] = require_n_accounts!(accounts, 9);
+    ] = require_n_accounts!(head_accounts, 9);
 
-    let escrow_index = parse_escrow_index(instruction_data)?;
+    let (escrow_index, close_stash_seeds) =
+        parse_instruction_data(instruction_data, close_stash_accounts.is_some())?;
+    let close_stash = close_stash_accounts.zip(close_stash_seeds).map(
+        |((stash_pda, rent_pda), (user, stash_bump))| CloseStashForward {
+            stash_pda,
+            rent_pda,
+            user,
+            stash_bump,
+        },
+    );
 
     // TODO (snawaz):  unauthorized third-party cleanup/cancellation is possible.
     //
@@ -126,19 +161,29 @@ pub fn process_undelegate_and_close_shuttle_to_owner(
         magic_context,
         magic_program,
         escrow_index,
+        close_stash.as_ref(),
     )
 }
 
 #[inline(always)]
-fn parse_escrow_index(instruction_data: &[u8]) -> Result<u8, ProgramError> {
-    if instruction_data.is_empty() {
-        return Ok(DEFAULT_ESCROW_INDEX);
-    }
-    require!(
-        instruction_data.len() == 1,
-        ProgramError::InvalidInstructionData
-    );
-    Ok(instruction_data[0])
+fn parse_instruction_data(
+    instruction_data: &[u8],
+    expect_close_stash: bool,
+) -> Result<(u8, Option<([u8; 32], u8)>), ProgramError> {
+    let (escrow_index, tail) = match instruction_data.split_first() {
+        None => (DEFAULT_ESCROW_INDEX, &[][..]),
+        Some((first, rest)) => (*first, rest),
+    };
+    let close_stash = match (expect_close_stash, tail.len()) {
+        (false, 0) => None,
+        (true, n) if n == CLOSE_STASH_DATA_LEN => {
+            let mut user = [0u8; 32];
+            user.copy_from_slice(&tail[0..32]);
+            Some((user, tail[32]))
+        }
+        _ => return Err(ProgramError::InvalidInstructionData),
+    };
+    Ok((escrow_index, close_stash))
 }
 
 #[inline(never)]
@@ -155,14 +200,19 @@ fn schedule_shuttle_close_after_undelegate(
     magic_context: &AccountView,
     magic_program: &AccountView,
     escrow_index: u8,
+    close_stash: Option<&CloseStashForward<'_>>,
 ) -> ProgramResult {
     let (vault_info, _) =
         ephemeral_spl_api::Address::find_program_address(&[mint.as_ref()], &crate::ID);
     let vault_token_info =
         get_associated_token_address(&vault_info, mint, token_program_info.address());
-    let close_handler_data =
+    let mut close_handler_data =
         ESplInternalInstruction::SettleAndCloseShuttleIntent.with_data(&[escrow_index]);
-    let close_handler_accounts = [
+    if let Some(close) = close_stash {
+        close_handler_data.extend_from_slice(&close.user);
+        close_handler_data.push(close.stash_bump);
+    }
+    let mut close_handler_accounts = alloc::vec![
         ShortAccountMeta {
             pubkey: *rent_reimbursement.address(),
             is_writable: true,
@@ -200,6 +250,16 @@ fn schedule_shuttle_close_after_undelegate(
             is_writable: false,
         },
     ];
+    if let Some(close) = close_stash {
+        close_handler_accounts.push(ShortAccountMeta {
+            pubkey: *close.stash_pda.address(),
+            is_writable: true,
+        });
+        close_handler_accounts.push(ShortAccountMeta {
+            pubkey: *close.rent_pda.address(),
+            is_writable: true,
+        });
+    }
     let close_handler = [CallHandler {
         destination_program: crate::ID,
         escrow_authority: executor.clone(),

--- a/e-token/src/processor/undelegate_and_close_shuttle_to_owner.rs
+++ b/e-token/src/processor/undelegate_and_close_shuttle_to_owner.rs
@@ -10,16 +10,11 @@ use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
 
 use crate::instruction::ESplInternalInstruction;
 
-const DEFAULT_ESCROW_INDEX: u8 = u8::MAX;
+pub(crate) const DEFAULT_ESCROW_INDEX: u8 = u8::MAX;
 const INTENT_BUNDLE_DATA_BUF_SIZE: usize = 1536;
 const CLOSE_SHUTTLE_ATA_COMPUTE_UNITS: u32 = 100_000;
-
-/// Length of the optional close-stash payload appended to the ix data:
-/// 32 bytes user pubkey + 1 byte stash bump.
 const CLOSE_STASH_DATA_LEN: usize = 33;
 
-/// Optional accounts/data forwarded into the post-undelegate close handler when the
-/// scheduled flow needs the source stash ATA + stash PDA refunded to the rent PDA.
 struct CloseStashForward<'a> {
     stash_pda: &'a AccountView,
     rent_pda: &'a AccountView,
@@ -42,13 +37,11 @@ struct CloseStashForward<'a> {
 ///  7: [writable]          - Any     : Magic context account.
 ///  8: []                  - Program : Magic program.
 ///
-/// Optional trailing accounts (only when the source token account is a stash ATA
-/// scheduled for cleanup; signaled by 11-account variant + extended ix data):
-///
+/// Optional trailing accounts (11-account variant, scheduled flow only):
 ///  9: [writable]          - PDA     : Stash PDA (authority of `refund_token_info`).
 /// 10: [writable]          - PDA     : Rent PDA (lamport sink for the closed stash).
 ///
-/// Instruction Data: optional escrow_index (u8) optionally followed by 33 bytes
+/// Instruction Data: optional escrow_index (u8), optionally followed by
 /// `[user(32) | stash_bump(1)]` for the stash close path.
 ///
 pub fn process_undelegate_and_close_shuttle_to_owner(

--- a/e-token/src/processor/withdraw_through_delegated_shuttle_with_merge.rs
+++ b/e-token/src/processor/withdraw_through_delegated_shuttle_with_merge.rs
@@ -159,6 +159,7 @@ pub fn process_withdraw_through_delegated_shuttle_with_merge(
             accounts.shuttle_wallet_ata_info.address(),
             accounts.owner_token_info.address(),
             accounts.token_program_info.address(),
+            None,
         ),
     ];
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new instruction to perform deposit + delegation + private transfer with optional stash-close in a single flow.
  * New args type supports user-specific stash-close seeds and encrypted transfer payloads.

* **Improvements**
  * Post-delegation actions now optionally include stash closure; routing updated to handle extended account layouts.
  * Scheduled/private-transfer flows and settlement now propagate stash-close data for end-to-end cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->