### PR TITLE
feat: impl stealth addresses

### DIFF
--- a/e-token-api/src/instruction.rs
+++ b/e-token-api/src/instruction.rs
@@ -88,6 +88,9 @@ pub enum ESplInstruction {
     ///      []
     EnsureTransferQueueCrank = 17,
 
+    /// Unused slot.
+    __Unused0 = 18,
+
     /// 19 - DelegateTransferQueue: delegate the per-mint transfer queue PDA to the delegation program
     ///      Instruction data:
     ///      []        no instruction args
@@ -101,6 +104,17 @@ pub enum ESplInstruction {
     ///      [0..8]   amount (u64 LE)
     ///      [8..40]  salt ([u8; 32])
     SponsoredLamportsTransfer = 20,
+
+    /// 21 - UpdateStealthPool: write or rotate stealth-pool data inside the
+    ///      already delegated ER account. The stored authority must sign
+    ///      existing-pool updates.
+    UpdateStealthPool = 21,
+
+    /// 22 - EnsureStealthPoolDelegated: ensure the zeroed stealth-pool PDA
+    ///      exists on base and is delegated. Destination keys are not part of
+    ///      this instruction; they are written later inside the ER via
+    ///      UpdateStealthPool.
+    EnsureStealthPoolDelegated = 22,
 
     /// 23 - InitializeRentPda: initialize the global rent-sponsoring PDA derived from ["rent"]
     ///      Instruction data:
@@ -264,6 +278,8 @@ impl TryFrom<u8> for ESplInstruction {
             17 => Ok(Self::EnsureTransferQueueCrank),
             19 => Ok(Self::DelegateTransferQueue),
             20 => Ok(Self::SponsoredLamportsTransfer),
+            21 => Ok(Self::UpdateStealthPool),
+            22 => Ok(Self::EnsureStealthPoolDelegated),
             23 => Ok(Self::InitializeRentPda),
             24 => Ok(Self::SetupAndDelegateShuttleEphemeralAtaWithMerge),
             25 => Ok(Self::DepositAndDelegateShuttleEphemeralAtaWithMergeAndPrivateTransfer),

--- a/e-token-api/src/requires.rs
+++ b/e-token-api/src/requires.rs
@@ -1,3 +1,16 @@
+#[inline(always)]
+pub const fn filename_start(path: &'static str) -> usize {
+    let bytes = path.as_bytes();
+    let mut i = bytes.len();
+    while i > 0 {
+        i -= 1;
+        if bytes[i] == b'/' || bytes[i] == b'\\' {
+            return i + 1;
+        }
+    }
+    0
+}
+
 ///
 /// require true
 ///
@@ -6,7 +19,14 @@ macro_rules! require {
     ($cond:expr, $error:expr) => {{
         if !$cond {
             let expr = stringify!($cond);
-            pinocchio_log::log!("require!({}) failed.", expr);
+            const FILE: &str = file!();
+            const FILE_START: usize = $crate::requires::filename_start(FILE);
+            pinocchio_log::log!(
+                "require!({}) failed, {}:{}",
+                expr,
+                &FILE[FILE_START..],
+                line!()
+            );
             return Err($error.into());
         }
     }};
@@ -19,10 +39,14 @@ macro_rules! require {
 macro_rules! require_owned_by {
     ($account:expr, $owner_ref:expr) => {{
         if !pinocchio::address::address_eq(unsafe { $account.owner() }, $owner_ref) {
+            const FILE: &str = file!();
+            const FILE_START: usize = $crate::requires::filename_start(FILE);
             pinocchio_log::log!(
-                "require_owned_by!({}, {}) failed.",
+                "require_owned_by!({}, {}) failed, {}:{}",
                 stringify!($account),
-                stringify!($owner_ref)
+                stringify!($owner_ref),
+                &FILE[FILE_START..],
+                line!()
             );
             $account.address().log();
             unsafe { $account.owner() }.log();
@@ -39,10 +63,14 @@ macro_rules! require_owned_by {
 macro_rules! require_eq_keys {
     ( $key1:expr, $key2:expr, $error:expr) => {{
         if !pinocchio::address::address_eq($key1, $key2) {
+            const FILE: &str = file!();
+            const FILE_START: usize = $crate::requires::filename_start(FILE);
             pinocchio_log::log!(
-                "require_eq_keys!({}, {}) failed: ",
+                "require_eq_keys!({}, {}) failed, {}:{}",
                 stringify!($key1),
-                stringify!($key2)
+                stringify!($key2),
+                &FILE[FILE_START..],
+                line!()
             );
             $key1.log();
             $key2.log();
@@ -58,10 +86,14 @@ macro_rules! require_eq_keys {
 macro_rules! require_ne_keys {
     ( $key1:expr, $key2:expr, $error:expr) => {{
         if pinocchio::address::address_eq($key1, $key2) {
+            const FILE: &str = file!();
+            const FILE_START: usize = $crate::requires::filename_start(FILE);
             pinocchio_log::log!(
-                "require_ne_keys!({}, {}) failed: ",
+                "require_ne_keys!({}, {}) failed, {}:{}",
                 stringify!($key1),
-                stringify!($key2)
+                stringify!($key2),
+                &FILE[FILE_START..],
+                line!()
             );
             $key1.log();
             $key2.log();
@@ -77,12 +109,16 @@ macro_rules! require_ne_keys {
 macro_rules! require_le {
     ( $val1:expr, $val2:expr, $error:expr) => {{
         if !($val1 <= $val2) {
+            const FILE: &str = file!();
+            const FILE_START: usize = $crate::requires::filename_start(FILE);
             pinocchio_log::log!(
-                "require_le!({}, {}) failed: {} <= {}",
+                "require_le!({}, {}) failed: {} <= {}, {}:{}",
                 stringify!($val1),
                 stringify!($val2),
                 $val1,
-                $val2
+                $val2,
+                &FILE[FILE_START..],
+                line!()
             );
             return Err($error.into());
         }
@@ -96,12 +132,16 @@ macro_rules! require_le {
 macro_rules! require_lt {
     ( $val1:expr, $val2:expr, $error:expr) => {{
         if !($val1 < $val2) {
+            const FILE: &str = file!();
+            const FILE_START: usize = $crate::requires::filename_start(FILE);
             pinocchio_log::log!(
-                "require_lt!({}, {}) failed: {} < {}",
+                "require_lt!({}, {}) failed: {} < {}, {}:{}",
                 stringify!($val1),
                 stringify!($val2),
                 $val1,
-                $val2
+                $val2,
+                &FILE[FILE_START..],
+                line!()
             );
             return Err($error.into());
         }
@@ -115,12 +155,16 @@ macro_rules! require_lt {
 macro_rules! require_eq {
     ( $val1:expr, $val2:expr, $error:expr) => {{
         if !($val1 == $val2) {
+            const FILE: &str = file!();
+            const FILE_START: usize = $crate::requires::filename_start(FILE);
             pinocchio_log::log!(
-                "require_eq!({}, {}) failed: {} == {}",
+                "require_eq!({}, {}) failed: {} == {}, {}:{}",
                 stringify!($val1),
                 stringify!($val2),
                 $val1,
-                $val2
+                $val2,
+                &FILE[FILE_START..],
+                line!()
             );
             return Err($error.into());
         }
@@ -134,12 +178,16 @@ macro_rules! require_eq {
 macro_rules! require_ge {
     ( $val1:expr, $val2:expr, $error:expr) => {{
         if !($val1 >= $val2) {
+            const FILE: &str = file!();
+            const FILE_START: usize = $crate::requires::filename_start(FILE);
             pinocchio_log::log!(
-                "require_ge!({}, {}) failed: {} >= {}",
+                "require_ge!({}, {}) failed: {} >= {}, {}:{}",
                 stringify!($val1),
                 stringify!($val2),
                 $val1,
-                $val2
+                $val2,
+                &FILE[FILE_START..],
+                line!()
             );
             return Err($error.into());
         }
@@ -153,12 +201,16 @@ macro_rules! require_ge {
 macro_rules! require_gt {
     ( $val1:expr, $val2:expr, $error:expr) => {{
         if !($val1 > $val2) {
+            const FILE: &str = file!();
+            const FILE_START: usize = $crate::requires::filename_start(FILE);
             pinocchio_log::log!(
-                "require_gt!({}, {}) failed: {} > {}",
+                "require_gt!({}, {}) failed: {} > {}, {}:{}",
                 stringify!($val1),
                 stringify!($val2),
                 $val1,
-                $val2
+                $val2,
+                &FILE[FILE_START..],
+                line!()
             );
             return Err($error.into());
         }
@@ -173,20 +225,28 @@ macro_rules! require_n_accounts {
     ( $accounts:expr, $n:literal) => {{
         match $accounts.len().cmp(&$n) {
             core::cmp::Ordering::Less => {
+                const FILE: &str = file!();
+                const FILE_START: usize = $crate::requires::filename_start(FILE);
                 pinocchio_log::log!(
-                    "Need {} accounts, but got less ({}) accounts",
+                    "Need {} accounts, but got less ({}) accounts, {}:{}",
                     $n,
-                    $accounts.len()
+                    $accounts.len(),
+                    &FILE[FILE_START..],
+                    line!()
                 );
                 return Err(pinocchio::error::ProgramError::NotEnoughAccountKeys);
             }
             core::cmp::Ordering::Equal => TryInto::<&[_; $n]>::try_into($accounts)
                 .map_err(|_| $crate::error::EphemeralSplError::InfallibleError)?,
             core::cmp::Ordering::Greater => {
+                const FILE: &str = file!();
+                const FILE_START: usize = $crate::requires::filename_start(FILE);
                 pinocchio_log::log!(
-                    "Need {} accounts, but got more ({}) accounts",
+                    "Need {} accounts, but got more ({}) accounts, {}:{}",
                     $n,
-                    $accounts.len()
+                    $accounts.len(),
+                    &FILE[FILE_START..],
+                    line!()
                 );
                 return Err($crate::error::EphemeralSplError::TooManyAccountKeys.into());
             }
@@ -202,10 +262,14 @@ macro_rules! require_n_accounts_with_optionals {
     ( $accounts:expr, $n:literal) => {{
         match $accounts.len().cmp(&$n) {
             core::cmp::Ordering::Less => {
+                const FILE: &str = file!();
+                const FILE_START: usize = $crate::requires::filename_start(FILE);
                 pinocchio_log::log!(
-                    "Need {} accounts, but got less ({}) accounts",
+                    "Need {} accounts, but got less ({}) accounts, {}:{}",
                     $n,
-                    $accounts.len()
+                    $accounts.len(),
+                    &FILE[FILE_START..],
+                    line!()
                 );
                 return Err(pinocchio::error::ProgramError::NotEnoughAccountKeys);
             }
@@ -230,10 +294,14 @@ macro_rules! require_n_accounts_with_ignored {
     ( $accounts:expr, $n:literal) => {{
         match $accounts.len().cmp(&$n) {
             core::cmp::Ordering::Less => {
+                const FILE: &str = file!();
+                const FILE_START: usize = $crate::requires::filename_start(FILE);
                 pinocchio_log::log!(
-                    "Need {} accounts, but got less ({}) accounts",
+                    "Need {} accounts, but got less ({}) accounts, {}:{}",
                     $n,
-                    $accounts.len()
+                    $accounts.len(),
+                    &FILE[FILE_START..],
+                    line!()
                 );
                 return Err(pinocchio::error::ProgramError::NotEnoughAccountKeys);
             }
@@ -254,7 +322,58 @@ macro_rules! require_some {
     ($option:expr, $error:expr) => {{
         match $option {
             Some(val) => val,
-            None => return Err($error.into()),
+            None => {
+                const FILE: &str = file!();
+                const FILE_START: usize = $crate::requires::filename_start(FILE);
+                pinocchio_log::log!(
+                    "require_some!({}) failed, {}:{}",
+                    stringify!($option),
+                    &FILE[FILE_START..],
+                    line!()
+                );
+                return Err($error.into());
+            }
+        }
+    }};
+}
+
+///
+/// require Result to be Ok
+///
+#[macro_export]
+macro_rules! require_ok {
+    ($result:expr) => {{
+        match $result {
+            Ok(val) => val,
+            Err(e) => {
+                const FILE: &str = file!();
+                const FILE_START: usize = $crate::requires::filename_start(FILE);
+                pinocchio_log::log!(
+                    "require_ok!({}) failed: {}, {}:{}",
+                    stringify!($result),
+                    alloc::format!("{:?}", e).as_str(),
+                    &FILE[FILE_START..],
+                    line!()
+                );
+                return Err(e.into());
+            }
+        }
+    }};
+    ($result:expr, $error:expr) => {{
+        match $result {
+            Ok(val) => val,
+            Err(e) => {
+                const FILE: &str = file!();
+                const FILE_START: usize = $crate::requires::filename_start(FILE);
+                pinocchio_log::log!(
+                    "require_ok!({}) failed: {}, {}:{}",
+                    stringify!($result),
+                    alloc::format!("{:?}", e).as_str(),
+                    &FILE[FILE_START..],
+                    line!()
+                );
+                return Err($error.into());
+            }
         }
     }};
 }

--- a/e-token-api/src/state/mod.rs
+++ b/e-token-api/src/state/mod.rs
@@ -5,6 +5,7 @@ pub mod global_vault;
 pub mod group_receipt;
 pub mod shuttle_ephemeral_ata;
 pub mod stash;
+pub mod stealth_pool;
 pub mod transfer_queue;
 pub mod transfer_queue_refill;
 

--- a/e-token-api/src/state/stealth_pool.rs
+++ b/e-token-api/src/state/stealth_pool.rs
@@ -107,15 +107,19 @@ impl StealthPool {
     }
 }
 
+///
+/// BitMask Flags
+///
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum StealthPoolFlags {
-    SplitAcrossKeys = 1 << 0,
+    Empty = 0x00, // means no flags
+    SplitAcrossKeys = 0x01,
 }
 
 impl StealthPoolFlags {
-    pub const MIN: u8 = StealthPoolFlags::SplitAcrossKeys.value();
-    pub const MAX: u8 = StealthPoolFlags::SplitAcrossKeys.value();
+    pub const MASK: u8 =
+        StealthPoolFlags::Empty.value() | StealthPoolFlags::SplitAcrossKeys.value();
 
     #[inline(always)]
     pub const fn value(self) -> u8 {
@@ -127,6 +131,37 @@ impl StealthPoolFlags {
     }
 
     pub const fn is_valid(flags: u8) -> bool {
-        flags >= Self::MIN && flags <= Self::MAX
+        flags & !Self::MASK == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StealthPoolFlags;
+
+    #[test]
+    fn stealth_pool_flags_accept_empty_and_known_bits() {
+        assert!(StealthPoolFlags::is_valid(StealthPoolFlags::Empty.value()));
+        assert!(StealthPoolFlags::is_valid(
+            StealthPoolFlags::SplitAcrossKeys.value()
+        ));
+        assert!(StealthPoolFlags::is_valid(
+            StealthPoolFlags::Empty.value() | StealthPoolFlags::SplitAcrossKeys.value()
+        ));
+    }
+
+    #[test]
+    fn stealth_pool_flags_reject_unknown_bits() {
+        assert!(!StealthPoolFlags::is_valid(1 << 1));
+        assert!(!StealthPoolFlags::is_valid(
+            StealthPoolFlags::SplitAcrossKeys.value() | (1 << 1)
+        ));
+        assert!(!StealthPoolFlags::is_valid(u8::MAX));
+    }
+
+    #[test]
+    fn stealth_pool_flags_check_membership_by_bit() {
+        assert!(!StealthPoolFlags::SplitAcrossKeys.is_in(StealthPoolFlags::Empty.value()));
+        assert!(StealthPoolFlags::SplitAcrossKeys.is_in(StealthPoolFlags::SplitAcrossKeys.value()));
     }
 }

--- a/e-token-api/src/state/stealth_pool.rs
+++ b/e-token-api/src/state/stealth_pool.rs
@@ -1,0 +1,132 @@
+use bytemuck::{Pod, Zeroable};
+use pinocchio::{cpi::Seed, error::ProgramError, Address};
+
+use crate::{
+    require, require_eq_keys,
+    state::{Initializable, RawType},
+};
+
+// TODO (snawaz): can be replaced with fixed_offset_layout, or
+// variable_offset_layout that provides flexibility.
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+pub struct StealthPool {
+    // Type marker that prevents unrelated program-owned accounts from resolving as pools.
+    pub discriminator: [u8; 8],
+    pub bump: u8,
+    //
+    // Pool-level behavior config. When FLAG_SPLIT_ACROSS_KEYS is set,
+    // split payments may resolve each split independently across destination
+    // keys; otherwise all splits in a payment group resolve to the same key.
+    //
+    // Unknown flag bits are rejected during pool initialization.
+    //
+    pub flags: u8,
+    pub authority: Address,
+    //
+    // Deterministic handle identifier, usually `hash(canonical_handle)`
+    // where canonical_handle could be human-readable id such as `magicblock.id`
+    // or `myname@mydomain`.
+    //
+    // The original handle string is not stored, so the program can route
+    // payments by handle hash but cannot recover or display the handle text.
+    //
+    pub handle_hash: [u8; 32],
+    pub destination_count: u8,
+    pub destinations: [Address; 10],
+}
+
+impl Initializable for StealthPool {
+    #[inline(always)]
+    fn is_initialized(&self) -> bool {
+        self.discriminator == StealthPool::DISCRIMINATOR
+            && self.destination_count != 0
+            && self.destination_count as usize <= StealthPool::MAX_DESTINATIONS
+    }
+}
+
+impl RawType for StealthPool {
+    const LEN: usize = core::mem::size_of::<StealthPool>();
+}
+
+impl StealthPool {
+    // The discriminator has name + version
+    pub const DISCRIMINATOR: [u8; 8] = *b"stpool@1";
+
+    pub const SEED: &'static [u8] = b"stealth_pool";
+
+    pub const MAX_DESTINATIONS: usize = 10;
+
+    #[inline(always)]
+    pub fn derive_pda(handle_hash: &[u8; 32], bump_seed: u8) -> Result<Address, ProgramError> {
+        let bump = [bump_seed];
+        Ok(Address::create_program_address(
+            &Self::seeds_with_bump(handle_hash, &bump),
+            &crate::ID,
+        )?)
+    }
+
+    #[inline(always)]
+    pub fn find_pda(handle_hash: &[u8; 32]) -> (Address, u8) {
+        Address::find_program_address(&Self::seeds(handle_hash), &crate::ID)
+    }
+
+    #[inline(always)]
+    pub fn seeds<'a>(handle_hash: &'a [u8; 32]) -> [&'a [u8]; 2] {
+        [Self::SEED, handle_hash.as_ref()]
+    }
+
+    #[inline(always)]
+    pub fn seeds_with_bump<'a>(handle_hash: &'a [u8; 32], bump: &'a [u8]) -> [&'a [u8]; 3] {
+        [Self::SEED, handle_hash.as_ref(), bump]
+    }
+
+    #[inline(always)]
+    pub fn signer_seeds<'a>(handle_hash: &'a [u8; 32], bump: &'a [u8]) -> [Seed<'a>; 3] {
+        [
+            Seed::from(Self::SEED),
+            Seed::from(handle_hash.as_ref()),
+            Seed::from(bump),
+        ]
+    }
+
+    #[inline(always)]
+    pub fn validate_pda(&self, address_of_self: &Address) -> Result<(), ProgramError> {
+        require!(self.is_initialized(), ProgramError::InvalidAccountData);
+
+        let derived = Self::derive_pda(&self.handle_hash, self.bump)?;
+
+        require_eq_keys!(&derived, address_of_self, ProgramError::InvalidSeeds);
+
+        Ok(())
+    }
+
+    #[inline(always)]
+    pub fn split_across_keys(&self) -> bool {
+        StealthPoolFlags::SplitAcrossKeys.is_in(self.flags)
+    }
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StealthPoolFlags {
+    SplitAcrossKeys = 1 << 0,
+}
+
+impl StealthPoolFlags {
+    pub const MIN: u8 = StealthPoolFlags::SplitAcrossKeys.value();
+    pub const MAX: u8 = StealthPoolFlags::SplitAcrossKeys.value();
+
+    #[inline(always)]
+    pub const fn value(self) -> u8 {
+        self as u8
+    }
+
+    pub const fn is_in(self, flags: u8) -> bool {
+        flags & self.value() != 0
+    }
+
+    pub const fn is_valid(flags: u8) -> bool {
+        flags <= Self::MAX
+    }
+}

--- a/e-token-api/src/state/stealth_pool.rs
+++ b/e-token-api/src/state/stealth_pool.rs
@@ -127,6 +127,6 @@ impl StealthPoolFlags {
     }
 
     pub const fn is_valid(flags: u8) -> bool {
-        flags <= Self::MAX
+        flags >= Self::MIN && flags <= Self::MAX
     }
 }

--- a/e-token/src/entrypoint.rs
+++ b/e-token/src/entrypoint.rs
@@ -70,6 +70,7 @@ fn process_public_instruction(accounts: &[AccountView], instruction_data: &[u8])
     match ESplInstruction::try_from(discriminator[0])
         .map_err(|_| EphemeralSplError::InstructionNotFound)?
     {
+        ESplInstruction::__Unused0 => Err(EphemeralSplError::InstructionNotFound.into()),
         ESplInstruction::InitializeEphemeralAta => {
             debug_log!("Instruction: InitializeEphemeralAta");
 
@@ -187,6 +188,16 @@ fn process_public_instruction(accounts: &[AccountView], instruction_data: &[u8])
             debug_log!("Instruction: EnsureTransferQueueCrank");
 
             process_ensure_transfer_queue_crank(accounts, data)
+        }
+        ESplInstruction::UpdateStealthPool => {
+            debug_log!("Instruction: UpdateStealthPool");
+
+            process_update_stealth_pool(accounts, data)
+        }
+        ESplInstruction::EnsureStealthPoolDelegated => {
+            debug_log!("Instruction: EnsureStealthPoolDelegated");
+
+            process_ensure_stealth_pool_delegated(accounts, data)
         }
         ESplInstruction::DelegateTransferQueue => {
             debug_log!("Instruction: DelegateTransferQueue");

--- a/e-token/src/lib.rs
+++ b/e-token/src/lib.rs
@@ -12,5 +12,6 @@ pub use processor::{
     AmountAndSaltArgs, DelegateArgs, DelegateShuttleArgs, DepositAndDelegateShuttleArgs,
     DepositAndDelegateShuttleWithPrivateTransferAndStashCloseArgs,
     DepositAndDelegateShuttleWithPrivateTransferArgs, DepositAndQueueTransferArgs,
-    ExecuteQueuedTransferArgs, InitializeTransferQueueArgs,
+    EnsureStealthPoolDelegatedArgs, ExecuteQueuedTransferArgs, InitializeTransferQueueArgs,
+    UpdateStealthPoolArgs,
 };

--- a/e-token/src/processor/deposit_and_queue_transfer.rs
+++ b/e-token/src/processor/deposit_and_queue_transfer.rs
@@ -11,6 +11,7 @@ use core::convert::TryFrom;
 use data_layout::variable_offset_layout;
 use ephemeral_rollups_pinocchio::consts::MAGIC_PROGRAM_ID;
 use ephemeral_spl_api::debug_log;
+use ephemeral_spl_api::state::stealth_pool::StealthPool;
 #[cfg(feature = "logging")]
 use ephemeral_spl_api::state::transfer_queue::capacity_from_data_len;
 use ephemeral_spl_api::state::transfer_queue::{
@@ -18,11 +19,12 @@ use ephemeral_spl_api::state::transfer_queue::{
     queue_set_token_program_kind_from_data, QueuedTransfer, TransferQueue,
     QUEUED_TRANSFER_FLAG_CREATE_IDEMPOTENT_ATA,
 };
+use ephemeral_spl_api::state::RawType;
 use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
 use pinocchio::address::address_eq;
 use pinocchio::sysvars::clock::Clock;
 use pinocchio::sysvars::Sysvar;
-use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
 use pinocchio_token_2022::instructions::TransferChecked;
 
 const MILLIS_PER_SECOND: u64 = 1_000;
@@ -36,7 +38,7 @@ const MILLIS_PER_SECOND: u64 = 1_000;
 ///  1: []                  - PDA     : Vault authority account (global vault or transfer queue).
 ///  2: []                  - SPL     : Mint account.
 ///  3: [writable]          - SPL     : User source token account.
-///  4: [writable]          - SPL     : Vault destination token account.
+///  4: [writable]          - SPL     : Vault token account.
 ///  5: []                  - Any     : Destination owner.
 ///  6: [signer]            - Keypair : Sender authority.
 ///  7: []                  - SPL     : Token program.
@@ -135,13 +137,8 @@ pub fn process_deposit_and_queue_transfer(
 
     let now_ms = queue_timestamp_now()?;
 
-    require!(
-        !address_eq(
-            unsafe { destination_info.owner() },
-            token_program_info.address()
-        ),
-        ProgramError::InvalidAccountData
-    );
+    let destination_resolution =
+        DestinationResolution::from_account(destination_info, token_program_info.address())?;
 
     if address_eq(vault_info.address(), queue_info.address()) {
         let queue_vault = validate_queue_vault_for_mint(
@@ -182,17 +179,30 @@ pub fn process_deposit_and_queue_transfer(
     }
 
     let source = *user_authority.address();
-    let destination_owner = *destination_info.address();
     let client_ref_id = args.client_ref_id().unwrap_or(0);
     let split_plan = build_split_plan(amount, split, decimals)?;
 
     let data = unsafe { queue_info.borrow_unchecked_mut() };
     queue_set_token_program_kind_from_data(data, queue_token_program_kind)?;
+    let group_destination_owner = destination_resolution.group_destination(
+        &source,
+        group_id,
+        queue_len_before,
+        client_ref_id,
+    )?;
     for index in 0..split {
         let queued_amount = split_plan.amount_for_index(index);
         let queue_position = queue_len_before
             .checked_add(index)
             .ok_or(ProgramError::InvalidInstructionData)?;
+        let destination_owner = destination_resolution.destination_for_split(
+            group_destination_owner,
+            &source,
+            group_id,
+            queue_position,
+            client_ref_id,
+            index,
+        )?;
         let selected_delay_ms = choose_split_delay_ms(
             args.min_delay_ms(),
             args.max_delay_ms(),
@@ -265,6 +275,111 @@ pub fn process_deposit_and_queue_transfer(
     });
 
     Ok(())
+}
+
+#[derive(Copy, Clone)]
+enum DestinationResolution {
+    Direct(Address),
+    StealthPool(StealthPool),
+}
+
+impl DestinationResolution {
+    #[inline(always)]
+    fn from_account(
+        destination_info: &AccountView,
+        token_program: &Address,
+    ) -> Result<Self, ProgramError> {
+        require!(
+            !address_eq(unsafe { destination_info.owner() }, token_program),
+            ProgramError::InvalidAccountData
+        );
+
+        if destination_info.owned_by(&crate::ID) && destination_info.data_len() == StealthPool::LEN
+        {
+            let data = unsafe { destination_info.borrow_unchecked() };
+            let pool = bytemuck::try_from_bytes::<StealthPool>(data)
+                .map_err(|_| ProgramError::InvalidAccountData)?;
+            if pool.discriminator == StealthPool::DISCRIMINATOR {
+                pool.validate_pda(destination_info.address())?;
+                return Ok(Self::StealthPool(*pool));
+            }
+        }
+
+        Ok(Self::Direct(*destination_info.address()))
+    }
+
+    #[inline(always)]
+    fn group_destination(
+        &self,
+        source: &Address,
+        group_id: u32,
+        queue_position: usize,
+        client_ref_id: u64,
+    ) -> Result<Option<Address>, ProgramError> {
+        match self {
+            Self::Direct(destination) => Ok(Some(*destination)),
+            Self::StealthPool(pool) => {
+                let destination_count = pool.destination_count as usize;
+                require!(
+                    destination_count != 0 && destination_count <= StealthPool::MAX_DESTINATIONS,
+                    ProgramError::InvalidAccountData
+                );
+                if destination_count == 1 {
+                    return Ok(Some(pool.destinations[0]));
+                }
+
+                if pool.split_across_keys() {
+                    return Ok(None);
+                }
+
+                let selected = hash_stealth_pool_seed(
+                    pool,
+                    source,
+                    group_id,
+                    queue_position,
+                    client_ref_id,
+                    0,
+                ) % destination_count as u64;
+                Ok(Some(pool.destinations[selected as usize]))
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn destination_for_split(
+        &self,
+        group_destination: Option<Address>,
+        source: &Address,
+        group_id: u32,
+        queue_position: usize,
+        client_ref_id: u64,
+        split_index: usize,
+    ) -> Result<Address, ProgramError> {
+        match self {
+            Self::StealthPool(pool) if pool.split_across_keys() && pool.destination_count > 1 => {
+                let destination_count = pool.destination_count as usize;
+                require!(
+                    destination_count <= StealthPool::MAX_DESTINATIONS,
+                    ProgramError::InvalidAccountData
+                );
+                // TODO (snawaz): we have 2 options here:
+                //  - hash_stealth_pool_seed()
+                //  - round_robin_stealth_pool_index()
+                // since hash_stealth_pool_seed() seems to be expensive, measure CU consumption and
+                // make decision.
+                let selected = hash_stealth_pool_seed(
+                    pool,
+                    source,
+                    group_id,
+                    queue_position,
+                    client_ref_id,
+                    split_index,
+                ) % destination_count as u64;
+                Ok(pool.destinations[selected as usize])
+            }
+            _ => group_destination.ok_or(ProgramError::InvalidAccountData),
+        }
+    }
 }
 
 #[variable_offset_layout(buffer_offset = 1, option = implicit)]
@@ -477,4 +592,59 @@ fn hash_delay_seed(destination: &ephemeral_spl_api::Address, queue_position: u64
     hash ^= queue_position;
     hash = hash.wrapping_mul(0x100_0000_01b3);
     hash ^ (hash >> 32)
+}
+
+#[inline(always)]
+fn hash_stealth_pool_seed(
+    pool: &StealthPool,
+    source: &Address,
+    group_id: u32,
+    queue_position: usize,
+    client_ref_id: u64,
+    split_index: usize,
+) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in pool.handle_hash.iter() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100_0000_01b3);
+    }
+    for byte in source.as_ref().iter() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100_0000_01b3);
+    }
+    for byte in group_id.to_le_bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x100_0000_01b3);
+    }
+    for byte in (queue_position as u64).to_le_bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x100_0000_01b3);
+    }
+    for byte in client_ref_id.to_le_bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x100_0000_01b3);
+    }
+    for byte in (split_index as u64).to_le_bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x100_0000_01b3);
+    }
+    hash ^ (hash >> 32)
+}
+
+#[allow(dead_code)]
+#[inline(always)]
+fn round_robin_stealth_pool_index(
+    group_id: u32,
+    split_index: usize,
+    destination_count: usize,
+) -> usize {
+    // Candidate lower-CU selector for stealth pools.
+    //
+    // `group_id` is allocated once per enqueue group, so it naturally rotates
+    // separate payments through the destination list. Passing `split_index = 0`
+    // gives one key for the whole group; passing the actual split index makes
+    // split fanout walk consecutive keys.
+    //
+    // Caller must validate `destination_count != 0`.
+    ((group_id.saturating_sub(1) as usize).wrapping_add(split_index)) % destination_count
 }

--- a/e-token/src/processor/ensure_stealth_pool_delegated.rs
+++ b/e-token/src/processor/ensure_stealth_pool_delegated.rs
@@ -1,0 +1,135 @@
+use alloc::vec;
+use alloc::vec::Vec;
+use data_layout::variable_offset_layout;
+use ephemeral_rollups_pinocchio::instruction::DelegateAccountCpiBuilder;
+use ephemeral_rollups_pinocchio::types::DelegateConfig;
+use ephemeral_spl_api::state::stealth_pool::StealthPool;
+use ephemeral_spl_api::state::RawType;
+use ephemeral_spl_api::{require, require_eq_keys, require_n_accounts};
+use pinocchio::cpi::Signer;
+use pinocchio::sysvars::rent::Rent;
+use pinocchio::sysvars::Sysvar;
+use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
+use pinocchio_system::instructions::CreateAccount;
+
+///
+/// Executes on: base.
+///
+/// Accounts:
+///
+///  0: [signer]            - Keypair : Payer.
+///  1: [writable]          - PDA     : Stealth pool account.
+///  2: []                  - Program : Owner program (this program).
+///  3: [writable]          - PDA     : Buffer account.
+///  4: [writable]          - PDA     : Delegation record account.
+///  5: [writable]          - PDA     : Delegation metadata account.
+///  6: []                  - Program : Delegation program.
+///  7: []                  - Builtin : System program.
+///
+/// Instruction Data: EnsureStealthPoolDelegatedArgs
+///
+pub fn process_ensure_stealth_pool_delegated(
+    accounts: &[AccountView],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    let [
+        payer_info, // force multi-line
+        stealth_pool_info,
+        owner_program,
+        buffer_acc,
+        delegation_record,
+        delegation_metadata,
+        _delegation_program,
+        system_program,
+    ] = require_n_accounts!(accounts, 8);
+
+    let args = EnsureStealthPoolDelegatedArgs::decode(instruction_data)?;
+
+    require!(
+        payer_info.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
+
+    let (derived_pool, bump) = StealthPool::find_pda(args.handle_hash());
+    require_eq_keys!(
+        &derived_pool,
+        stealth_pool_info.address(),
+        ProgramError::InvalidSeeds
+    );
+
+    let delegation_program = ephemeral_spl_api::program::DELEGATION_PROGRAM_ID;
+    if stealth_pool_info.owned_by(&delegation_program) {
+        return Ok(());
+    }
+
+    if !stealth_pool_info.owned_by(&crate::ID) {
+        require!(
+            stealth_pool_info.lamports() == 0,
+            ProgramError::IllegalOwner
+        );
+
+        let rent = Rent::get()?;
+        let lamports = rent.try_minimum_balance(StealthPool::LEN)?;
+        let bump_seed = [bump];
+        let signer_seeds = StealthPool::signer_seeds(args.handle_hash(), &bump_seed);
+        let signer = Signer::from(&signer_seeds);
+
+        CreateAccount {
+            from: payer_info,
+            to: stealth_pool_info,
+            space: StealthPool::LEN as u64,
+            lamports,
+            owner: &crate::ID,
+        }
+        .invoke_signed(&[signer])?;
+    } else {
+        require!(
+            stealth_pool_info.data_len() == StealthPool::LEN,
+            ProgramError::InvalidAccountData
+        );
+    }
+
+    require_eq_keys!(
+        owner_program.address(),
+        &crate::ID,
+        ProgramError::IncorrectProgramId
+    );
+    require_eq_keys!(
+        system_program.address(),
+        &pinocchio_system::ID,
+        ProgramError::IncorrectProgramId
+    );
+
+    let config = DelegateConfig {
+        validator: args
+            .validator()
+            .map(|slice| Address::new_from_array(*slice)),
+        ..DelegateConfig::default()
+    };
+    let seeds = StealthPool::seeds(args.handle_hash());
+
+    DelegateAccountCpiBuilder::new(
+        payer_info,
+        stealth_pool_info,
+        owner_program,
+        buffer_acc,
+        delegation_record,
+        delegation_metadata,
+        system_program,
+    )
+    .seeds(&seeds)
+    .bump(bump)
+    .config(config)
+    .invoke()
+}
+
+#[variable_offset_layout(buffer_offset = 1, option = implicit)]
+pub struct EnsureStealthPoolDelegatedArgs {
+    pub handle_hash: [u8; 32],
+    pub validator: Option<[u8; 32]>,
+}
+
+static_assertions::const_assert!(matches!(
+    EnsureStealthPoolDelegatedArgs::DATA_LENS,
+    [32, 64]
+));

--- a/e-token/src/processor/mod.rs
+++ b/e-token/src/processor/mod.rs
@@ -12,6 +12,7 @@ pub mod deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transf
 pub mod deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer_and_stash_close;
 pub mod deposit_and_queue_transfer;
 pub mod deposit_spl_tokens;
+pub mod ensure_stealth_pool_delegated;
 pub mod ensure_transfer_queue_crank;
 pub mod execute_pending_transfer_queue_refill;
 pub mod execute_ready_queued_transfer;
@@ -35,6 +36,7 @@ pub mod undelegate_ephemeral_ata;
 pub mod undelegate_ephemeral_ata_permission;
 pub mod undelegate_lamports_pda;
 pub mod undelegation_callback;
+pub mod update_stealth_pool;
 pub(crate) mod utils;
 pub mod withdraw_spl_tokens;
 pub mod withdraw_through_delegated_shuttle_with_merge;
@@ -65,6 +67,9 @@ pub use deposit_and_queue_transfer::{
     process_deposit_and_queue_transfer, DepositAndQueueTransferArgs,
 };
 pub use deposit_spl_tokens::process_deposit_spl_tokens;
+pub use ensure_stealth_pool_delegated::{
+    process_ensure_stealth_pool_delegated, EnsureStealthPoolDelegatedArgs,
+};
 pub use ensure_transfer_queue_crank::process_ensure_transfer_queue_crank;
 pub use execute_pending_transfer_queue_refill::process_execute_pending_transfer_queue_refill;
 pub use execute_ready_queued_transfer::{
@@ -86,6 +91,7 @@ pub use schedule_private_transfer::process_schedule_private_transfer;
 pub use sponsored_lamports_transfer::process_sponsored_lamports_transfer;
 pub use transfer_lamports_pda::process_transfer_lamports_pda;
 pub use transfer_queue_tick::process_transfer_queue_tick;
+pub use update_stealth_pool::{process_update_stealth_pool, UpdateStealthPoolArgs};
 pub use undelegate_and_close_shuttle_to_owner::process_undelegate_and_close_shuttle_to_owner;
 pub use undelegate_ephemeral_ata::process_undelegate_ephemeral_ata;
 pub use undelegate_ephemeral_ata_permission::process_undelegate_ephemeral_ata_permission;

--- a/e-token/src/processor/update_stealth_pool.rs
+++ b/e-token/src/processor/update_stealth_pool.rs
@@ -100,7 +100,7 @@ pub fn process_update_stealth_pool(
 pub struct UpdateStealthPoolArgs {
     pub handle_hash: [u8; 32],
     // TODO (snawaz): support enum based flags in data-layout
-    pub flags: u8,
+    pub flags: u8, // StealthPoolFlags
     #[flexible = 1]
     pub destinations: Vec<[u8; 32]>,
 }

--- a/e-token/src/processor/update_stealth_pool.rs
+++ b/e-token/src/processor/update_stealth_pool.rs
@@ -1,0 +1,109 @@
+use alloc::vec;
+use alloc::vec::Vec;
+use data_layout::variable_offset_layout;
+use ephemeral_spl_api::require_n_accounts;
+use ephemeral_spl_api::state::stealth_pool::{StealthPool, StealthPoolFlags};
+use ephemeral_spl_api::state::{Initializable, RawType};
+use ephemeral_spl_api::{require, require_eq_keys};
+use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
+
+///
+/// Executes on: ER only.
+///
+/// Accounts:
+///
+///  0: []                  - Keypair : Payer.
+///  1: [writable]          - PDA     : Stealth pool account.
+///  2: [signer]            - Keypair : Pool authority.
+///  3: []                  - Builtin : System program.
+///
+/// Instruction Data: UpdateStealthPoolArgs
+///
+#[inline(always)]
+pub fn process_update_stealth_pool(
+    accounts: &[AccountView],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    let [
+        _payer_info, // force multi-line
+        stealth_pool_info,
+        authority_info,
+        _system_program_info,
+    ] = require_n_accounts!(accounts, 4);
+
+    let args = UpdateStealthPoolArgs::decode(instruction_data)?;
+    let destination_addresses = bytemuck::try_cast_slice::<[u8; 32], Address>(args.destinations())
+        .map_err(|_| ProgramError::InvalidInstructionData)?;
+    let destination_count = destination_addresses.len();
+
+    require!(
+        destination_count != 0 && destination_count <= StealthPool::MAX_DESTINATIONS,
+        ProgramError::InvalidInstructionData
+    );
+    require!(
+        StealthPoolFlags::is_valid(args.flags()),
+        ProgramError::InvalidInstructionData
+    );
+    require!(
+        authority_info.is_signer(),
+        ProgramError::MissingRequiredSignature
+    );
+
+    let (derived_pool, bump) = StealthPool::find_pda(args.handle_hash());
+    require_eq_keys!(
+        &derived_pool,
+        stealth_pool_info.address(),
+        ProgramError::InvalidSeeds
+    );
+
+    require!(
+        stealth_pool_info.owned_by(&crate::ID),
+        ProgramError::InvalidAccountOwner
+    );
+    require!(
+        stealth_pool_info.data_len() == StealthPool::LEN,
+        ProgramError::InvalidAccountData
+    );
+    let data = unsafe { stealth_pool_info.borrow_unchecked() };
+    let existing = bytemuck::try_from_bytes::<StealthPool>(data)
+        .map_err(|_| ProgramError::InvalidAccountData)?;
+    if existing.is_initialized() {
+        require_eq_keys!(
+            &existing.authority,
+            authority_info.address(),
+            ProgramError::MissingRequiredSignature
+        );
+    }
+
+    let data = unsafe { stealth_pool_info.borrow_unchecked_mut() };
+    let pool = bytemuck::try_from_bytes_mut::<StealthPool>(data)
+        .map_err(|_| ProgramError::InvalidAccountData)?;
+
+    *pool = StealthPool {
+        discriminator: StealthPool::DISCRIMINATOR,
+        bump,
+        destination_count: destination_count as u8,
+        flags: args.flags(),
+        authority: *authority_info.address(),
+        handle_hash: *args.handle_hash(),
+        destinations: {
+            let mut destinations = [Address::default(); StealthPool::MAX_DESTINATIONS];
+            destinations[..destination_count].copy_from_slice(destination_addresses);
+            destinations
+        },
+    };
+
+    Ok(())
+}
+
+#[variable_offset_layout(buffer_offset = 1)]
+pub struct UpdateStealthPoolArgs {
+    pub handle_hash: [u8; 32],
+    // TODO (snawaz): support enum based flags in data-layout
+    pub flags: u8,
+    #[flexible = 1]
+    pub destinations: Vec<[u8; 32]>,
+}
+
+static_assertions::const_assert!(UpdateStealthPoolArgs::DATA_LEN_RANGE.0 == 34);
+static_assertions::const_assert!(UpdateStealthPoolArgs::DATA_LEN_RANGE.1 == 8194);

--- a/e-token/src/processor/update_stealth_pool.rs
+++ b/e-token/src/processor/update_stealth_pool.rs
@@ -71,7 +71,7 @@ pub fn process_update_stealth_pool(
         require_eq_keys!(
             &existing.authority,
             authority_info.address(),
-            ProgramError::MissingRequiredSignature
+            ProgramError::IncorrectAuthority
         );
     }
 

--- a/e-token/src/processor/utils/group_receipt_accounts.rs
+++ b/e-token/src/processor/utils/group_receipt_accounts.rs
@@ -2,6 +2,7 @@ use crate::processor::execute_transfer_callback::GROUP_RECEIPT_SEED;
 use crate::processor::utils::ephemeral_account::{
     close_ephemeral_account, create_ephemeral_account,
 };
+use ephemeral_spl_api::require_ok;
 use ephemeral_spl_api::state::group_receipt;
 use ephemeral_spl_api::state::group_receipt::GroupReceipt;
 use ephemeral_spl_api::state::transfer_queue::{queue_views_checked, QUEUE_SEED};
@@ -48,7 +49,8 @@ pub fn group_receipt_create<'a>(
     let receipt_signer = Signer::from(&receipt_signer_seeds);
 
     let space = GroupReceipt::required_size(splits as usize);
-    create_ephemeral_account(
+
+    require_ok!(create_ephemeral_account(
         accounts.queue_info,
         accounts.group_receipt_info,
         accounts.magic_vault,
@@ -56,13 +58,14 @@ pub fn group_receipt_create<'a>(
             .try_into()
             .map_err(|_| ProgramError::ArithmeticOverflow)?,
         &[queue_signer, receipt_signer],
-    )?;
-    group_receipt::initialize_group_receipt(
+    ));
+
+    require_ok!(group_receipt::initialize_group_receipt(
         accounts.group_receipt_info,
         group_id,
         splits,
         group_receipt_bump,
-    )?;
+    ));
 
     GroupReceipt::new(accounts.group_receipt_info)
 }

--- a/e-token/tests/deposit_and_queue_transfer.rs
+++ b/e-token/tests/deposit_and_queue_transfer.rs
@@ -1198,8 +1198,13 @@ async fn deposit_and_queue_transfer_resolves_stealth_pool_destination() {
         utils::test_keypair("stealth_pool::destination_0").pubkey(),
         utils::test_keypair("stealth_pool::destination_1").pubkey(),
     ];
-    let (stealth_pool, init_ix) =
-        build_update_stealth_pool_ix(fixture.payer, fixture.payer, handle_hash, 0, &destinations);
+    let (stealth_pool, init_ix) = build_update_stealth_pool_ix(
+        fixture.payer,
+        fixture.payer,
+        handle_hash,
+        StealthPoolFlags::Empty.value(),
+        &destinations,
+    );
     pre_create_stealth_pool(&mut fixture.context, stealth_pool);
     let split = 3;
     let group_id: u32 = 1;

--- a/e-token/tests/deposit_and_queue_transfer.rs
+++ b/e-token/tests/deposit_and_queue_transfer.rs
@@ -1,13 +1,16 @@
-use crate::utils::pre_create_group_receipt;
+use crate::utils::{pre_create_group_receipt, pre_create_stealth_pool};
 use bytemuck::Zeroable;
 use ephemeral_spl_api::instruction;
 use ephemeral_spl_api::state::group_receipt::GroupReceiptHeader;
 use ephemeral_spl_api::state::shuttle_ephemeral_ata::ShuttleMetadata;
+use ephemeral_spl_api::state::stealth_pool::{StealthPool, StealthPoolFlags};
 use ephemeral_spl_api::state::transfer_queue::{
     queue_views_checked, QueuedTransfer, TransferQueue, TransferQueueHeader, HEADER_LEN, ITEM_LEN,
 };
 use ephemeral_spl_api::ID as PROGRAM;
-use ephemeral_token_program::DepositAndQueueTransferArgs;
+use ephemeral_token_program::{
+    DepositAndQueueTransferArgs, InitializeTransferQueueArgs, UpdateStealthPoolArgs,
+};
 use serial_test::serial;
 use solana_instruction::{AccountMeta, Instruction};
 use solana_program::clock::Clock;
@@ -54,6 +57,8 @@ fn read_item_unaligned(data: &[u8], index: usize) -> QueuedTransfer {
 }
 
 async fn setup_fixture(items: Option<u32>) -> Fixture {
+    common::magic_mock::take_captured_ephemeral_creates(MAGIC_PROGRAM);
+
     let mut context = utils::start_program_test_with(PROGRAM, |pt| {
         pt.prefer_bpf(false);
         pt.add_program(
@@ -227,6 +232,90 @@ fn build_deposit_and_queue_ix_for_destination(
         ],
         data,
     }
+}
+
+fn build_update_stealth_pool_ix(
+    payer: Pubkey,
+    authority: Pubkey,
+    handle_hash: [u8; 32],
+    flags: u8,
+    destinations: &[Pubkey],
+) -> (Pubkey, Instruction) {
+    let (stealth_pool, _) = StealthPool::find_pda(&handle_hash);
+    let destination_bytes = destinations
+        .iter()
+        .map(|destination| destination.to_bytes())
+        .collect::<Vec<_>>();
+
+    let data = instruction::ESplInstruction::UpdateStealthPool.with_data(
+        &UpdateStealthPoolArgs {
+            handle_hash,
+            flags,
+            destinations: destination_bytes,
+        }
+        .encode()
+        .unwrap(),
+    );
+
+    (
+        stealth_pool,
+        Instruction {
+            program_id: PROGRAM,
+            accounts: vec![
+                AccountMeta::new(payer, true),
+                AccountMeta::new(stealth_pool, false),
+                AccountMeta::new_readonly(authority, true),
+                AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+            ],
+            data,
+        },
+    )
+}
+
+fn expected_stealth_destination(
+    handle_hash: &[u8; 32],
+    destinations: &[Pubkey],
+    split_across_keys: bool,
+    source: &Pubkey,
+    group_id: u32,
+    first_queue_position: usize,
+    queue_position: usize,
+    client_ref_id: u64,
+    split_index: usize,
+) -> Pubkey {
+    let queue_seed = if split_across_keys {
+        queue_position
+    } else {
+        first_queue_position
+    };
+    let split_seed = if split_across_keys { split_index } else { 0 };
+    let mut value = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in handle_hash {
+        value ^= u64::from(*byte);
+        value = value.wrapping_mul(0x100_0000_01b3);
+    }
+    for byte in source.to_bytes() {
+        value ^= u64::from(byte);
+        value = value.wrapping_mul(0x100_0000_01b3);
+    }
+    for byte in group_id.to_le_bytes() {
+        value ^= u64::from(byte);
+        value = value.wrapping_mul(0x100_0000_01b3);
+    }
+    for byte in (queue_seed as u64).to_le_bytes() {
+        value ^= u64::from(byte);
+        value = value.wrapping_mul(0x100_0000_01b3);
+    }
+    for byte in client_ref_id.to_le_bytes() {
+        value ^= u64::from(byte);
+        value = value.wrapping_mul(0x100_0000_01b3);
+    }
+    for byte in (split_seed as u64).to_le_bytes() {
+        value ^= u64::from(byte);
+        value = value.wrapping_mul(0x100_0000_01b3);
+    }
+    value ^= value >> 32;
+    destinations[(value % destinations.len() as u64) as usize]
 }
 
 fn expected_split_delay_ms(
@@ -1098,4 +1187,184 @@ async fn deposit_and_queue_transfer_return_to_shuttle() {
     // return_to_shuttle takes a different code path — no group-receipt CPI expected.
     let creates = common::magic_mock::take_captured_ephemeral_creates(MAGIC_PROGRAM);
     assert_eq!(creates.len(), 0, "expected no CreateEphemeralAccount CPIs");
+}
+
+#[tokio::test]
+#[serial]
+async fn deposit_and_queue_transfer_resolves_stealth_pool_destination() {
+    let mut fixture = setup_fixture(None).await;
+    let handle_hash = [42u8; 32];
+    let destinations = [
+        utils::test_keypair("stealth_pool::destination_0").pubkey(),
+        utils::test_keypair("stealth_pool::destination_1").pubkey(),
+    ];
+    let (stealth_pool, init_ix) =
+        build_update_stealth_pool_ix(fixture.payer, fixture.payer, handle_hash, 0, &destinations);
+    pre_create_stealth_pool(&mut fixture.context, stealth_pool);
+    let split = 3;
+    let group_id: u32 = 1;
+    let group_receipt = pre_create_group_receipt(
+        &mut fixture.context,
+        fixture.queue,
+        fixture.payer,
+        group_id,
+        split,
+    );
+    let deposit_ix = build_deposit_and_queue_ix_for_destination(
+        &fixture,
+        stealth_pool,
+        12,
+        0,
+        0,
+        split,
+        None,
+        None,
+        group_id,
+        group_receipt,
+    );
+    let blockhash = fixture
+        .context
+        .banks_client
+        .get_latest_blockhash()
+        .await
+        .unwrap();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[init_ix, deposit_ix],
+        Some(&fixture.payer),
+        &[&fixture.payer_kp],
+        blockhash,
+    );
+    common::metrics::process_transaction_record_cu(
+        &fixture.context.banks_client,
+        tx,
+        "dep_queue::stealth_pool_resolve",
+    )
+    .await
+    .unwrap();
+
+    let queue_account = fixture
+        .context
+        .banks_client
+        .get_account(fixture.queue)
+        .await
+        .unwrap()
+        .expect("queue account must exist");
+    let expected = expected_stealth_destination(
+        &handle_hash,
+        &destinations,
+        false,
+        &fixture.payer,
+        1,
+        0,
+        0,
+        0,
+        0,
+    );
+
+    for index in 0..split as usize {
+        let queued = read_item_unaligned(&queue_account.data, index);
+        assert_eq!(queued.destination_owner.as_array(), &expected.to_bytes());
+        assert_ne!(
+            queued.destination_owner.as_array(),
+            &stealth_pool.to_bytes()
+        );
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn deposit_and_queue_transfer_can_split_stealth_pool_across_keys() {
+    let mut fixture = setup_fixture(None).await;
+    let handle_hash = [77u8; 32];
+    let destinations = [
+        utils::test_keypair("stealth_pool::split_destination_0").pubkey(),
+        utils::test_keypair("stealth_pool::split_destination_1").pubkey(),
+        utils::test_keypair("stealth_pool::split_destination_2").pubkey(),
+    ];
+    let (stealth_pool, init_ix) = build_update_stealth_pool_ix(
+        fixture.payer,
+        fixture.payer,
+        handle_hash,
+        StealthPoolFlags::SplitAcrossKeys.value(),
+        &destinations,
+    );
+    pre_create_stealth_pool(&mut fixture.context, stealth_pool);
+    let split = 5;
+    let client_ref_id = 99;
+    let group_id: u32 = 1;
+    let group_receipt = pre_create_group_receipt(
+        &mut fixture.context,
+        fixture.queue,
+        fixture.payer,
+        group_id,
+        split,
+    );
+    let deposit_ix = build_deposit_and_queue_ix_for_destination(
+        &fixture,
+        stealth_pool,
+        15,
+        0,
+        0,
+        split,
+        None,
+        Some(client_ref_id),
+        group_id,
+        group_receipt,
+    );
+    let blockhash = fixture
+        .context
+        .banks_client
+        .get_latest_blockhash()
+        .await
+        .unwrap();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[init_ix, deposit_ix],
+        Some(&fixture.payer),
+        &[&fixture.payer_kp],
+        blockhash,
+    );
+    common::metrics::process_transaction_record_cu(
+        &fixture.context.banks_client,
+        tx,
+        "dep_queue::stealth_pool_split_keys",
+    )
+    .await
+    .unwrap();
+
+    let queue_account = fixture
+        .context
+        .banks_client
+        .get_account(fixture.queue)
+        .await
+        .unwrap()
+        .expect("queue account must exist");
+
+    let mut actual = (0..split as usize)
+        .map(|index| {
+            read_item_unaligned(&queue_account.data, index)
+                .destination_owner
+                .to_bytes()
+        })
+        .collect::<Vec<_>>();
+    let mut expected = (0..split as usize)
+        .map(|index| {
+            expected_stealth_destination(
+                &handle_hash,
+                &destinations,
+                true,
+                &fixture.payer,
+                1,
+                0,
+                index,
+                client_ref_id,
+                index,
+            )
+            .to_bytes()
+        })
+        .collect::<Vec<_>>();
+    actual.sort_unstable();
+    expected.sort_unstable();
+    assert_eq!(actual, expected);
 }

--- a/e-token/tests/utils.rs
+++ b/e-token/tests/utils.rs
@@ -8,6 +8,8 @@ use ephemeral_rollups_pinocchio::pda::{
     delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
 };
 use ephemeral_spl_api::state::group_receipt::GroupReceipt;
+use ephemeral_spl_api::state::stealth_pool::StealthPool;
+use ephemeral_spl_api::state::RawType;
 use ephemeral_spl_api::{instruction, ID as PROGRAM};
 use ephemeral_token_program::InitializeTransferQueueArgs;
 use solana_account::Account;
@@ -324,6 +326,22 @@ pub fn pre_create_group_receipt(
         .into(),
     );
     receipt
+}
+
+pub fn pre_create_stealth_pool(context: &mut ProgramTestContext, stealth_pool: Pubkey) {
+    let data = vec![0u8; StealthPool::LEN];
+    let rent = Rent::default();
+    context.set_account(
+        &stealth_pool,
+        &Account {
+            lamports: rent.minimum_balance(data.len()),
+            data,
+            owner: PROGRAM,
+            executable: false,
+            rent_epoch: 0,
+        }
+        .into(),
+    );
 }
 
 pub fn derive_associated_token_address(wallet: Pubkey, mint: Pubkey) -> Pubkey {


### PR DESCRIPTION
Add **stealth pools** for **handle-based** private payments. As per my understanding, it should be created inside the ER, else the handle-to-key-set mapping can become publicly visible. 

The queue layout stays the same: 
- we still enqueue a concrete `destination_owner`, but it can now be resolved from a pool inside `process_deposit_and_queue_transfer` which receives `destination_info` that, now, can be either `destination_owner` or `destination_stealth_pool`.

## end-to-end high-level flow

 - first and foremost, a recipient initializes/updates a stealth pool with up to **10 destination owner keys** (not token accounts).
    - the offchain service/client layer defines the canonical handle format, e.g. **magicblock.id**, **myname@mydomain**, or whatever naming scheme it supports.
    - that canonical handle is hashed to derive the `StealthPool` PDA.
    - `StealthPool` stores the backing owner addresses. This PDA can be used as a virtual `destination_owner` in the payment flow.
  - sender pays to the same canonical handle, e.g. **`john.doe@magicblock.id`**.
    - the offchain layer applies the same canonicalization + hashing rule, derives the pool PDA, and uses that PDA as the destination in the eSPL instruction.
  - inside the ER, `DepositAndQueueTransfer` detects whether the destination is a pool or a real owner.
    - if it is a pool, it picks one destination key depending on the strategy configured by `StealthPool.flags`, and enqueues the normal `QueuedTransfer`.
    - otherwise, it proceeds as usual.
  - base only sees the resolved destination key, not the handle-to-pool/key-set mapping.


Spec: https://github.com/magicblock-labs/dev-kanban/issues/153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stealth pool support enabling delegated account provisioning and configurable destination lists
  * Two new instructions to create/ensure delegation and to update stealth pools; deterministic per-split destination resolution (including split-across-keys)

* **Improvements**
  * Failure logs now include filename and line number for clearer diagnostics
  * Destination selection and delay logic refined for stealth-pool destinations

* **Tests**
  * New integration tests and helpers validating stealth-pool setup and deterministic destination resolution
<!-- end of auto-generated comment: release notes by coderabbit.ai -->