### PR TITLE
feat: add stealth-address functionalities to the backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3138,9 +3138,9 @@ dependencies = [
 
 [[package]]
 name = "magicblock-delegation-program-api"
-version = "0.1.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a413fd0a3ce67bba8c31b681f37088a897d47a3c39fd0d9303725882898ad78"
+checksum = "b8447309107c033ed0b5416c485b64f281a2e49c28adee03d14899fe58301187"
 dependencies = [
  "bincode 1.3.3",
  "borsh 1.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ solana-keypair = "3.0.1"
 solana-transaction = "3.0.1"
 solana-system-interface = { version = "2.0.0", features = ["bincode"] }
 spl-token-interface = "2.0.0"
-magicblock-delegation-program-api = { version = "0.1.1", default-features = false }
+magicblock-delegation-program-api = { version = "0.3.0", default-features = false }
 bytemuck = { version = "1.25.0", features = ["derive", "min_const_generics"] }
 const-crypto = "0.3.0"
 hydra-api = { version = "0.1.1", default-features = false, features = ["client"] }

--- a/api/.dev.vars
+++ b/api/.dev.vars
@@ -1,7 +1,10 @@
 CLUSTER=custom
-BASE_RPC_URL=https://rpc.magicblock.app/mainnet
-EPHEMERAL_RPC_URL=https://as.magicblock.app
+#BASE_RPC_URL=https://rpc.magicblock.app/mainnet
+#EPHEMERAL_RPC_URL=https://as.magicblock.app
 EPHEMERAL_TEE_RPC_URL=https://mainnet-tee.magicblock.app
+BASE_RPC_URL=http://127.0.0.1:8899
+EPHEMERAL_RPC_URL=http://127.0.0.1:7799
+>>>>>>> e7c9d0d (feat: impl stealth addresses)
 GASLESS_SPONSOR_SECRET_KEY=[114,224,209,25,48,159,240,82,196,182,158,173,208,186,82,245,141,146,106,250,224,208,67,165,134,2,179,26,0,22,235,115,228,230,1,190,192,92,140,220,185,176,151,196,217,59,205,155,237,114,219,161,110,119,164,99,176,28,5,5,155,177,91,49]
 BASE_DEVNET_RPC_URL=https://rpc.magicblock.app/devnet
 EPHEMERAL_DEVNET_RPC_URL=https://devnet.magicblock.app

--- a/api/README.md
+++ b/api/README.md
@@ -20,6 +20,9 @@ The API exposes:
 - `POST /v1/spl/deposit`
 - `POST /v1/spl/withdraw`
 - `POST /v1/spl/transfer`
+- `POST /v1/spl/transfer-stealth`
+- `POST /v1/spl/stealth-pool`
+- `GET /v1/spl/stealth-pool`
 - `GET /v1/spl/balance`
 - `GET /v1/spl/private-balance`
 - `GET /v1/swap/quote`
@@ -45,6 +48,8 @@ Important behavior:
 - `deposit` always uses `escrowIndex = 0`
 - `withdraw` uses `withdrawSpl(...)`
 - `transfer` uses `transferSpl(...)`
+- stealth handles are hashed exactly as provided with SHA-256 over UTF-8 bytes
+- `transfer-stealth` uses the derived stealth-pool PDA as the virtual destination owner
 - every SPL endpoint accepts an optional `cluster` parameter
 - `cluster=mainnet` uses `BASE_RPC_URL` and `EPHEMERAL_RPC_URL`
 - `cluster=devnet` uses `BASE_DEVNET_RPC_URL` and `EPHEMERAL_DEVNET_RPC_URL`
@@ -693,6 +698,65 @@ Relevant fields:
 - `exactOut`
 - `gasless`
 - `legacy`
+
+### `POST /v1/spl/stealth-pool`
+
+Builds an unsigned base-chain transaction that initializes or updates a stealth pool. The caller provides the exact handle string, payer, authority, and 1 to 10 destination owner keys.
+
+The API does not canonicalize the handle. For example, `John.Doe@magicblock.id` and `john.doe@magicblock.id` hash to different pools.
+
+Temporary integration note: this setup transaction is currently built for base so the end-to-end handle flow can be exercised without ER auth. The ER is expected to read/clone the pool state for private transfer resolution.
+
+```bash
+curl -X POST http://127.0.0.1:8787/v1/spl/stealth-pool \
+  -H 'content-type: application/json' \
+  -d '{
+    "payer": "PAYER_PUBKEY",
+    "authority": "AUTHORITY_PUBKEY",
+    "handle": "john.doe@magicblock.id",
+    "destinations": ["DESTINATION_OWNER_PUBKEY"],
+    "splitAcrossKeys": false
+  }'
+```
+
+Response includes:
+
+- `stealthPool`: derived PDA
+- `handleHash`: lowercase hex SHA-256 hash
+- normal unsigned transaction fields
+
+### `GET /v1/spl/stealth-pool`
+
+Derives the stealth-pool PDA for a handle and reports whether the base account exists. It does not return destination keys.
+
+```bash
+curl "http://127.0.0.1:8787/v1/spl/stealth-pool?handle=john.doe%40magicblock.id"
+```
+
+### `POST /v1/spl/transfer-stealth`
+
+Builds an unsigned private transfer addressed to a handle. The API hashes `toHandle`, derives the stealth-pool PDA, verifies the pool account exists, and passes that PDA as the private transfer destination owner.
+
+Missing or wrong handles are rejected before an unsigned transaction is returned.
+
+```bash
+curl -X POST http://127.0.0.1:8787/v1/spl/transfer-stealth \
+  -H 'content-type: application/json' \
+  -d '{
+    "from": "FROM_OWNER_PUBKEY",
+    "toHandle": "john.doe@magicblock.id",
+    "mint": "MINT_PUBKEY",
+    "amount": 5000000,
+    "fromBalance": "base",
+    "minDelayMs": "0",
+    "maxDelayMs": "0"
+  }'
+```
+
+Supported stealth transfer routes:
+
+- `base -> base` private transfer, submitted to base
+- `ephemeral -> base` private transfer, submitted to ER and requiring an auth token
 
 ### `GET /v1/spl/balance`
 

--- a/api/package.json
+++ b/api/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@hono/zod-openapi": "^1.0.2",
-    "@magicblock-labs/ephemeral-rollups-sdk": "0.15.3",
+    "@magicblock-labs/ephemeral-rollups-sdk": "0.15.5",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@scalar/hono-api-reference": "^0.9.13",
     "@solana/web3.js": "^1.98.0",

--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -3,6 +3,8 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import {
   DELEGATION_PROGRAM_ID,
+  delegateBufferPdaFromDelegatedAccountAndOwnerProgram,
+  delegationMetadataPdaFromDelegatedAccount,
   delegationRecordPdaFromDelegatedAccount,
   deriveEphemeralAta,
   deriveHydraCrankPda,
@@ -33,7 +35,11 @@ import {
 } from "@solana/web3.js";
 
 import app from "./app";
-import { TOKEN_2022_PROGRAM_ID, TOKEN_PROGRAM_ID } from "./lib/solana";
+import {
+  deriveStealthPoolFromHash,
+  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+} from "./lib/solana";
 import { MOCK_AUTH_TOKEN } from "./lib/auth";
 
 const env = {
@@ -49,6 +55,10 @@ const DEVNET_USDC_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
 const owner = Keypair.generate().publicKey.toBase58();
 const destination = Keypair.generate().publicKey.toBase58();
 const resolvedValidator = Keypair.generate().publicKey.toBase58();
+const stealthHandle = "john.doe@magicblock.id";
+const stealthHandleHash
+  = "c76229d36cb5b94158e26526845f91decc075f7e85c0624cb988e40acec01f1e";
+const stealthPool = "U9J8KRwqDoqVN4H1qvv6GzKdxQ2k1Jq8dqczeaMyc39";
 
 function deriveAssociatedTokenAddress(mint: string, owner: string) {
   const [ata] = PublicKey.findProgramAddressSync(
@@ -113,7 +123,6 @@ function createQueueAccountInfo(owner: PublicKey): AccountInfo<Buffer> {
 function createDelegationAccountInfo(validator: PublicKey): AccountInfo<Buffer> {
   const data = Buffer.alloc(40);
   validator.toBuffer().copy(data, 8);
-
   return {
     data,
     executable: false,
@@ -123,11 +132,22 @@ function createDelegationAccountInfo(validator: PublicKey): AccountInfo<Buffer> 
   };
 }
 
+function createStealthPoolAccountInfo(): AccountInfo<Buffer> {
+  const data = Buffer.alloc(395);
+  data.set(Buffer.from("stpool@1"), 0);
+  return {
+    data,
+    executable: false,
+    lamports: 1,
+    owner: EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+    rentEpoch: 0,
+  };
+}
+
 function deriveEataDelegationRecord(owner: string, mint: string) {
   const [eata] = deriveEphemeralAta(new PublicKey(owner), new PublicKey(mint));
   return delegationRecordPdaFromDelegatedAccount(eata);
 }
-
 function createIdentityResponse(identity: string) {
   return new Response(
     JSON.stringify({
@@ -237,7 +257,10 @@ describe("app", () => {
     expect(json.paths["/v1/spl/login"]).toBeDefined();
     expect(json.paths["/v1/spl/is-mint-initialized"]).toBeDefined();
     expect(json.paths["/v1/spl/initialize-mint"]).toBeDefined();
+    expect(json.paths["/v1/spl/transfer-queue/ensure-crank"]).toBeDefined();
     expect(json.paths["/v1/spl/undelegate-ephemeral-ata"]).toBeDefined();
+    expect(json.paths["/v1/spl/stealth-pool"]).toBeDefined();
+    expect(json.paths["/v1/spl/transfer-stealth"]).toBeDefined();
     expect(json.paths["/v1/swap/quote"]).toBeDefined();
     expect(json.paths["/v1/swap/swap"]).toBeDefined();
     expect(json.tags).toEqual(
@@ -376,6 +399,14 @@ describe("app", () => {
       json.components?.schemas as Record<string, any>
     )?.SendTransactionRequest;
     expect(sendTransactionRequestSchema?.properties?.sendRpcEndpoint).toBeDefined();
+    const stealthTransferRequestSchema = (
+      json.components?.schemas as Record<string, any>
+    )?.StealthTransferRequest;
+    expect(stealthTransferRequestSchema?.properties?.toHandle).toBeDefined();
+    expect(stealthTransferRequestSchema?.example).toMatchObject({
+      toHandle: "john.doe@magicblock.id",
+      fromBalance: "base",
+    });
     expect(
       json.paths["/v1/spl/withdraw"]?.post?.responses?.["200"]?.content?.[
         "application/json"
@@ -3283,10 +3314,6 @@ describe("app", () => {
     expect(json.recentBlockhash).toBe("11111111111111111111111111111111");
     expect(json.validator).toBe(resolvedValidator);
     expect(json.version).toBe("legacy");
-    expect(json.fees).toEqual({
-      lamports: "2039280",
-      tokens: "5000",
-    });
   });
 
   it("rejects private base transfers when the source eATA is delegated to another validator", async () => {
@@ -3492,6 +3519,306 @@ describe("app", () => {
     );
 
     expect(transferInstruction).toBeDefined();
+  });
+
+  it("builds an initialize-or-update stealth pool transaction", async () => {
+    const payer = Keypair.generate().publicKey.toBase58();
+    const authority = Keypair.generate().publicKey.toBase58();
+
+    vi.spyOn(Connection.prototype, "getLatestBlockhash").mockImplementation(
+      async function getLatestBlockhash(
+        this: Connection & { _rpcEndpoint: string },
+      ) {
+        return {
+          blockhash: "11111111111111111111111111111111",
+          lastValidBlockHeight: 123,
+        };
+      },
+    );
+
+    const response = await app.request(
+      "/v1/spl/stealth-pool",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "authorization": `Bearer ${MOCK_AUTH_TOKEN}`,
+        },
+        body: JSON.stringify({
+          payer,
+          authority,
+          handle: stealthHandle,
+          destinations: [destination],
+          splitAcrossKeys: true,
+        }),
+      },
+      env,
+    );
+
+    expect(response.status, await response.clone().text()).toBe(200);
+
+    const json = (await response.json()) as {
+      kind: string;
+      sendTo: string;
+      stealthPool: string;
+      handleHash: string;
+      transactionBase64: string;
+      requiredSigners: string[];
+      setupTransaction: {
+        sendTo: string;
+        transactionBase64: string;
+        requiredSigners: string[];
+        validator: string;
+      };
+    };
+    expect(json.kind).toBe("stealthPool");
+    expect(json.sendTo).toBe("ephemeral");
+    expect(json.stealthPool).toBe(stealthPool);
+    expect(json.handleHash).toBe(stealthHandleHash);
+    expect(json.requiredSigners.sort()).toEqual([authority, payer].sort());
+    expect(json.setupTransaction.sendTo).toBe("base");
+    expect(json.setupTransaction.requiredSigners).toEqual([payer]);
+
+    const setupTransaction = Transaction.from(
+      Buffer.from(json.setupTransaction.transactionBase64, "base64"),
+    );
+    const setupInstruction = setupTransaction.instructions[0];
+    const stealthPoolPubkey = new PublicKey(stealthPool);
+    expect(setupInstruction.programId.equals(EPHEMERAL_SPL_TOKEN_PROGRAM_ID)).toBe(
+      true,
+    );
+    expect(setupInstruction.keys.map(key => key.pubkey.toBase58())).toEqual([
+      payer,
+      stealthPool,
+      EPHEMERAL_SPL_TOKEN_PROGRAM_ID.toBase58(),
+      delegateBufferPdaFromDelegatedAccountAndOwnerProgram(
+        stealthPoolPubkey,
+        EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+      ).toBase58(),
+      delegationRecordPdaFromDelegatedAccount(stealthPoolPubkey).toBase58(),
+      delegationMetadataPdaFromDelegatedAccount(stealthPoolPubkey).toBase58(),
+      DELEGATION_PROGRAM_ID.toBase58(),
+      SystemProgram.programId.toBase58(),
+    ]);
+    expect([...setupInstruction.data]).toEqual([
+      22,
+      ...Buffer.from(stealthHandleHash, "hex"),
+      ...new PublicKey(json.setupTransaction.validator).toBuffer(),
+    ]);
+
+    const transaction = Transaction.from(
+      Buffer.from(json.transactionBase64, "base64"),
+    );
+    const instruction = transaction.instructions[0];
+    expect(instruction.programId.equals(EPHEMERAL_SPL_TOKEN_PROGRAM_ID)).toBe(
+      true,
+    );
+    expect(instruction.keys.map(key => key.pubkey.toBase58())).toEqual([
+      payer,
+      stealthPool,
+      authority,
+      SystemProgram.programId.toBase58(),
+    ]);
+    expect([...instruction.data.subarray(0, 35)]).toEqual([
+      21,
+      ...Buffer.from(stealthHandleHash, "hex"),
+      1,
+      1,
+    ]);
+    expect(instruction.data.subarray(35).toString("hex")).toBe(
+      new PublicKey(destination).toBuffer().toString("hex"),
+    );
+  });
+
+  it("reports base stealth pool status without exposing destinations", async () => {
+    vi.spyOn(Connection.prototype, "getAccountInfo").mockImplementation(
+      async function getAccountInfo(
+        this: Connection & { _rpcEndpoint: string },
+        address: PublicKey,
+      ) {
+        expect(this._rpcEndpoint).toBe(env.BASE_RPC_URL);
+        expect(address.toBase58()).toBe(stealthPool);
+        return createStealthPoolAccountInfo();
+      },
+    );
+
+    const response = await app.request(
+      `/v1/spl/stealth-pool?handle=${encodeURIComponent(stealthHandle)}`,
+      {},
+      env,
+    );
+
+    expect(response.status).toBe(200);
+
+    const json = (await response.json()) as {
+      stealthPool: string;
+      handleHash: string;
+      exists: boolean;
+      destinations?: unknown;
+    };
+    expect(json).toEqual({
+      stealthPool,
+      handleHash: stealthHandleHash,
+      exists: true,
+    });
+    expect(json.destinations).toBeUndefined();
+  });
+
+  it("rejects stealth transfers from ephemeral balance", async () => {
+    const response = await app.request(
+      "/v1/spl/transfer-stealth",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "authorization": "Bearer abc",
+        },
+        body: JSON.stringify({
+          from: owner,
+          toHandle: stealthHandle,
+          mint: "So11111111111111111111111111111111111111112",
+          amount: 2,
+          fromBalance: "ephemeral",
+          minDelayMs: "0",
+          maxDelayMs: "0",
+          split: 1,
+        }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(422);
+
+    const json = (await response.json()) as {
+      error: { code: string; message: string };
+    };
+    expect(json.error.code).toBe("VALIDATION_ERROR");
+    expect(json.error.message).toBe("Request validation failed");
+  });
+
+  it("rejects stealth transfers when the derived pool PDA is missing", async () => {
+    const mint = new PublicKey("So11111111111111111111111111111111111111112");
+    const [stealthPoolPubkey] = deriveStealthPoolFromHash(
+      Buffer.from(stealthHandleHash, "hex"),
+    );
+    expect(stealthPoolPubkey.toBase58()).toBe(stealthPool);
+    const getAccountInfo = vi.spyOn(Connection.prototype, "getAccountInfo").mockImplementation(
+      async function getAccountInfo(
+        this: Connection & { _rpcEndpoint: string },
+        address: PublicKey,
+      ) {
+        expect(this._rpcEndpoint).toBe(env.BASE_RPC_URL);
+        expect(address.toBase58()).toBe(stealthPoolPubkey.toBase58());
+        return null;
+      },
+    );
+
+    const response = await app.request(
+      "/v1/spl/transfer-stealth",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          from: owner,
+          toHandle: stealthHandle,
+          mint: mint.toBase58(),
+          amount: 2,
+          fromBalance: "base",
+          minDelayMs: "0",
+          maxDelayMs: "0",
+          split: 1,
+          legacy: true,
+        }),
+      },
+      env,
+    );
+
+    expect(response.status, await response.clone().text()).toBe(400);
+    expect(getAccountInfo).toHaveBeenCalledTimes(1);
+
+    const json = (await response.json()) as {
+      error: { code: string; message: string };
+    };
+    expect(json.error.code).toBe("STEALTH_POOL_NOT_FOUND");
+    expect(json.error.message).toBe("Stealth handle is not initialized");
+  });
+
+  it("builds a base stealth transfer after verifying the derived pool PDA exists", async () => {
+    const mint = new PublicKey("So11111111111111111111111111111111111111112");
+    const [stealthPoolPubkey] = deriveStealthPoolFromHash(
+      Buffer.from(stealthHandleHash, "hex"),
+    );
+    expect(stealthPoolPubkey.toBase58()).toBe(stealthPool);
+
+    vi.spyOn(Connection.prototype, "getLatestBlockhash").mockImplementation(
+      async function getLatestBlockhash(
+        this: Connection & { _rpcEndpoint: string },
+      ) {
+        expect(this._rpcEndpoint).toBe(env.BASE_RPC_URL);
+        return {
+          blockhash: "11111111111111111111111111111111",
+          lastValidBlockHeight: 123,
+        };
+      },
+    );
+    vi.spyOn(Connection.prototype, "getAccountInfo").mockImplementation(
+      async (address) => {
+        if (address.equals(stealthPoolPubkey)) {
+          return createStealthPoolAccountInfo();
+        }
+
+        if (address.equals(mint)) {
+          return createMintAccountInfo(TOKEN_PROGRAM_ID);
+        }
+
+        throw new Error(`Unexpected transfer-stealth account lookup: ${address.toBase58()}`);
+      },
+    );
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      expect(String(input)).toBe(env.EPHEMERAL_RPC_URL);
+      return createIdentityResponse(resolvedValidator);
+    });
+
+    const response = await app.request(
+      "/v1/spl/transfer-stealth",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          from: owner,
+          toHandle: stealthHandle,
+          mint: mint.toBase58(),
+          amount: 2,
+          fromBalance: "base",
+          minDelayMs: "0",
+          maxDelayMs: "0",
+          split: 1,
+          legacy: true,
+        }),
+      },
+      env,
+    );
+
+    expect(response.status, await response.clone().text()).toBe(200);
+
+    const json = (await response.json()) as {
+      sendTo: string;
+      transactionBase64: string;
+      validator: string;
+    };
+    expect(json.sendTo).toBe("base");
+    expect(json.validator).toBe(resolvedValidator);
+
+    const transaction = Transaction.from(
+      Buffer.from(json.transactionBase64, "base64"),
+    );
+    const instruction = transaction.instructions.at(-1)!;
+    expect(instruction.data[0]).toBe(25);
+    expect(instruction.keys).toHaveLength(19);
   });
 
   it("builds a v0 private base transfer when the LUT is useful", async () => {
@@ -5341,6 +5668,124 @@ describe("app", () => {
 
     expect(getLatestBlockhashSpy).not.toHaveBeenCalled();
     expect(sendRawTransactionSpy).not.toHaveBeenCalled();
+  });
+
+  it("forces the transfer queue crank endpoint even when recent activity exists", async () => {
+    const mint = "So11111111111111111111111111111111111111112";
+    const validator = Keypair.generate().publicKey.toBase58();
+    const validatorPublicKey = new PublicKey(validator);
+    const [transferQueue] = deriveTransferQueue(
+      new PublicKey(mint),
+      validatorPublicKey,
+    );
+    const nowMs = 1_700_000_000_000;
+    let rawTransaction: Buffer | undefined;
+
+    vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    vi.spyOn(Connection.prototype, "getAccountInfo").mockImplementation(
+      async function getAccountInfo(
+        this: Connection & { _rpcEndpoint: string },
+        address,
+      ) {
+        expect((this as Connection & { _rpcEndpoint: string })._rpcEndpoint).toBe(
+          env.BASE_RPC_URL,
+        );
+        expect(address.toBase58()).toBe(transferQueue.toBase58());
+        return createQueueAccountInfo(DELEGATION_PROGRAM_ID);
+      },
+    );
+    vi.spyOn(
+      Connection.prototype,
+      "getSignaturesForAddress",
+    ).mockImplementation(async function getSignaturesForAddress(
+      this: Connection & { _rpcEndpoint: string },
+      address,
+    ) {
+      expect((this as Connection & { _rpcEndpoint: string })._rpcEndpoint).toBe(
+        env.EPHEMERAL_RPC_URL,
+      );
+      expect(address.toBase58()).toBe(transferQueue.toBase58());
+      return [
+        {
+          blockTime: Math.floor((nowMs - 30_000) / 1000),
+          confirmationStatus: "confirmed",
+          err: null,
+          memo: null,
+          signature: "recent-signature",
+          slot: 1,
+        },
+      ];
+    });
+    vi.spyOn(
+      Connection.prototype,
+      "getLatestBlockhashAndContext",
+    ).mockResolvedValue({
+      context: { slot: 1 },
+      value: {
+        blockhash: "11111111111111111111111111111111",
+        lastValidBlockHeight: 123,
+      },
+    });
+    vi.spyOn(Connection.prototype, "getEpochInfo").mockResolvedValue({
+      absoluteSlot: 1,
+      blockHeight: 1,
+      epoch: 1,
+      slotIndex: 1,
+      slotsInEpoch: 1,
+      transactionCount: 1,
+    });
+    vi.spyOn(Connection.prototype, "sendRawTransaction").mockImplementation(
+      async function sendRawTransaction(
+        this: Connection & { _rpcEndpoint: string },
+        raw,
+      ) {
+        expect((this as Connection & { _rpcEndpoint: string })._rpcEndpoint).toBe(
+          env.EPHEMERAL_RPC_URL,
+        );
+        rawTransaction = Buffer.from(raw);
+        return "forced-crank-signature";
+      },
+    );
+    vi.spyOn(Connection.prototype, "confirmTransaction").mockResolvedValue({
+      context: { slot: 1 },
+      value: { err: null },
+    } as never);
+
+    const response = await app.request(
+      "/v1/spl/transfer-queue/ensure-crank",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ mint, validator }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(200);
+
+    const json = (await response.json()) as {
+      mint: string;
+      validator: string;
+      transferQueue: string;
+      crankSignature: string;
+    };
+
+    expect(json).toEqual({
+      mint,
+      validator,
+      transferQueue: transferQueue.toBase58(),
+      crankSignature: "forced-crank-signature",
+    });
+    expect(rawTransaction).toBeDefined();
+
+    const transaction = Transaction.from(rawTransaction!);
+    expect(transaction.instructions).toHaveLength(1);
+    expect(transaction.instructions[0]?.keys[1]?.pubkey.toBase58()).toBe(
+      transferQueue.toBase58(),
+    );
+    expect(transaction.instructions[0]?.keys[2]?.pubkey.toBase58()).toBe(
+      magicFeeVaultPdaFromValidator(validatorPublicKey).toBase58(),
+    );
   });
 
   it("does not fail mint initialization when transfer queue activity is auth-filtered", async () => {

--- a/api/src/lib/solana.ts
+++ b/api/src/lib/solana.ts
@@ -3,6 +3,8 @@ import {
   DELEGATION_PROGRAM_ID,
   DelegationStatus,
   delegateTransferQueueIx,
+  delegateBufferPdaFromDelegatedAccountAndOwnerProgram,
+  delegationMetadataPdaFromDelegatedAccount,
   delegationRecordPdaFromDelegatedAccount,
   deriveRentPda,
   deriveTransferQueue,
@@ -32,8 +34,31 @@ import nacl from "tweetnacl";
 
 import type { AppEnv } from "../env";
 import { ApiError } from "./errors";
-import { BalanceRequest, BalanceResponse, DepositRequest, InitializeMintRequest, InitializeMintResponse, MintInitializationRequest, MintInitializationResponse, TransactionResponse, TransferRequest, UndelegateEphemeralAtaRequest, UndelegateEphemeralAtaResponse, WithdrawRequest } from "../routes/spl/spl.schemas";
-import { SendTransactionRequest, SendTransactionResponse } from "../routes/transaction.schemas";
+import {
+  BalanceRequest,
+  BalanceResponse,
+  DepositRequest,
+  InitializeMintRequest,
+  InitializeMintResponse,
+  MintInitializationRequest,
+  MintInitializationResponse,
+  StealthPoolRequest,
+  StealthPoolResponse,
+  StealthPoolStatusRequest,
+  StealthPoolStatusResponse,
+  StealthTransferRequest,
+  TransactionResponse,
+  TransferRequest,
+  TransferQueueEnsureCrankRequest,
+  TransferQueueEnsureCrankResponse,
+  UndelegateEphemeralAtaRequest,
+  UndelegateEphemeralAtaResponse,
+  WithdrawRequest,
+} from "../routes/spl/spl.schemas";
+import {
+  SendTransactionRequest,
+  SendTransactionResponse,
+} from "../routes/transaction.schemas";
 import { getCachedAddressLookupTable, getConnection } from "./rpc-cache";
 
 export const TOKEN_PROGRAM_ID = new PublicKey(
@@ -73,6 +98,10 @@ const TRANSFER_QUEUE_RECENT_SIGNATURE_LIMIT = 5;
 const TRANSFER_QUEUE_STALE_MS = 60_000;
 const TRANSFER_QUEUE_AUTH_ERROR_FORCE_INTERVAL = 100;
 const SOLANA_WIRE_TRANSACTION_SIZE_LIMIT = 1232;
+const UPDATE_STEALTH_POOL_DISCRIMINATOR = 21;
+const ENSURE_STEALTH_POOL_DELEGATED_DISCRIMINATOR = 22;
+const STEALTH_POOL_SEED = Buffer.from("stealth_pool");
+const STEALTH_POOL_SPLIT_ACROSS_KEYS_FLAG = 1 << 0;
 // Keep these defaults aligned with scripts/create-private-transfer-lut.js. Updating them requires a redeploy.
 const PRIVATE_BASE_TO_BASE_TRANSFER_LOOKUP_TABLES = {
   mainnet: new PublicKey("54M1BrqVSg1UGTmhH44gQPsPVyuMpmcVBkaY2wYNSVZB"),
@@ -138,6 +167,9 @@ type BackgroundTaskScheduler = {
 };
 
 type TransferFees = NonNullable<TransactionResponse["fees"]>;
+type EnsureTransferQueueCrankOptions = {
+  force?: boolean;
+};
 type ProjectedWritableAta = {
   role: string;
   owner: PublicKey;
@@ -445,7 +477,7 @@ function getAssociatedTokenAddressSync(
   associatedTokenProgramId: PublicKey = ASSOCIATED_TOKEN_PROGRAM_ID,
 ) {
   if (!allowOwnerOffCurve && !PublicKey.isOnCurve(owner.toBuffer())) {
-    throw new ApiError(400, "INVALID_OWNER", "Owner public key is off-curve");
+    throw new ApiError(400, "INVALID_OWNER", `Owner public key ${owner.toBase58()} is off-curve`);
   }
 
   const [ata] = PublicKey.findProgramAddressSync(
@@ -473,6 +505,165 @@ function createMemoInstruction(memo: string) {
     programId: MEMO_PROGRAM_ID,
     keys: [],
     data: Buffer.from(memo, "utf8"),
+  });
+}
+
+function bytesToHex(bytes: Uint8Array) {
+  return [...bytes]
+    .map(byte => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function requireAuthToken(authToken: string | undefined, message: string) {
+  if (!authToken) {
+    throw new ApiError(400, "MISSING_AUTH_TOKEN", message);
+  }
+}
+
+export async function hashStealthHandle(handle: string) {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(handle),
+  );
+
+  return new Uint8Array(digest);
+}
+
+export function deriveStealthPoolFromHash(handleHash: Uint8Array): [PublicKey, number] {
+  if (handleHash.length !== 32) {
+    throw new ApiError(400, "INVALID_STEALTH_HANDLE_HASH", "handle hash must be 32 bytes");
+  }
+
+  return PublicKey.findProgramAddressSync(
+    [STEALTH_POOL_SEED, Buffer.from(handleHash)],
+    EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+  );
+}
+
+async function resolveStealthPool(handle: string) {
+  const handleHash = await hashStealthHandle(handle);
+  const [stealthPool] = deriveStealthPoolFromHash(handleHash);
+
+  return {
+    handleHash,
+    handleHashHex: bytesToHex(handleHash),
+    stealthPool,
+  };
+}
+
+function isStealthPoolAccount(accountInfo: { owner: PublicKey } | null) {
+  return accountInfo !== null
+    && (
+      accountInfo.owner.equals(EPHEMERAL_SPL_TOKEN_PROGRAM_ID)
+      || accountInfo.owner.equals(DELEGATION_PROGRAM_ID)
+    );
+}
+
+async function assertStealthPoolExists(
+  config: RpcConfig,
+  handle: string,
+  stealthPool: PublicKey,
+) {
+  let accountInfo: { owner: PublicKey } | null;
+  try {
+    accountInfo = await getBaseConnection(config).getAccountInfo(stealthPool, "confirmed");
+  } catch (error) {
+    throw new ApiError(502, "RPC_ERROR", "Failed to fetch stealth pool account", {
+      handle,
+      stealthPool: stealthPool.toBase58(),
+      message: getSanitizedErrorMessage(error),
+    });
+  }
+
+  if (!isStealthPoolAccount(accountInfo)) {
+    throw new ApiError(400, "STEALTH_POOL_NOT_FOUND", "Stealth handle is not initialized", {
+      handle,
+      stealthPool: stealthPool.toBase58(),
+      owner: accountInfo?.owner.toBase58(),
+    });
+  }
+}
+
+function updateStealthPoolInstruction(
+  payer: PublicKey,
+  stealthPool: PublicKey,
+  authority: PublicKey,
+  handleHash: Uint8Array,
+  destinations: PublicKey[],
+  flags: number,
+) {
+  const data = Buffer.alloc(1 + 32 + 1 + 1 + destinations.length * 32);
+  let offset = 0;
+  data[offset] = UPDATE_STEALTH_POOL_DISCRIMINATOR;
+  offset += 1;
+  data.set(handleHash, offset);
+  offset += 32;
+  data[offset] = flags;
+  offset += 1;
+  data[offset] = destinations.length;
+  offset += 1;
+
+  for (const destination of destinations) {
+    data.set(destination.toBuffer(), offset);
+    offset += 32;
+  }
+
+  return new TransactionInstruction({
+    programId: EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+    keys: [
+      { pubkey: payer, isSigner: true, isWritable: true },
+      { pubkey: stealthPool, isSigner: false, isWritable: true },
+      { pubkey: authority, isSigner: true, isWritable: false },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data,
+  });
+}
+
+function ensureStealthPoolDelegatedInstruction(
+  payer: PublicKey,
+  stealthPool: PublicKey,
+  handleHash: Uint8Array,
+  validator?: PublicKey,
+) {
+  const data = Buffer.alloc(1 + 32 + (validator ? 32 : 0));
+  let offset = 0;
+  data[offset] = ENSURE_STEALTH_POOL_DELEGATED_DISCRIMINATOR;
+  offset += 1;
+  data.set(handleHash, offset);
+  offset += 32;
+  if (validator) {
+    data.set(validator.toBuffer(), offset);
+  }
+
+  return new TransactionInstruction({
+    programId: EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+    keys: [
+      { pubkey: payer, isSigner: true, isWritable: true },
+      { pubkey: stealthPool, isSigner: false, isWritable: true },
+      { pubkey: EPHEMERAL_SPL_TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      {
+        pubkey: delegateBufferPdaFromDelegatedAccountAndOwnerProgram(
+          stealthPool,
+          EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+        ),
+        isSigner: false,
+        isWritable: true,
+      },
+      {
+        pubkey: delegationRecordPdaFromDelegatedAccount(stealthPool),
+        isSigner: false,
+        isWritable: true,
+      },
+      {
+        pubkey: delegationMetadataPdaFromDelegatedAccount(stealthPool),
+        isSigner: false,
+        isWritable: true,
+      },
+      { pubkey: DELEGATION_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data,
   });
 }
 
@@ -715,6 +906,30 @@ async function assertProjectedWritableAtaValidators(
       { accounts: mismatchedAccounts },
     );
   }
+}
+
+function withPrivateTransferExactOut(
+  instruction: TransactionInstruction,
+  exactOut: boolean,
+) {
+  if (
+    !instruction.programId.equals(EPHEMERAL_SPL_TOKEN_PROGRAM_ID)
+    || instruction.data[0] !== 25
+    || instruction.data[93] !== 1
+    || instruction.data[126] !== instruction.data.length - 127
+  ) {
+    return instruction;
+  }
+
+  return new TransactionInstruction({
+    programId: instruction.programId,
+    keys: instruction.keys,
+    data: Buffer.concat([
+      instruction.data.subarray(0, 13),
+      Buffer.from([exactOut ? 1 : 0]),
+      instruction.data.subarray(13),
+    ]),
+  });
 }
 
 function createRandomShuttleId() {
@@ -1378,6 +1593,97 @@ export async function buildUndelegateEphemeralAtaTransaction(
   }
 }
 
+export async function buildUpdateStealthPoolTransaction(
+  env: AppEnv,
+  input: StealthPoolRequest,
+  authToken?: string,
+): Promise<StealthPoolResponse> {
+  try {
+    requireAuthToken(authToken, "authToken is required to initialize stealth pool destinations inside the ER");
+
+    const config = resolveRpcConfig(env, input.cluster);
+    const payer = parsePublicKey(input.payer, "payer");
+    const authority = parsePublicKey(input.authority, "authority");
+    const destinations = input.destinations.map((destination, index) =>
+      parsePublicKey(destination, `destinations[${index}]`));
+    const { handleHash, handleHashHex, stealthPool } = await resolveStealthPool(input.handle);
+    const flags = input.splitAcrossKeys ? STEALTH_POOL_SPLIT_ACROSS_KEYS_FLAG : 0;
+    const validator = await resolveValidator(config, input.validator);
+    const setupBlockhash = await getBlockhash(config, "base");
+    const initializeBlockhash = await getBlockhash(config, "ephemeral", authToken);
+    const setupInstructions = [
+      ensureStealthPoolDelegatedInstruction(
+        payer,
+        stealthPool,
+        handleHash,
+        validator,
+      ),
+    ];
+    const initializeInstructions = [
+      updateStealthPoolInstruction(
+        payer,
+        stealthPool,
+        authority,
+        handleHash,
+        destinations,
+        flags,
+      ),
+    ];
+
+    const setupTransaction = serializeTransaction(
+      "stealthPool",
+      "base",
+      setupInstructions,
+      payer,
+      setupBlockhash,
+      validator,
+    );
+    const response = serializeTransaction(
+      "stealthPool",
+      "ephemeral",
+      initializeInstructions,
+      payer,
+      initializeBlockhash,
+      validator,
+    );
+
+    return {
+      ...response,
+      kind: "stealthPool",
+      setupTransaction,
+      stealthPool: stealthPool.toBase58(),
+      handleHash: handleHashHex,
+    };
+  } catch (error) {
+    throwTransactionBuildError(error);
+  }
+}
+
+export async function getStealthPoolStatus(
+  env: AppEnv,
+  input: StealthPoolStatusRequest,
+): Promise<StealthPoolStatusResponse> {
+  const config = resolveRpcConfig(env, input.cluster);
+
+  const { handleHashHex, stealthPool } = await resolveStealthPool(input.handle);
+  const connection = getBaseConnection(config);
+
+  try {
+    const accountInfo = await connection.getAccountInfo(stealthPool, "confirmed");
+    const exists = isStealthPoolAccount(accountInfo);
+
+    return {
+      stealthPool: stealthPool.toBase58(),
+      handleHash: handleHashHex,
+      exists,
+    };
+  } catch (error) {
+    throw new ApiError(502, "RPC_ERROR", "Failed to fetch stealth pool account", {
+      message: getSanitizedErrorMessage(error),
+    });
+  }
+}
+
 export async function buildTransferTransaction(env: AppEnv, input: TransferRequest, authToken?: string) {
   try {
     const config = resolveRpcConfig(env, input.cluster);
@@ -1396,7 +1702,6 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
     const maxDelayMs = parseOptionalAmount(input.maxDelayMs, "maxDelayMs");
     const clientRefId = parseOptionalAmount(input.clientRefId, "clientRefId");
     const split = input.split;
-    const exactOut = input.exactOut;
 
     if (minDelayMs !== undefined && minDelayMs < 0n) {
       throw new ApiError(400, "INVALID_PRIVATE_TRANSFER", "minDelayMs must be non-negative");
@@ -1520,19 +1825,18 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
       initAtasIfMissing: input.initAtasIfMissing,
       initVaultIfMissing: input.initVaultIfMissing,
       shuttleId,
-      privateTransfer: input.minDelayMs !== undefined
-        || input.maxDelayMs !== undefined
-        || input.clientRefId !== undefined
-        || input.split !== undefined
+      privateTransfer: input.visibility === "private"
         ? {
             minDelayMs,
             maxDelayMs,
             clientRefId,
             split,
-            exactOut,
+            exactOut: input.exactOut ?? true,
           }
         : undefined,
     });
+    const normalizedTransferInstructions = transferInstructions.map(instruction =>
+      withPrivateTransferExactOut(instruction, input.exactOut ?? true));
     // Gasless private base->base already adds a relay-fee token transfer. Dropping
     // the opportunistic queue-refill ix keeps the full transaction under Solana's
     // packet limit while preserving the actual private transfer instruction.
@@ -1540,9 +1844,9 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
       && input.visibility === "private"
       && input.fromBalance === "base"
       && input.toBalance === "base"
-      && transferInstructions.length > 0
-      ? transferInstructions.filter(ix => !isProcessPendingTransferQueueRefillInstruction(ix))
-      : transferInstructions;
+      && normalizedTransferInstructions.length > 0
+      ? normalizedTransferInstructions.filter(ix => !isProcessPendingTransferQueueRefillInstruction(ix))
+      : normalizedTransferInstructions;
 
     const instructions = [
       ...gaslessFeeInstructions,
@@ -1586,6 +1890,43 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
   } catch (error) {
     throwTransactionBuildError(error);
   }
+}
+
+export async function buildStealthTransferTransaction(
+  env: AppEnv,
+  input: StealthTransferRequest,
+  authToken?: string,
+) {
+  console.log("buildStealthTransferTransaction invoked: ", input);
+
+  const config = resolveRpcConfig(env, input.cluster);
+  const { stealthPool } = await resolveStealthPool(input.toHandle);
+  await assertStealthPoolExists(config, input.toHandle, stealthPool);
+
+  const transferInput: TransferRequest = {
+    from: input.from,
+    to: stealthPool.toBase58(),
+    cluster: input.cluster,
+    mint: input.mint,
+    amount: input.amount,
+    visibility: "private",
+    fromBalance: input.fromBalance,
+    toBalance: "base",
+    validator: input.validator,
+    initIfMissing: input.initIfMissing,
+    initAtasIfMissing: input.initAtasIfMissing,
+    initVaultIfMissing: input.initVaultIfMissing,
+    memo: input.memo,
+    minDelayMs: input.minDelayMs,
+    maxDelayMs: input.maxDelayMs,
+    clientRefId: input.clientRefId,
+    split: input.split,
+    exactOut: input.exactOut,
+    gasless: input.gasless,
+    legacy: input.legacy,
+  };
+
+  return buildTransferTransaction(env, transferInput, authToken);
 }
 
 async function getBalanceInternal(
@@ -1725,7 +2066,9 @@ async function ensureTransferQueueCrankRunning(
   config: RpcConfig,
   transferQueue: PublicKey,
   validator: PublicKey,
-) {
+  options: EnsureTransferQueueCrankOptions = {},
+): Promise<string | undefined> {
+  const force = options.force === true;
   const activityConnection = getEphemeralConnection(config);
   let activityWasAuthFiltered = false;
   try {
@@ -1736,19 +2079,25 @@ async function ensureTransferQueueCrankRunning(
     );
     transferQueueAuthErrorCounts.delete(transferQueue.toBase58());
     const newestSignatureTimestampMs = getNewestSuccessfulSignatureTimestampMs(signatures);
+    const newestSignatureAgeMs = newestSignatureTimestampMs === undefined
+      ? undefined
+      : Date.now() - newestSignatureTimestampMs;
 
     if (
-      newestSignatureTimestampMs !== undefined
-      && Date.now() - newestSignatureTimestampMs < TRANSFER_QUEUE_STALE_MS
+      !force
+      && newestSignatureAgeMs !== undefined
+      && newestSignatureAgeMs < TRANSFER_QUEUE_STALE_MS
     ) {
+      console.warn("ensureTransferQueueCrankRunning (early return): ", newestSignatureTimestampMs, newestSignatureAgeMs, TRANSFER_QUEUE_STALE_MS);
       return;
     }
+    console.warn("ensureTransferQueueCrankRunning (ensuring): ", newestSignatureTimestampMs, newestSignatureAgeMs, TRANSFER_QUEUE_STALE_MS);
   } catch (error) {
     if (!isAuthFilteredRpcError(error)) {
       throw error;
     }
 
-    if (!shouldForceTransferQueueCrankAfterAuthError(transferQueue)) {
+    if (!force && !shouldForceTransferQueueCrankAfterAuthError(transferQueue)) {
       return;
     }
 
@@ -1830,6 +2179,8 @@ async function ensureTransferQueueCrankRunning(
   if (confirmation.value.err !== null) {
     throw new Error(`Transfer queue crank transaction failed: ${JSON.stringify(confirmation.value.err)}`);
   }
+
+  return signature;
 }
 
 function scheduleTransferQueueCrank(
@@ -1838,6 +2189,7 @@ function scheduleTransferQueueCrank(
   transferQueue: PublicKey,
   validator: PublicKey,
 ) {
+  console.warn("scheduleTransferQueueCrank: ", backgroundScheduler ? "backgroundScheduler exists" : "backgroundScheduler doesn't exist");
   if (!backgroundScheduler) {
     return;
   }
@@ -1851,6 +2203,66 @@ function scheduleTransferQueueCrank(
       });
     }),
   );
+}
+
+export async function ensureTransferQueueCrank(
+  env: AppEnv,
+  input: TransferQueueEnsureCrankRequest,
+): Promise<TransferQueueEnsureCrankResponse> {
+  const config = resolveRpcConfig(env, input.cluster);
+  const mint = parsePublicKey(input.mint, "mint");
+  const validator = await resolveRequiredValidator(config, input.validator);
+  const [transferQueue] = deriveTransferQueue(mint, validator);
+
+  let accountInfo: { owner: PublicKey } | null;
+  try {
+    accountInfo = await getBaseConnection(config).getAccountInfo(transferQueue, "confirmed");
+  } catch (error) {
+    throw new ApiError(502, "RPC_ERROR", "Failed to fetch transfer queue account", {
+      transferQueue: transferQueue.toBase58(),
+      message: getSanitizedErrorMessage(error),
+    });
+  }
+
+  if (accountInfo === null || !accountInfo.owner.equals(DELEGATION_PROGRAM_ID)) {
+    throw new ApiError(400, "TRANSFER_QUEUE_NOT_INITIALIZED", "Transfer queue is not initialized and delegated", {
+      mint: mint.toBase58(),
+      validator: validator.toBase58(),
+      transferQueue: transferQueue.toBase58(),
+      owner: accountInfo?.owner.toBase58(),
+    });
+  }
+
+  try {
+    const crankSignature = await ensureTransferQueueCrankRunning(
+      config,
+      transferQueue,
+      validator,
+      { force: true },
+    );
+
+    if (!crankSignature) {
+      throw new Error("Forced transfer queue crank did not produce a signature");
+    }
+
+    return {
+      mint: mint.toBase58(),
+      validator: validator.toBase58(),
+      transferQueue: transferQueue.toBase58(),
+      crankSignature,
+    };
+  } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
+
+    throw new ApiError(502, "RPC_ERROR", "Failed to ensure transfer queue crank", {
+      mint: mint.toBase58(),
+      validator: validator.toBase58(),
+      transferQueue: transferQueue.toBase58(),
+      message: getSanitizedErrorMessage(error),
+    });
+  }
 }
 
 export async function getMintInitializationStatus(
@@ -1868,6 +2280,8 @@ export async function getMintInitializationStatus(
     const accountInfo = await connection.getAccountInfo(transferQueue, "confirmed");
     const initialized = accountInfo !== null
       && accountInfo.owner.equals(DELEGATION_PROGRAM_ID);
+
+    console.warn("getMintInitializationStatus: ", accountInfo ? `${transferQueue.toBase58()} exists` : `${transferQueue.toBase58()} doesn't exist`, initialized);
 
     if (initialized) {
       scheduleTransferQueueCrank(backgroundScheduler, config, transferQueue, validator);

--- a/api/src/routes/spl/spl.handlers.ts
+++ b/api/src/routes/spl/spl.handlers.ts
@@ -4,12 +4,16 @@ import { getEnv, type AppBindings } from "../../env";
 import {
   buildDepositTransaction,
   buildInitializeMintTransaction,
+  buildUpdateStealthPoolTransaction,
+  buildStealthTransferTransaction,
   buildTransferTransaction,
   buildUndelegateEphemeralAtaTransaction,
   buildWithdrawTransaction,
+  ensureTransferQueueCrank,
   getBaseBalance,
   getMintInitializationStatus,
   getPrivateBalance,
+  getStealthPoolStatus,
 } from "../../lib/solana";
 import {
   balanceRoute,
@@ -19,6 +23,10 @@ import {
   loginRoute,
   mintInitializationRoute,
   privateBalanceRoute,
+  stealthPoolRoute,
+  stealthPoolStatusRoute,
+  stealthTransferRoute,
+  transferQueueEnsureCrankRoute,
   transferRoute,
   undelegateEphemeralAtaRoute,
   withdrawRoute,
@@ -30,7 +38,11 @@ import {
   InitializeMintRequest,
   LoginRequest,
   MintInitializationRequest,
+  StealthPoolRequest,
+  StealthPoolStatusRequest,
+  StealthTransferRequest,
   TransferRequest,
+  TransferQueueEnsureCrankRequest,
   UndelegateEphemeralAtaRequest,
   WithdrawRequest,
 } from "./spl.schemas";
@@ -86,6 +98,31 @@ export const undelegateEphemeralAtaHandler: RouteHandler<typeof undelegateEpheme
   return c.json(response, 200);
 };
 
+export const stealthTransferHandler: RouteHandler<typeof stealthTransferRoute, RouteEnv> = async (c) => {
+  const env = getEnv(c.env);
+  const body = c.req.valid("json") as StealthTransferRequest;
+  const authToken = parseAuthToken(c.req.header());
+  const response = await buildStealthTransferTransaction(env, body, authToken);
+  return c.json(response, 200);
+};
+
+export const stealthPoolHandler: RouteHandler<typeof stealthPoolRoute, RouteEnv> = async (c) => {
+  const env = getEnv(c.env);
+  const body = c.req.valid("json") as StealthPoolRequest;
+  const authToken = parseAuthToken(c.req.header());
+
+  const response = await buildUpdateStealthPoolTransaction(env, body, authToken);
+  return c.json(response, 200);
+};
+
+export const stealthPoolStatusHandler: RouteHandler<typeof stealthPoolStatusRoute, RouteEnv> = async (c) => {
+  const env = getEnv(c.env);
+  const query = c.req.valid("query") as StealthPoolStatusRequest;
+
+  const response = await getStealthPoolStatus(env, query);
+  return c.json(response, 200);
+};
+
 export const balanceHandler: RouteHandler<typeof balanceRoute, RouteEnv> = async (c) => {
   const env = getEnv(c.env);
   const query = c.req.valid("query") as BalanceRequest;
@@ -113,6 +150,13 @@ export const mintInitializationHandler: RouteHandler<typeof mintInitializationRo
     query,
     getBackgroundScheduler(c as { executionCtx: BackgroundScheduler }),
   );
+  return c.json(response, 200);
+};
+
+export const transferQueueEnsureCrankHandler: RouteHandler<typeof transferQueueEnsureCrankRoute, RouteEnv> = async (c) => {
+  const env = getEnv(c.env);
+  const body = c.req.valid("json") as TransferQueueEnsureCrankRequest;
+  const response = await ensureTransferQueueCrank(env, body);
   return c.json(response, 200);
 };
 

--- a/api/src/routes/spl/spl.index.ts
+++ b/api/src/routes/spl/spl.index.ts
@@ -10,6 +10,10 @@ import {
   loginHandler,
   mintInitializationHandler,
   privateBalanceHandler,
+  stealthPoolHandler,
+  stealthPoolStatusHandler,
+  stealthTransferHandler,
+  transferQueueEnsureCrankHandler,
   transferHandler,
   undelegateEphemeralAtaHandler,
   withdrawHandler,
@@ -22,6 +26,10 @@ import {
   loginRoute,
   mintInitializationRoute,
   privateBalanceRoute,
+  stealthPoolRoute,
+  stealthPoolStatusRoute,
+  stealthTransferRoute,
+  transferQueueEnsureCrankRoute,
   transferRoute,
   undelegateEphemeralAtaRoute,
   withdrawRoute,
@@ -36,9 +44,13 @@ app.openapi(withdrawRoute, withdrawHandler);
 app.openapi(initializeMintRoute, initializeMintHandler);
 app.openapi(transferRoute, transferHandler);
 app.openapi(undelegateEphemeralAtaRoute, undelegateEphemeralAtaHandler);
+app.openapi(stealthTransferRoute, stealthTransferHandler);
+app.openapi(stealthPoolRoute, stealthPoolHandler);
+app.openapi(stealthPoolStatusRoute, stealthPoolStatusHandler);
 app.openapi(balanceRoute, balanceHandler);
 app.openapi(privateBalanceRoute, privateBalanceHandler);
 app.openapi(mintInitializationRoute, mintInitializationHandler);
+app.openapi(transferQueueEnsureCrankRoute, transferQueueEnsureCrankHandler);
 app.openapi(challengeRoute, challengeHandler);
 app.openapi(loginRoute, loginHandler);
 

--- a/api/src/routes/spl/spl.routes.ts
+++ b/api/src/routes/spl/spl.routes.ts
@@ -25,6 +25,15 @@ import {
   mintInitializationRequestSchema,
   MintInitializationResponse,
   mintInitializationResponseSchema,
+  stealthPoolRequestSchema,
+  StealthPoolResponse,
+  stealthPoolResponseSchema,
+  stealthPoolStatusRequestSchema,
+  stealthPoolStatusResponseSchema,
+  stealthTransferRequestSchema,
+  TransferQueueEnsureCrankResponse,
+  transferQueueEnsureCrankRequestSchema,
+  transferQueueEnsureCrankResponseSchema,
   TransactionResponse,
   transactionResponseSchema,
   transferRequestSchema,
@@ -78,6 +87,12 @@ const mintInitializationResponseExample: MintInitializationResponse = {
   transferQueue: "BuBHLbaPmYmgvMiZ8uZb96RjBtmWzJY52u7Di5urNf6M",
   initialized: true,
 };
+const transferQueueEnsureCrankResponseExample: TransferQueueEnsureCrankResponse = {
+  mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  validator: "MAS1Dt9qreoRMQ14YQuhg8UTZMMzDdKhmkZMECCzk57",
+  transferQueue: "BuBHLbaPmYmgvMiZ8uZb96RjBtmWzJY52u7Di5urNf6M",
+  crankSignature: "5XwJvR8L5cYk2wA9yEq2Ur2VXn7zqftzZa8cqBgrQYorZxeFaNRDnQsf3tGYRjB3sxG9DhU6N2qWctvd8vG82yXQ",
+};
 const initializeMintResponseExample: InitializeMintResponse = {
   kind: "initializeMint" as const,
   version: "legacy" as const,
@@ -101,6 +116,29 @@ const undelegateEphemeralAtaResponseExample: UndelegateEphemeralAtaResponse = {
   lastValidBlockHeight: 284512451,
   instructionCount: 1,
   requiredSigners: ["3rXKwQ1kpjBd5tdcco32qsvqUh1BnZjcYnS5kYrP7AYE"],
+};
+const stealthPoolResponseExample: StealthPoolResponse = {
+  kind: "stealthPool" as const,
+  version: "legacy" as const,
+  transactionBase64: "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAIDKmcfsS5XfSOLaLlaBHJry50iH2Ufk2TMz4STC2fHzIcFKkerg3q2DD3Yn8TISmGeKoxSLz+BiP7iQ4pYqXYXsgu8D8C7R8ovdMQRLpSrE8+jxjTl3BfqywPNGiPNfnh8eS+smowIxqKDcCjw5liNXQkkCbBSDCBDFwtrgCKqoQ0DAgEBBAECAwQCAQEEAgIDBAIBAQQDAgME",
+  sendTo: "ephemeral" as const,
+  recentBlockhash: "9A4VhP8M8fQZxP4h7rB6mP6eM8w2pJkYh7QdZk7V4r2x",
+  lastValidBlockHeight: 284512337,
+  instructionCount: 1,
+  requiredSigners: ["3rXKwQ1kpjBd5tdcco32qsvqUh1BnZjcYnS5kYrP7AYE"],
+  setupTransaction: {
+    kind: "stealthPool" as const,
+    version: "legacy" as const,
+    transactionBase64: "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAIDKgcfsS5XfSOLaLlaBHJry50iH2Ufk2TMz4STC2fHzIcFKkerg3q2DD3Yn8TISmGeKoxSLz+BiP7iQ4pYqXYXsgu8D8C7R8ovdMQRLpSrE8+jxjTl3BfqywPNGiPNfnh8eS+smowIxqKDcCjw5liNXQkkCbBSDCBDFwtrgCKqoQ0DAgEBBAECAwQCAQEEAgIDBAIBAQQDAgME",
+    sendTo: "base" as const,
+    recentBlockhash: "7YH7nE6qj8vH3L9pR5uM2cD1xK4sT8wQ6bN3fJ2mP9z",
+    lastValidBlockHeight: 284512451,
+    instructionCount: 1,
+    requiredSigners: ["3rXKwQ1kpjBd5tdcco32qsvqUh1BnZjcYnS5kYrP7AYE"],
+    validator: "MAS1Dt9qreoRMQ14YQuhg8UTZMMzDdKhmkZMECCzk57",
+  },
+  stealthPool: "Bt9oNR5cCtnfuMmXgWELd6q5i974PdEMQDUE55nBC57L",
+  handleHash: "f1b46b77cd9bb77a6e3593e5eb02e291457061d1bcb83c929b3165fa7b522477",
 };
 const challengeResponseExample: ChallengeResponse = {
   challenge: "1234567890",
@@ -186,6 +224,53 @@ export const undelegateEphemeralAtaRoute = createRoute({
   },
 });
 
+export const stealthTransferRoute = createRoute({
+  path: "/v1/spl/transfer-stealth",
+  method: "post",
+  tags,
+  description: "Build an unsigned private transfer transaction addressed to an initialized stealth handle.",
+  request: {
+    body: jsonContentRequired(stealthTransferRequestSchema, "Stealth transfer request"),
+    headers: optionalAuthTokenSchema,
+  },
+  responses: {
+    200: jsonContent(transactionResponseSchema, "Unsigned serialized transaction"),
+    400: jsonContent(errorResponseSchema, "Build error"),
+    422: jsonContent(validationErrorResponseSchema, "Validation error"),
+  },
+});
+
+export const stealthPoolRoute = createRoute({
+  path: "/v1/spl/stealth-pool",
+  method: "post",
+  tags,
+  description: "Build unsigned stealth-pool setup and ER update transactions.",
+  request: {
+    headers: requiredAuthTokenSchema,
+    body: jsonContentRequired(stealthPoolRequestSchema, "Stealth pool request"),
+  },
+  responses: {
+    200: jsonContent(stealthPoolResponseSchema, "Unsigned serialized transaction", stealthPoolResponseExample),
+    400: jsonContent(errorResponseSchema, "Build error"),
+    422: jsonContent(validationErrorResponseSchema, "Validation error"),
+  },
+});
+
+export const stealthPoolStatusRoute = createRoute({
+  path: "/v1/spl/stealth-pool",
+  method: "get",
+  tags,
+  description: "Derive a stealth pool PDA from an exact handle and report whether the base account exists.",
+  request: {
+    query: stealthPoolStatusRequestSchema,
+  },
+  responses: {
+    200: jsonContent(stealthPoolStatusResponseSchema, "Stealth pool status"),
+    400: jsonContent(errorResponseSchema, "Query error"),
+    422: jsonContent(validationErrorResponseSchema, "Validation error"),
+  },
+});
+
 export const balanceRoute = createRoute({
   path: "/v1/spl/balance",
   method: "get",
@@ -228,6 +313,21 @@ export const mintInitializationRoute = createRoute({
   responses: {
     200: jsonContent(mintInitializationResponseSchema, "Mint transfer queue initialization status", mintInitializationResponseExample),
     400: jsonContent(errorResponseSchema, "Query error"),
+    422: jsonContent(validationErrorResponseSchema, "Validation error"),
+  },
+});
+
+export const transferQueueEnsureCrankRoute = createRoute({
+  path: "/v1/spl/transfer-queue/ensure-crank",
+  method: "post",
+  tags,
+  description: "After setup confirmation, verify the validator-scoped transfer queue and force one crank attempt.",
+  request: {
+    body: jsonContentRequired(transferQueueEnsureCrankRequestSchema, "Transfer queue crank request"),
+  },
+  responses: {
+    200: jsonContent(transferQueueEnsureCrankResponseSchema, "Forced transfer queue crank result", transferQueueEnsureCrankResponseExample),
+    400: jsonContent(errorResponseSchema, "Crank error"),
     422: jsonContent(validationErrorResponseSchema, "Validation error"),
   },
 });

--- a/api/src/routes/spl/spl.schemas.ts
+++ b/api/src/routes/spl/spl.schemas.ts
@@ -22,7 +22,7 @@ export const transferFeesSchema = z.object({
 export type TransferFees = z.infer<typeof transferFeesSchema>;
 
 export const transactionResponseSchema = z.object({
-  kind: z.enum(["deposit", "withdraw", "transfer", "initializeMint", "undelegateEphemeralAta"]),
+  kind: z.enum(["deposit", "withdraw", "transfer", "initializeMint", "undelegateEphemeralAta", "stealthPool"]),
   version: z.enum(["legacy", "v0"]),
   transactionBase64: z.string(),
   sendTo: balanceLocationSchema,
@@ -72,6 +72,31 @@ export const mintInitializationResponseSchema = z.object({
   initialized: z.boolean(),
 }).openapi("MintInitializationResponse");
 export type MintInitializationResponse = z.infer<typeof mintInitializationResponseSchema>;
+
+export const transferQueueEnsureCrankRequestSchema = z.object({
+  mint: publicKeySchema.openapi({
+    example: DEFAULT_DEPOSIT_MINT,
+  }),
+  cluster: clusterSchema.optional(),
+  validator: publicKeySchema.openapi({
+    example: DEFAULT_DEPOSIT_VALIDATOR,
+    description: "Optional. Defaults to the selected ephemeral RPC identity resolved via `getIdentity`.",
+  }).optional(),
+}).openapi("TransferQueueEnsureCrankRequest", {
+  example: {
+    mint: DEFAULT_DEPOSIT_MINT,
+    validator: DEFAULT_DEPOSIT_VALIDATOR,
+  },
+});
+export type TransferQueueEnsureCrankRequest = z.infer<typeof transferQueueEnsureCrankRequestSchema>;
+
+export const transferQueueEnsureCrankResponseSchema = z.object({
+  mint: publicKeySchema,
+  validator: publicKeySchema,
+  transferQueue: publicKeySchema,
+  crankSignature: z.string(),
+}).openapi("TransferQueueEnsureCrankResponse");
+export type TransferQueueEnsureCrankResponse = z.infer<typeof transferQueueEnsureCrankResponseSchema>;
 
 export const initializeMintRequestSchema = z.object({
   payer: publicKeySchema.openapi({
@@ -126,6 +151,72 @@ export const undelegateEphemeralAtaResponseSchema = transactionResponseSchema.ex
   }),
 }).openapi("UndelegateEphemeralAtaResponse");
 export type UndelegateEphemeralAtaResponse = z.infer<typeof undelegateEphemeralAtaResponseSchema>;
+
+export const stealthHandleSchema = z.string().min(1).openapi({
+  example: "john.doe@magicblock.id",
+  description: "Exact canonical handle string. The API hashes these UTF-8 bytes as-is; it does not trim, lowercase, or normalize.",
+});
+
+export const stealthPoolRequestSchema = z.object({
+  payer: publicKeySchema.openapi({
+    example: DEPOSIT_EXAMPLE_OWNER,
+  }),
+  authority: publicKeySchema.openapi({
+    example: DEPOSIT_EXAMPLE_OWNER,
+  }),
+  handle: stealthHandleSchema,
+  destinations: z.array(publicKeySchema).min(1).max(10).openapi({
+    example: [
+      "Bt9oNR5cCtnfuMmXgWELd6q5i974PdEMQDUE55nBC57L",
+      "3rXKwQ1kpjBd5tdcco32qsvqUh1BnZjcYnS5kYrP7AYE",
+    ],
+    description: "Owner public keys, not token accounts. Must contain between 1 and 10 keys.",
+  }),
+  splitAcrossKeys: z.boolean().openapi({
+    example: false,
+    description: "Optional. When true, split payments may resolve independently across destination keys.",
+  }).optional(),
+  validator: publicKeySchema.openapi({
+    example: DEFAULT_DEPOSIT_VALIDATOR,
+    description: "Optional validator identity to receive the delegated stealth pool.",
+  }).optional(),
+  cluster: clusterSchema.optional(),
+}).openapi("StealthPoolRequest", {
+  example: {
+    payer: DEPOSIT_EXAMPLE_OWNER,
+    authority: DEPOSIT_EXAMPLE_OWNER,
+    handle: "john.doe@magicblock.id",
+    destinations: [TRANSFER_EXAMPLE_TO],
+    splitAcrossKeys: false,
+    validator: DEFAULT_DEPOSIT_VALIDATOR,
+  },
+});
+export type StealthPoolRequest = z.infer<typeof stealthPoolRequestSchema>;
+
+export const stealthPoolResponseSchema = transactionResponseSchema.extend({
+  kind: z.literal("stealthPool"),
+  setupTransaction: transactionResponseSchema,
+  stealthPool: publicKeySchema,
+  handleHash: z.string(),
+}).openapi("StealthPoolResponse");
+export type StealthPoolResponse = z.infer<typeof stealthPoolResponseSchema>;
+
+export const stealthPoolStatusRequestSchema = z.object({
+  handle: stealthHandleSchema,
+  cluster: clusterSchema.optional(),
+}).openapi("StealthPoolStatusRequest", {
+  example: {
+    handle: "john.doe@magicblock.id",
+  },
+});
+export type StealthPoolStatusRequest = z.infer<typeof stealthPoolStatusRequestSchema>;
+
+export const stealthPoolStatusResponseSchema = z.object({
+  stealthPool: publicKeySchema,
+  handleHash: z.string(),
+  exists: z.boolean(),
+}).openapi("StealthPoolStatusResponse");
+export type StealthPoolStatusResponse = z.infer<typeof stealthPoolStatusResponseSchema>;
 
 export const depositRequestSchema = z.object({
   owner: publicKeySchema.openapi({
@@ -254,6 +345,69 @@ export const transferRequestSchema = z.object({
   },
 });
 export type TransferRequest = z.infer<typeof transferRequestSchema>;
+
+export const stealthTransferRequestSchema = z.object({
+  from: publicKeySchema,
+  toHandle: stealthHandleSchema,
+  cluster: clusterSchema.optional(),
+  mint: publicKeySchema,
+  amount: amountSchema,
+  fromBalance: z.literal("base").openapi({
+    example: "base",
+    description: "Stealth transfers are base-chain source only.",
+  }).default("base"),
+  validator: publicKeySchema.openapi({
+    example: DEFAULT_DEPOSIT_VALIDATOR,
+    description: "Optional. When none is provided, the API resolves it from the selected ephemeral RPC via `getIdentity`.",
+  }).optional(),
+  initIfMissing: z.boolean().optional(),
+  initAtasIfMissing: z.boolean().optional(),
+  initVaultIfMissing: z.boolean().optional(),
+  memo: z.string().openapi({
+    example: "Order #1042",
+    description: "Optional. Appends a final Memo Program instruction with this UTF-8 message.",
+  }).optional(),
+  minDelayMs: optionalBigIntStringSchema.openapi({
+    example: "0",
+    description: "Optional. Defaults to 0.",
+  }).optional(),
+  maxDelayMs: optionalBigIntStringSchema.openapi({
+    example: "0",
+    description: "Optional. Defaults to 0 when omitted, or to minDelayMs when minDelayMs is set.",
+  }).optional(),
+  clientRefId: optionalBigIntStringSchema.openapi({
+    example: "42",
+    description: "Optional. Encrypted client reference ID that can be used to confirm a payment.",
+  }).optional(),
+  split: z.int().positive().max(15).openapi({
+    example: 1,
+    description: "Optional. Defaults to 1. Must be between 1 and 15.",
+  }).optional(),
+  exactOut: z.boolean().openapi({
+    example: boolean,
+    description: "Optional. If true, the fees are deducted from the sender, else from the recipient amount.",
+  }).optional(),
+  gasless: z.boolean().openapi({
+    example: true,
+    description: "Optional. Same gasless policy as `/v1/spl/transfer`.",
+  }).optional(),
+  legacy: z.boolean().openapi({
+    description: "Optional. Defaults to false. When true, skips lookup-table compilation and returns a legacy transaction.",
+  }).optional(),
+}).openapi("StealthTransferRequest", {
+  example: {
+    from: DEPOSIT_EXAMPLE_OWNER,
+    toHandle: "john.doe@magicblock.id",
+    mint: DEFAULT_DEPOSIT_MINT,
+    amount: 5000000,
+    fromBalance: "base",
+    minDelayMs: "0",
+    maxDelayMs: "0",
+    clientRefId: "42",
+    gasless: true,
+  },
+});
+export type StealthTransferRequest = z.infer<typeof stealthTransferRequestSchema>;
 
 export const balanceRequestSchema = z.object({
   address: publicKeySchema,

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -591,10 +591,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@magicblock-labs/ephemeral-rollups-sdk@0.15.3":
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/@magicblock-labs/ephemeral-rollups-sdk/-/ephemeral-rollups-sdk-0.15.3.tgz#40934d8f0f8a3a81d47c5905cc45042d08a3a48a"
-  integrity sha512-UsKrw+3UYpHTvCdCKmvhUBakVWVRq3YHJkMAK0P/ZeAw0BSlij/FVUww0XeVxrjvlsorCm57p5pd16i3EHycBw==
+"@magicblock-labs/ephemeral-rollups-sdk@0.15.5":
+  version "0.15.5"
+  resolved "https://registry.yarnpkg.com/@magicblock-labs/ephemeral-rollups-sdk/-/ephemeral-rollups-sdk-0.15.5.tgz#c64d0bda81b8b2d3d0b1793b218125701a266d2a"
+  integrity sha512-X8X4RGfiMaqaWZEw3OKE6zg32ng/OMyalbnWTRJ7O+h6Xu2A9Zj+YC9yWp0aIxi5spMmIfNtEZwyxzTs1fXszQ==
   dependencies:
     "@noble/curves" "^1.4.2"
     "@noble/hashes" "^1.4.0"

--- a/e-token/src/entrypoint.rs
+++ b/e-token/src/entrypoint.rs
@@ -59,7 +59,14 @@ pub fn process_instruction(accounts: &[AccountView], instruction_data: &[u8]) ->
             process_internal_instruction(accounts, instruction_data)
         }
     };
-    result.inspect_err(log_error)
+    result.inspect_err(|e| {
+        log_error(e);
+        pinocchio_log::log!(
+            "ixdatalen = {} ixdata: {}",
+            instruction_data.len(),
+            &instruction_data[0..8.min(instruction_data.len())]
+        );
+    })
 }
 
 /// Process public instruction

--- a/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
+++ b/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
@@ -149,7 +149,7 @@ pub(crate) fn process_with_merge_and_private_transfer_inner(
     debug_log!({
         let shuttle = common_accounts.shuttle_info.address().to_string();
         let shuttle_eata = common_accounts.shuttle_eata_info.address().to_string();
-        let shuttle_wallet = common_accounts
+        let shuttle_ata = common_accounts
             .shuttle_wallet_ata_info
             .address()
             .to_string();
@@ -162,10 +162,11 @@ pub(crate) fn process_with_merge_and_private_transfer_inner(
         let queue = queue_info.address().to_string();
 
         pinocchio_log::log!(
-            "Private shuttle ix accounts shuttle={} shuttle_eata={} shuttle_wallet={} mint={} owner_source={} vault_token={} queue={}",
+            350,
+            "privatetx: shuttle={}, ata={} eata={} mint={} owner_source={} vault_token={} queue={}",
             shuttle.as_str(),
+            shuttle_ata.as_str(),
             shuttle_eata.as_str(),
-            shuttle_wallet.as_str(),
             mint.as_str(),
             owner_source.as_str(),
             vault_token.as_str(),

--- a/e-token/src/processor/internal/shuttle_delegation.rs
+++ b/e-token/src/processor/internal/shuttle_delegation.rs
@@ -177,15 +177,15 @@ pub(crate) fn prepare_sponsored_shuttle_delegation(
     debug_log!({
         let shuttle = shuttle_info.address().to_string();
         let shuttle_eata = shuttle_eata_info.address().to_string();
-        let shuttle_wallet = shuttle_wallet_ata_info.address().to_string();
+        let shuttle_ata = shuttle_wallet_ata_info.address().to_string();
         let owner = owner_info.address().to_string();
         let mint = mint_info.address().to_string();
         let rent_pda = rent_pda_info.address().to_string();
         pinocchio_log::log!(
-            "PrepareShuttleDelegation accounts shuttle={} shuttle_eata={} shuttle_wallet={} owner={} mint={} rent_pda={} shuttle_id={}",
+            "prepare_shuttle_delegation: shuttle={} ata={} eata={} owner={} mint={} rent_pda={} shuttle_id={}",
             shuttle.as_str(),
+            shuttle_ata.as_str(),
             shuttle_eata.as_str(),
-            shuttle_wallet.as_str(),
             owner.as_str(),
             mint.as_str(),
             rent_pda.as_str(),
@@ -397,8 +397,8 @@ pub(crate) fn build_undelegate_and_close_shuttle_instruction(
     close_stash: Option<CloseStashArgs>,
 ) -> Instruction {
     let accounts = alloc::vec![
-        AccountMeta::new_readonly(*payer, true),
-        AccountMeta::new_readonly(*rent_pda, false),
+        AccountMeta::new_readonly(*payer, true), // TODO: can be removed, or passed as pubkey
+        AccountMeta::new_readonly(*rent_pda, false), // TODO (snawaz): can be passed as pubkey
         AccountMeta::new_readonly(*shuttle, false),
         AccountMeta::new_readonly(*shuttle_eata, false),
         AccountMeta::new(*shuttle_wallet_ata, false),

--- a/e-token/src/processor/merge_shuttle_into_ephemeral_ata.rs
+++ b/e-token/src/processor/merge_shuttle_into_ephemeral_ata.rs
@@ -7,7 +7,7 @@ use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 use crate::processor::utils::{read_mint_decimals, validate_token_account};
 
 ///
-/// Executes on:
+/// Executes on: ER only
 ///
 /// Accounts:
 ///


### PR DESCRIPTION
- add stealth-address functionalities to the backend
- also add `POST /v1/spl/transfer-queue/ensure-crank` that is called from UI immediately after setup is executed successfully. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new endpoints for stealth pool creation and management
  * Added stealth transfer capability to the API
  * Added endpoint to force transfer queue crank execution

* **Documentation**
  * Updated REST API documentation with complete stealth functionality details and usage examples

* **Tests**
  * Expanded test coverage for stealth pool operations, stealth transfers, and transfer queue crank management

* **Chores**
  * Updated project dependencies to newer versions
  * Updated local development RPC endpoint configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->