### PR TITLE
chore: add fees info in the api

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -601,7 +601,8 @@ The returned `sendTo` value is:
 - `"base"` when `fromBalance` is `"base"`
 - `"ephemeral"` when `fromBalance` is `"ephemeral"`
 
-Transfer responses also include `from`, which mirrors the request `fromBalance`.
+Transfer responses also include `from`, which mirrors the request `fromBalance`, and `fees`.
+`fees.lamports` and `fees.tokens` are total fee strings and return `"0"` when that fee type is not charged. `fees.tokens` uses mint base units. Private `base -> base` transfers report the on-chain private-transfer token fee and shuttle setup lamport fee. Gasless transfers add the relay fee to `fees.tokens` only when gasless is honored.
 
 Example:
 
@@ -655,6 +656,7 @@ Gasless transfer validation:
 - the API prepends a 0.2 USDC/USDT relay-fee token transfer from the sender to the sponsor ATA
 - gasless transfers require an approved stablecoin mint: mainnet USDC, mainnet USDT, or devnet USDC
 - gasless transfers must be at least 5 USDC/USDT
+- if `from` is an off-curve PDA owner, `gasless: true` is ignored because gasless transfers require a supported wallet sender
 
 Relevant fields:
 
@@ -674,6 +676,7 @@ Relevant fields:
 - `minDelayMs`
 - `maxDelayMs`
 - `split`
+- `exactOut`
 - `gasless`
 - `legacy`
 

--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -353,6 +353,10 @@ describe("app", () => {
       "initVaultIfMissing",
     );
     expect(transferRequestSchema?.example).not.toHaveProperty("split");
+    const transactionResponseSchema = (
+      json.components?.schemas as Record<string, any>
+    )?.UnsignedTransactionResponse;
+    expect(transactionResponseSchema?.properties?.fees).toBeDefined();
     expect(
       json.paths["/v1/spl/withdraw"]?.post?.responses?.["200"]?.content?.[
         "application/json"
@@ -2649,12 +2653,20 @@ describe("app", () => {
       from: string;
       recentBlockhash: string;
       instructionCount: number;
+      fees: {
+        lamports: string;
+        tokens: string;
+      };
     };
 
     expect(json.sendTo).toBe("ephemeral");
     expect(json.from).toBe("ephemeral");
     expect(json.recentBlockhash).toBe("11111111111111111111111111111111");
     expect(json.instructionCount).toBe(1);
+    expect(json.fees).toEqual({
+      lamports: "0",
+      tokens: "0",
+    });
   });
 
   it("builds a private transfer with top-level split and delay options", async () => {
@@ -2689,7 +2701,7 @@ describe("app", () => {
           from: owner,
           to: destination,
           mint: "So11111111111111111111111111111111111111112",
-          amount: 2,
+          amount: 5_000_000,
           visibility: "private",
           fromBalance: "base",
           toBalance: "base",
@@ -2709,6 +2721,10 @@ describe("app", () => {
       recentBlockhash: string;
       validator: string;
       version: string;
+      fees: {
+        lamports: string;
+        tokens: string;
+      };
     };
 
     expect(json.sendTo).toBe("base");
@@ -2716,6 +2732,10 @@ describe("app", () => {
     expect(json.recentBlockhash).toBe("11111111111111111111111111111111");
     expect(json.validator).toBe(resolvedValidator);
     expect(json.version).toBe("legacy");
+    expect(json.fees).toEqual({
+      lamports: "2039280",
+      tokens: "5000",
+    });
   });
 
   it("uses the mint token program when initializing a transfer vault", async () => {
@@ -3219,7 +3239,15 @@ describe("app", () => {
     const json = (await response.json()) as {
       requiredSigners: string[];
       transactionBase64: string;
+      fees: {
+        lamports: string;
+        tokens: string;
+      };
     };
+    expect(json.fees).toEqual({
+      lamports: "2039280",
+      tokens: "205000",
+    });
     expect(json.requiredSigners).toEqual(
       expect.arrayContaining([owner, sponsor.publicKey.toBase58()]),
     );
@@ -3349,8 +3377,16 @@ describe("app", () => {
       requiredSigners: string[];
       transactionBase64: string;
       version: string;
+      fees: {
+        lamports: string;
+        tokens: string;
+      };
     };
     expect(json.version).toBe("v0");
+    expect(json.fees).toEqual({
+      lamports: "2039280",
+      tokens: "205000",
+    });
     expect(json.requiredSigners).toEqual(
       expect.arrayContaining([owner, sponsor.publicKey.toBase58()]),
     );
@@ -3437,7 +3473,15 @@ describe("app", () => {
     const json = (await response.json()) as {
       requiredSigners: string[];
       transactionBase64: string;
+      fees: {
+        lamports: string;
+        tokens: string;
+      };
     };
+    expect(json.fees).toEqual({
+      lamports: "0",
+      tokens: "200000",
+    });
     expect(json.requiredSigners).toEqual(
       expect.arrayContaining([owner, sponsor.publicKey.toBase58()]),
     );
@@ -3469,6 +3513,58 @@ describe("app", () => {
     ]);
     expect(publicTransferIx.data[0]).toBe(3);
     expect(publicTransferIx.data.readBigUInt64LE(1)).toBe(BigInt(amount));
+  });
+
+  it("ignores gasless for off-curve transfer senders", async () => {
+    const [offCurveSender] = PublicKey.findProgramAddressSync(
+      [Buffer.from("off-curve-sender")],
+      EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+    );
+
+    vi.spyOn(Connection.prototype, "getLatestBlockhash").mockResolvedValue({
+      blockhash: "11111111111111111111111111111111",
+      lastValidBlockHeight: 123,
+    });
+    vi.spyOn(Connection.prototype, "getAccountInfo").mockResolvedValue(
+      createMintAccountInfo(TOKEN_PROGRAM_ID),
+    );
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      expect(String(input)).toBe(env.EPHEMERAL_DEVNET_RPC_URL);
+      return createIdentityResponse(resolvedValidator);
+    });
+
+    const response = await app.request(
+      "/v1/spl/transfer",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          from: offCurveSender.toBase58(),
+          to: destination,
+          mint: DEVNET_USDC_MINT,
+          amount: 1,
+          cluster: "devnet",
+          visibility: "public",
+          fromBalance: "base",
+          toBalance: "base",
+          gasless: true,
+        }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(400);
+
+    const json = (await response.json()) as {
+      error: {
+        code: string;
+        message: string;
+      };
+    };
+    expect(json.error.code).toBe("TRANSACTION_BUILD_ERROR");
+    expect(json.error.message).toBe("Owner public key is off-curve");
   });
 
   it("rejects gasless transfers when the sponsor key is not configured", async () => {

--- a/api/src/lib/solana.ts
+++ b/api/src/lib/solana.ts
@@ -64,6 +64,9 @@ const PRIVATE_BASE_TO_BASE_TRANSFER_LOOKUP_TABLES = {
   mainnet: new PublicKey("2J2Pw639kU7U6rj7qUXY5sVXdJqyt4DjEcVxzqmFrFds"),
   devnet: new PublicKey("HFmj4QbofPjhXP2vdnDARDQFw1AucSQTKVAs8df4tkUy"),
 } as const;
+const PRIVATE_TRANSFER_SETUP_LAMPORTS = 2_039_280n;
+const PRIVATE_TRANSFER_FEE_BASIS_POINTS = 10n;
+const BASIS_POINTS_FACTOR = 10_000n;
 const GASLESS_RELAY_FEE_MICRO_USDC = 200_000n; // 0.2 USDC/USDT
 const GASLESS_STABLECOIN_MIN_AMOUNT = BigInt(5 * 1_000_000); // 5 USDC/USDT
 
@@ -94,6 +97,8 @@ type RpcIdentityResponse = {
 type BackgroundTaskScheduler = {
   waitUntil: (promise: Promise<unknown>) => void;
 };
+
+type TransferFees = NonNullable<TransactionResponse["fees"]>;
 
 function getBaseConnection(config: RpcConfig) {
   return getConnection(config.baseRpcUrl);
@@ -617,6 +622,27 @@ function isSupportedGaslessMint(cluster: RpcConfig["cluster"], mint: PublicKey) 
   return mintAddress === DEFAULT_DEPOSIT_MINT || mintAddress === MAINNET_USDT_MINT;
 }
 
+function privateTransferFeeAmount(amount: bigint) {
+  return amount * PRIVATE_TRANSFER_FEE_BASIS_POINTS / BASIS_POINTS_FACTOR;
+}
+
+function isPrivateBaseToBaseTransfer(input: TransferRequest) {
+  return input.visibility === "private"
+    && input.fromBalance === "base"
+    && input.toBalance === "base";
+}
+
+function privateTransferSetupLamports(input: TransferRequest) {
+  return isPrivateBaseToBaseTransfer(input) ? PRIVATE_TRANSFER_SETUP_LAMPORTS : 0n;
+}
+
+function createTransferFees(lamports: bigint, tokens: bigint): TransferFees {
+  return {
+    lamports: lamports.toString(),
+    tokens: tokens.toString(),
+  };
+}
+
 function isTransactionTooLargeMessage(message: string) {
   const normalized = message.toLowerCase();
 
@@ -683,6 +709,7 @@ function serializeTransaction(
   validator?: PublicKey,
   partialSigners: Keypair[] = [],
   from?: SendTarget,
+  fees?: TransferFees,
 ): TransactionResponse {
   const transaction = createUnsignedTransaction(instructions, feePayer, blockhash);
   if (partialSigners.length > 0) {
@@ -705,6 +732,7 @@ function serializeTransaction(
     instructionCount: instructions.length,
     requiredSigners: getRequiredSigners(feePayer, instructions),
     validator: validator?.toBase58(),
+    fees,
   };
 }
 
@@ -716,6 +744,7 @@ async function trySerializePrivateBaseToBaseTransferTransactionWithLookupTable(
   blockhash: BlockhashResult,
   validator?: PublicKey,
   partialSigners: Keypair[] = [],
+  fees?: TransferFees,
 ): Promise<TransactionResponse | undefined> {
   if (config.cluster === "custom") {
     return undefined;
@@ -770,6 +799,7 @@ async function trySerializePrivateBaseToBaseTransferTransactionWithLookupTable(
       instructionCount: instructions.length,
       requiredSigners: getRequiredSigners(feePayer, instructions),
       validator: validator?.toBase58(),
+      fees,
     };
   } catch (error) {
     console.warn("LUT v0 compilation failed, falling back to legacy", {
@@ -989,7 +1019,9 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
       throw new ApiError(400, "INVALID_PRIVATE_TRANSFER", "split cannot exceed amount");
     }
 
-    if (input.gasless && !isSupportedGaslessMint(config.cluster, mint)) {
+    const useGasless = input.gasless === true && PublicKey.isOnCurve(from.toBuffer());
+
+    if (useGasless && !isSupportedGaslessMint(config.cluster, mint)) {
       throw new ApiError(
         400,
         "INVALID_GASLESS_TRANSFER_MINT",
@@ -997,7 +1029,7 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
       );
     }
 
-    if (input.gasless && amount < GASLESS_STABLECOIN_MIN_AMOUNT) {
+    if (useGasless && amount < GASLESS_STABLECOIN_MIN_AMOUNT) {
       throw new ApiError(
         400,
         "INVALID_GASLESS_TRANSFER_AMOUNT",
@@ -1005,9 +1037,14 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
       );
     }
 
-    const sponsor = input.gasless ? getGaslessSponsorKeypair(env) : undefined;
+    const sponsor = useGasless ? getGaslessSponsorKeypair(env) : undefined;
     const payer = sponsor?.publicKey ?? from;
     const feePayer = sponsor?.publicKey ?? from;
+    const privateTransferFee = isPrivateBaseToBaseTransfer(input) ? privateTransferFeeAmount(amount) : 0n;
+    const fees = createTransferFees(
+      privateTransferSetupLamports(input),
+      privateTransferFee + (sponsor ? GASLESS_RELAY_FEE_MICRO_USDC : 0n),
+    );
 
     const shouldResolveValidator = input.validator
       || input.visibility === "private"
@@ -1089,6 +1126,7 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
         blockhash,
         validator,
         sponsor ? [sponsor] : [],
+        fees,
       );
 
       if (versionedResponse) {
@@ -1106,6 +1144,7 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
       validator,
       sponsor ? [sponsor] : [],
       input.fromBalance,
+      fees,
     );
   } catch (error) {
     throwTransactionBuildError(error);

--- a/api/src/routes/spl/spl.schemas.ts
+++ b/api/src/routes/spl/spl.schemas.ts
@@ -9,6 +9,18 @@ const DEPOSIT_EXAMPLE_OWNER = "3rXKwQ1kpjBd5tdcco32qsvqUh1BnZjcYnS5kYrP7AYE";
 const TRANSFER_EXAMPLE_TO = "Bt9oNR5cCtnfuMmXgWELd6q5i974PdEMQDUE55nBC57L";
 const BALANCE_EXAMPLE_ADDRESS = "Bt9oNR5cCtnfuMmXgWELd6q5i974PdEMQDUE55nBC57L";
 
+export const transferFeesSchema = z.object({
+  lamports: z.string().openapi({
+    example: "2039280",
+    description: "Total lamport fees charged by the transfer. Returns \"0\" when no lamport fee is charged.",
+  }),
+  tokens: z.string().openapi({
+    example: "205000",
+    description: "Total token fees charged by the transfer, in mint base units. Returns \"0\" when no token fee is charged.",
+  }),
+}).openapi("TransferFees");
+export type TransferFees = z.infer<typeof transferFeesSchema>;
+
 export const transactionResponseSchema = z.object({
   kind: z.enum(["deposit", "withdraw", "transfer", "initializeMint"]),
   version: z.enum(["legacy", "v0"]),
@@ -20,6 +32,7 @@ export const transactionResponseSchema = z.object({
   instructionCount: z.number().int().nonnegative(),
   requiredSigners: z.array(publicKeySchema),
   validator: publicKeySchema.optional(),
+  fees: transferFeesSchema.optional(),
 }).openapi("UnsignedTransactionResponse");
 export type TransactionResponse = z.infer<typeof transactionResponseSchema>;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Transfer API responses now include detailed fee information (lamports and tokens).

* **Bug Fixes**
  * Gasless transfers are now properly rejected when the sender public key is off-curve.

* **Documentation**
  * Updated transfer endpoint documentation to reflect new fee response fields and updated gasless transfer validation conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->