### PR TITLE
Route undelegation transactions to delegated endpoint

### DIFF
--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -364,6 +364,10 @@ describe("app", () => {
       json.components?.schemas as Record<string, any>
     )?.UnsignedTransactionResponse;
     expect(transactionResponseSchema?.properties?.fees).toBeDefined();
+    const sendTransactionRequestSchema = (
+      json.components?.schemas as Record<string, any>
+    )?.SendTransactionRequest;
+    expect(sendTransactionRequestSchema?.properties?.sendRpcEndpoint).toBeDefined();
     expect(
       json.paths["/v1/spl/withdraw"]?.post?.responses?.["200"]?.content?.[
         "application/json"
@@ -481,6 +485,108 @@ describe("app", () => {
       confirmationRpcEndpoint: env.EPHEMERAL_DEVNET_RPC_URL,
       confirmationRequiresAuthToken: true,
     });
+  });
+
+  it("sends and confirms a signed ephemeral transaction to the provided RPC endpoint", async () => {
+    const transaction = Buffer.from([5, 6, 7, 8]);
+    const sendRpcEndpoint = "https://devnet-tee.magicblock.app";
+    const blockhash = "11111111111111111111111111111111";
+
+    vi.spyOn(Connection.prototype, "sendRawTransaction").mockImplementation(
+      async function sendRawTransaction(
+        this: Connection & { _rpcEndpoint: string },
+        raw,
+      ) {
+        expect((this as Connection & { _rpcEndpoint: string })._rpcEndpoint).toBe(
+          `${sendRpcEndpoint}/?token=private-token`,
+        );
+        expect(Buffer.from(raw as Uint8Array)).toEqual(transaction);
+        return "endpoint-signature";
+      },
+    );
+    vi.spyOn(Connection.prototype, "confirmTransaction").mockImplementation(
+      async function confirmTransaction(this: Connection & { _rpcEndpoint: string }) {
+        expect((this as Connection & { _rpcEndpoint: string })._rpcEndpoint).toBe(
+          `${sendRpcEndpoint}/?token=private-token`,
+        );
+        return {
+          context: { slot: 1 },
+          value: { err: null },
+        };
+      },
+    );
+
+    const response = await app.request(
+      "/v1/transaction/send",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Authorization": "Bearer private-token",
+        },
+        body: JSON.stringify({
+          transactionBase64: transaction.toString("base64"),
+          sendTo: "ephemeral",
+          sendRpcEndpoint,
+          cluster: "devnet",
+          confirm: true,
+          recentBlockhash: blockhash,
+          lastValidBlockHeight: 123,
+        }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(200);
+
+    const json = (await response.json()) as {
+      signature: string;
+      sendTo: string;
+      confirmed: boolean;
+      confirmationRpcEndpoint: string;
+      confirmationRequiresAuthToken: boolean;
+    };
+
+    expect(json).toEqual({
+      signature: "endpoint-signature",
+      sendTo: "ephemeral",
+      confirmed: true,
+      confirmationRpcEndpoint: sendRpcEndpoint,
+      confirmationRequiresAuthToken: true,
+    });
+  });
+
+  it("rejects a send RPC endpoint override for base transactions", async () => {
+    const sendRawTransactionSpy = vi.spyOn(
+      Connection.prototype,
+      "sendRawTransaction",
+    );
+
+    const response = await app.request(
+      "/v1/transaction/send",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          transactionBase64: Buffer.from([1, 2, 3]).toString("base64"),
+          sendTo: "base",
+          sendRpcEndpoint: "https://devnet-tee.magicblock.app",
+        }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(400);
+    expect(sendRawTransactionSpy).not.toHaveBeenCalled();
+
+    const json = (await response.json()) as {
+      error: {
+        code: string;
+      };
+    };
+    expect(json.error.code).toBe("INVALID_SEND_RPC_ENDPOINT");
   });
 
   it("confirms a sent transaction when requested", async () => {
@@ -1915,7 +2021,7 @@ describe("app", () => {
         method: "POST",
         headers: {
           "content-type": "application/json",
-          authorization: `Bearer ${MOCK_AUTH_TOKEN}`,
+          "authorization": `Bearer ${MOCK_AUTH_TOKEN}`,
         },
         body: JSON.stringify({
           payer: owner,
@@ -2027,7 +2133,7 @@ describe("app", () => {
         method: "POST",
         headers: {
           "content-type": "application/json",
-          authorization: `Bearer ${MOCK_AUTH_TOKEN}`,
+          "authorization": `Bearer ${MOCK_AUTH_TOKEN}`,
         },
         body: JSON.stringify({
           payer: owner,
@@ -2089,7 +2195,7 @@ describe("app", () => {
         method: "POST",
         headers: {
           "content-type": "application/json",
-          authorization: `Bearer ${MOCK_AUTH_TOKEN}`,
+          "authorization": `Bearer ${MOCK_AUTH_TOKEN}`,
         },
         body: JSON.stringify({
           payer: owner,

--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import {
@@ -201,6 +201,12 @@ function createExecutionContext(): TestExecutionContext {
 }
 
 describe("app", () => {
+  beforeEach(() => {
+    vi.spyOn(Connection.prototype, "getMultipleAccountsInfo").mockImplementation(
+      async addresses => addresses.map(() => null),
+    );
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -231,6 +237,7 @@ describe("app", () => {
     expect(json.paths["/v1/spl/login"]).toBeDefined();
     expect(json.paths["/v1/spl/is-mint-initialized"]).toBeDefined();
     expect(json.paths["/v1/spl/initialize-mint"]).toBeDefined();
+    expect(json.paths["/v1/spl/undelegate-ephemeral-ata"]).toBeDefined();
     expect(json.paths["/v1/swap/quote"]).toBeDefined();
     expect(json.paths["/v1/swap/swap"]).toBeDefined();
     expect(json.tags).toEqual(
@@ -1856,6 +1863,256 @@ describe("app", () => {
     );
   });
 
+  it("builds an unsigned eATA undelegation transaction", async () => {
+    const mint = new PublicKey(DEVNET_USDC_MINT);
+    const payer = new PublicKey(owner);
+    const [ephemeralAta] = deriveEphemeralAta(payer, mint);
+    const ata = deriveAssociatedTokenAddress(mint.toBase58(), owner);
+    const sendRpcEndpoint = "https://devnet-tee.magicblock.app";
+
+    vi.spyOn(Connection.prototype, "getLatestBlockhash").mockImplementation(
+      async function getLatestBlockhash(this: Connection & { _rpcEndpoint: string }) {
+        expect((this as Connection & { _rpcEndpoint: string })._rpcEndpoint).toBe(
+          `${sendRpcEndpoint}/?token=${MOCK_AUTH_TOKEN}`,
+        );
+        return {
+          blockhash: "11111111111111111111111111111111",
+          lastValidBlockHeight: 123,
+        };
+      },
+    );
+    vi.spyOn(Connection.prototype, "getAccountInfo").mockResolvedValue(
+      createMintAccountInfo(TOKEN_PROGRAM_ID),
+    );
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      expect(String(input)).toBe("https://devnet-router.magicblock.app/");
+      const body = JSON.parse(String(init?.body)) as {
+        method?: string;
+        params?: string[];
+      };
+      expect(body.method).toBe("getDelegationStatus");
+      expect(body.params).toEqual([ephemeralAta.toBase58()]);
+
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            isDelegated: true,
+            fqdn: `${sendRpcEndpoint}/`,
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+
+    const response = await app.request(
+      "/v1/spl/undelegate-ephemeral-ata",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${MOCK_AUTH_TOKEN}`,
+        },
+        body: JSON.stringify({
+          payer: owner,
+          mint: mint.toBase58(),
+          cluster: "devnet",
+        }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(200);
+
+    const json = (await response.json()) as {
+      kind: string;
+      sendTo: string;
+      sendRpcEndpoint: string;
+      transactionBase64: string;
+      recentBlockhash: string;
+      requiredSigners: string[];
+    };
+
+    expect(json.kind).toBe("undelegateEphemeralAta");
+    expect(json.sendTo).toBe("ephemeral");
+    expect(json.sendRpcEndpoint).toBe(sendRpcEndpoint);
+    expect(json.recentBlockhash).toBe("11111111111111111111111111111111");
+    expect(json.requiredSigners).toContain(owner);
+
+    const transaction = Transaction.from(
+      Buffer.from(json.transactionBase64, "base64"),
+    );
+    expect(transaction.instructions).toHaveLength(1);
+
+    const instruction = transaction.instructions[0]!;
+    expect(instruction.programId.equals(EPHEMERAL_SPL_TOKEN_PROGRAM_ID)).toBe(true);
+    expect([...instruction.data]).toEqual([5]);
+    expect(instruction.keys[0]).toEqual(expect.objectContaining({
+      pubkey: payer,
+      isSigner: true,
+      isWritable: true,
+    }));
+    expect(instruction.keys[1]).toEqual(expect.objectContaining({
+      pubkey: new PublicKey(ata),
+      isSigner: false,
+      isWritable: true,
+    }));
+    expect(instruction.keys[2]).toEqual(expect.objectContaining({
+      pubkey: ephemeralAta,
+      isSigner: false,
+      isWritable: false,
+    }));
+  });
+
+  it("falls back to the hardcoded TEE endpoint when router delegation status has no fqdn", async () => {
+    const mint = new PublicKey(DEVNET_USDC_MINT);
+    const payer = new PublicKey(owner);
+    const [ephemeralAta] = deriveEphemeralAta(payer, mint);
+    const delegationRecord = delegationRecordPdaFromDelegatedAccount(ephemeralAta);
+    const teeValidator = new PublicKey("MTEWGuqxUpYZGFJQcp8tLN7x5v9BSeoFHYWQQ3n3xzo");
+    const sendRpcEndpoint = "https://mainnet-tee.magicblock.app";
+    const calls: string[] = [];
+
+    vi.spyOn(Connection.prototype, "getLatestBlockhash").mockImplementation(
+      async function getLatestBlockhash(this: Connection & { _rpcEndpoint: string }) {
+        calls.push("blockhash");
+        expect((this as Connection & { _rpcEndpoint: string })._rpcEndpoint).toBe(
+          `${sendRpcEndpoint}/?token=${MOCK_AUTH_TOKEN}`,
+        );
+        return {
+          blockhash: "11111111111111111111111111111111",
+          lastValidBlockHeight: 123,
+        };
+      },
+    );
+    vi.spyOn(Connection.prototype, "getAccountInfo").mockImplementation(
+      async (address) => {
+        if (address.equals(mint)) {
+          calls.push("mint");
+          return createMintAccountInfo(TOKEN_PROGRAM_ID);
+        }
+
+        if (address.equals(delegationRecord)) {
+          calls.push("delegationRecord");
+          return createDelegationAccountInfo(teeValidator);
+        }
+
+        return null;
+      },
+    );
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      calls.push("router");
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            isDelegated: true,
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+
+    const response = await app.request(
+      "/v1/spl/undelegate-ephemeral-ata",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${MOCK_AUTH_TOKEN}`,
+        },
+        body: JSON.stringify({
+          payer: owner,
+          mint: mint.toBase58(),
+        }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(200);
+
+    const json = (await response.json()) as {
+      sendRpcEndpoint: string;
+    };
+
+    expect(json.sendRpcEndpoint).toBe(sendRpcEndpoint);
+    expect(calls).toEqual(["mint", "router", "delegationRecord", "blockhash"]);
+  });
+
+  it("returns an error when the undelegation endpoint cannot be resolved", async () => {
+    const mint = new PublicKey(DEVNET_USDC_MINT);
+    const payer = new PublicKey(owner);
+    const [ephemeralAta] = deriveEphemeralAta(payer, mint);
+    const delegationRecord = delegationRecordPdaFromDelegatedAccount(ephemeralAta);
+    const getLatestBlockhashSpy = vi.spyOn(Connection.prototype, "getLatestBlockhash");
+
+    vi.spyOn(Connection.prototype, "getAccountInfo").mockImplementation(
+      async (address) => {
+        if (address.equals(mint)) {
+          return createMintAccountInfo(TOKEN_PROGRAM_ID);
+        }
+
+        if (address.equals(delegationRecord)) {
+          return null;
+        }
+
+        return null;
+      },
+    );
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            isDelegated: true,
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+
+    const response = await app.request(
+      "/v1/spl/undelegate-ephemeral-ata",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${MOCK_AUTH_TOKEN}`,
+        },
+        body: JSON.stringify({
+          payer: owner,
+          mint: mint.toBase58(),
+          cluster: "devnet",
+        }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(400);
+    expect(getLatestBlockhashSpy).not.toHaveBeenCalled();
+
+    const json = (await response.json()) as {
+      error: {
+        code: string;
+        message: string;
+      };
+    };
+    expect(json.error.code).toBe("EPHEMERAL_ENDPOINT_UNRESOLVED");
+    expect(json.error.message).toBe("Ephemeral RPC endpoint cannot be retrieved");
+  });
+
   it("returns MINT_NOT_FOUND when a deposit mint account is missing", async () => {
     const mint = new PublicKey("2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo");
     const getAccountInfoSpy = vi
@@ -2736,6 +2993,96 @@ describe("app", () => {
       lamports: "2039280",
       tokens: "5000",
     });
+  });
+
+  it("rejects private base transfers when the source eATA is delegated to another validator", async () => {
+    const transferEnv = {
+      ...env,
+      EPHEMERAL_RPC_URL: "https://ephemeral.transfer.mismatch.rpc.test",
+    };
+    const mint = DEVNET_USDC_MINT;
+    const currentValidator = Keypair.generate().publicKey;
+    const selectedValidator = new PublicKey(resolvedValidator);
+    const delegationRecord = deriveEataDelegationRecord(owner, mint);
+    const [sourceEata] = deriveEphemeralAta(new PublicKey(owner), new PublicKey(mint));
+    const sourceAta = deriveAssociatedTokenAddress(mint, owner);
+
+    vi.spyOn(Connection.prototype, "getAccountInfo").mockResolvedValue(
+      createMintAccountInfo(TOKEN_PROGRAM_ID),
+    );
+    const getMultipleAccountsInfoSpy = vi
+      .spyOn(Connection.prototype, "getMultipleAccountsInfo")
+      .mockImplementation(async function getMultipleAccountsInfo(
+        this: Connection & { _rpcEndpoint: string },
+        addresses,
+      ) {
+        const endpoint = (this as Connection & { _rpcEndpoint: string })
+          ._rpcEndpoint;
+        expect(endpoint).toBe(transferEnv.BASE_RPC_URL);
+        expect(addresses.map(address => address.toBase58())).toEqual([
+          delegationRecord.toBase58(),
+        ]);
+        return [createDelegationAccountInfo(currentValidator)];
+      });
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      expect(String(input)).toBe(transferEnv.EPHEMERAL_RPC_URL);
+      return createIdentityResponse(selectedValidator.toBase58());
+    });
+
+    const response = await app.request(
+      "/v1/spl/transfer",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          from: owner,
+          to: destination,
+          mint,
+          amount: 5_000_000,
+          visibility: "private",
+          fromBalance: "base",
+          toBalance: "base",
+          minDelayMs: "0",
+          maxDelayMs: "0",
+          split: 1,
+        }),
+      },
+      transferEnv,
+    );
+
+    expect(response.status).toBe(400);
+    expect(getMultipleAccountsInfoSpy).toHaveBeenCalledOnce();
+
+    const json = (await response.json()) as {
+      error: {
+        code: string;
+        details: {
+          accounts: Array<{
+            role: string;
+            ata: string;
+            eata: string;
+            currentValidator: string;
+            selectedValidator: string;
+          }>;
+        };
+      };
+    };
+
+    expect(json.error.code).toBe("EATA_VALIDATOR_MISMATCH");
+    expect(json.error.details.accounts).toEqual([
+      {
+        role: "source",
+        owner,
+        mint,
+        ata: sourceAta,
+        eata: sourceEata.toBase58(),
+        delegationRecord: delegationRecord.toBase58(),
+        currentValidator: currentValidator.toBase58(),
+        selectedValidator: selectedValidator.toBase58(),
+      },
+    ]);
   });
 
   it("uses the mint token program when initializing a transfer vault", async () => {

--- a/api/src/lib/solana.ts
+++ b/api/src/lib/solana.ts
@@ -3,6 +3,7 @@ import {
   DELEGATION_PROGRAM_ID,
   DelegationStatus,
   delegateTransferQueueIx,
+  delegationRecordPdaFromDelegatedAccount,
   deriveRentPda,
   deriveTransferQueue,
   delegateSpl,
@@ -13,6 +14,7 @@ import {
   initTransferQueueIx,
   magicFeeVaultPdaFromValidator,
   transferSpl,
+  undelegateIx,
   withdrawSpl, initVaultIx, initVaultAtaIx, delegateEphemeralAtaIx, deriveVault, deriveEphemeralAta, deriveVaultAta,
 } from "@magicblock-labs/ephemeral-rollups-sdk";
 import {
@@ -28,7 +30,7 @@ import {
 
 import type { AppEnv } from "../env";
 import { ApiError } from "./errors";
-import { BalanceRequest, BalanceResponse, DepositRequest, InitializeMintRequest, InitializeMintResponse, MintInitializationRequest, MintInitializationResponse, TransactionResponse, TransferRequest, WithdrawRequest } from "../routes/spl/spl.schemas";
+import { BalanceRequest, BalanceResponse, DepositRequest, InitializeMintRequest, InitializeMintResponse, MintInitializationRequest, MintInitializationResponse, TransactionResponse, TransferRequest, UndelegateEphemeralAtaRequest, UndelegateEphemeralAtaResponse, WithdrawRequest } from "../routes/spl/spl.schemas";
 import { SendTransactionRequest, SendTransactionResponse } from "../routes/transaction.schemas";
 import { getCachedAddressLookupTable, getConnection } from "./rpc-cache";
 
@@ -54,6 +56,15 @@ const MAINNET_USDT_MINT = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB";
 const DEFAULT_FALLBACK_VALIDATOR = new PublicKey(
   "MAS1Dt9qreoRMQ14YQuhg8UTZMMzDdKhmkZMECCzk57",
 );
+const TEE_VALIDATOR = new PublicKey(
+  "MTEWGuqxUpYZGFJQcp8tLN7x5v9BSeoFHYWQQ3n3xzo",
+);
+const DEVNET_TEE_RPC_URL = "https://devnet-tee.magicblock.app";
+const MAINNET_TEE_RPC_URL = "https://mainnet-tee.magicblock.app";
+const DELEGATION_ROUTER_RPC_URLS = {
+  mainnet: "https://router.magicblock.app/",
+  devnet: "https://devnet-router.magicblock.app/",
+} as const;
 const TRANSFER_QUEUE_RENT_LAMPORTS = LAMPORTS_PER_SOL / 50;
 const PRIVATE_TRANSFER_MAX_DELAY_MS_LIMIT = 10n * 60n * 1000n;
 const TRANSFER_QUEUE_RECENT_SIGNATURE_LIMIT = 5;
@@ -94,24 +105,52 @@ type RpcIdentityResponse = {
   };
 };
 
+type DelegationStatusRpcResponse = {
+  result?: {
+    isDelegated?: boolean;
+    fqdn?: unknown;
+  };
+  error?: {
+    message?: string;
+  };
+};
+
+type DelegationEndpointResolution = {
+  endpoint?: string;
+  error?: string;
+  isDelegated?: boolean;
+};
+
 type BackgroundTaskScheduler = {
   waitUntil: (promise: Promise<unknown>) => void;
 };
 
 type TransferFees = NonNullable<TransactionResponse["fees"]>;
+type ProjectedWritableAta = {
+  role: string;
+  owner: PublicKey;
+  mint: PublicKey;
+  ata: PublicKey;
+  eata: PublicKey;
+  delegationRecord: PublicKey;
+};
 
 function getBaseConnection(config: RpcConfig) {
   return getConnection(config.baseRpcUrl);
 }
 
-function getEphemeralConnection(config: RpcConfig, authToken?: string) {
+function getConnectionWithOptionalAuthToken(rpcUrl: string, authToken?: string) {
   if (!authToken) {
-    return getConnection(config.ephemeralRpcUrl);
+    return getConnection(rpcUrl);
   }
 
-  const url = new URL(config.ephemeralRpcUrl);
+  const url = new URL(rpcUrl);
   url.searchParams.set("token", authToken);
   return new Connection(url.toString(), "confirmed");
+}
+
+function getEphemeralConnection(config: RpcConfig, authToken?: string) {
+  return getConnectionWithOptionalAuthToken(config.ephemeralRpcUrl, authToken);
 }
 
 async function resolveMintTokenProgram(config: RpcConfig, mint: PublicKey) {
@@ -390,6 +429,215 @@ function isProcessPendingTransferQueueRefillInstruction(instruction: Transaction
     && instruction.data.readInt8(0) === 28;
 }
 
+function readDelegatedValidator(accountInfo: { owner: PublicKey; lamports: number; data: Buffer | Uint8Array } | null) {
+  if (
+    !accountInfo
+    || accountInfo.lamports === 0
+    || !accountInfo.owner.equals(DELEGATION_PROGRAM_ID)
+    || accountInfo.data.length < 40
+  ) {
+    return undefined;
+  }
+
+  return new PublicKey(Buffer.from(accountInfo.data).subarray(8, 40));
+}
+
+function normalizeRpcEndpoint(value: unknown) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return undefined;
+  }
+
+  try {
+    const url = new URL(value.trim());
+
+    if (!["http:", "https:"].includes(url.protocol)) {
+      return undefined;
+    }
+
+    if (url.pathname === "/" && !url.search && !url.hash) {
+      return url.origin;
+    }
+
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function getDelegationRouterRpcUrl(cluster: RpcConfig["cluster"]) {
+  return cluster === "mainnet" || cluster === "devnet"
+    ? DELEGATION_ROUTER_RPC_URLS[cluster]
+    : undefined;
+}
+
+async function tryResolveDelegationEndpointFromRouter(
+  config: RpcConfig,
+  delegatedAccount: PublicKey,
+): Promise<DelegationEndpointResolution> {
+  const routerRpcUrl = getDelegationRouterRpcUrl(config.cluster);
+
+  if (!routerRpcUrl) {
+    return {
+      error: `No delegation router configured for cluster=${config.cluster}`,
+    };
+  }
+
+  try {
+    const response = await fetch(routerRpcUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "getDelegationStatus",
+        params: [delegatedAccount.toBase58()],
+      }),
+    });
+
+    if (!response.ok) {
+      return {
+        error: `Delegation router returned HTTP ${response.status}`,
+      };
+    }
+
+    const payload = await response.json() as DelegationStatusRpcResponse;
+
+    if (payload.error) {
+      return {
+        error: payload.error.message ?? "Delegation router returned an error",
+      };
+    }
+
+    const endpoint = payload.result?.isDelegated
+      ? normalizeRpcEndpoint(payload.result.fqdn)
+      : undefined;
+
+    return {
+      endpoint,
+      isDelegated: payload.result?.isDelegated,
+      error: payload.result?.isDelegated && !endpoint
+        ? "Delegation router did not return a usable fqdn"
+        : undefined,
+    };
+  } catch (error) {
+    return {
+      error: getSanitizedErrorMessage(error),
+    };
+  }
+}
+
+function getHardcodedTeeRpcEndpoint(cluster: RpcConfig["cluster"], validator: PublicKey | undefined) {
+  if (!validator?.equals(TEE_VALIDATOR)) {
+    return undefined;
+  }
+
+  if (cluster === "devnet") {
+    return DEVNET_TEE_RPC_URL;
+  }
+
+  if (cluster === "mainnet") {
+    return MAINNET_TEE_RPC_URL;
+  }
+
+  return undefined;
+}
+
+async function resolveUndelegateEphemeralRpcEndpoint(
+  config: RpcConfig,
+  delegatedAccount: PublicKey,
+) {
+  const routerResolution = await tryResolveDelegationEndpointFromRouter(config, delegatedAccount);
+
+  if (routerResolution.endpoint) {
+    return routerResolution.endpoint;
+  }
+
+  const delegationRecord = delegationRecordPdaFromDelegatedAccount(delegatedAccount);
+  let delegationAccount: Awaited<ReturnType<Connection["getAccountInfo"]>>;
+  try {
+    delegationAccount = await getBaseConnection(config).getAccountInfo(delegationRecord, "confirmed");
+  } catch (error) {
+    throw new ApiError(502, "RPC_ERROR", "Failed to fetch delegation record", {
+      delegatedAccount: delegatedAccount.toBase58(),
+      delegationRecord: delegationRecord.toBase58(),
+      message: getSanitizedErrorMessage(error),
+    });
+  }
+
+  const delegatedValidator = readDelegatedValidator(delegationAccount);
+  const hardcodedEndpoint = getHardcodedTeeRpcEndpoint(config.cluster, delegatedValidator);
+
+  if (hardcodedEndpoint) {
+    return hardcodedEndpoint;
+  }
+
+  throw new ApiError(
+    400,
+    "EPHEMERAL_ENDPOINT_UNRESOLVED",
+    "Ephemeral RPC endpoint cannot be retrieved",
+    {
+      cluster: config.cluster,
+      delegatedAccount: delegatedAccount.toBase58(),
+      delegationRecord: delegationRecord.toBase58(),
+      delegatedValidator: delegatedValidator?.toBase58(),
+      routerIsDelegated: routerResolution.isDelegated,
+      routerError: routerResolution.error,
+    },
+  );
+}
+
+async function assertProjectedWritableAtaValidators(
+  config: RpcConfig,
+  accounts: ProjectedWritableAta[],
+  validator: PublicKey,
+) {
+  if (accounts.length === 0) {
+    return;
+  }
+
+  let delegationAccounts: Awaited<ReturnType<Connection["getMultipleAccountsInfo"]>>;
+  try {
+    delegationAccounts = await getBaseConnection(config).getMultipleAccountsInfo(
+      accounts.map(account => account.delegationRecord),
+      "confirmed",
+    );
+  } catch (error) {
+    throw new ApiError(502, "RPC_ERROR", "Failed to fetch delegation records", {
+      message: getSanitizedErrorMessage(error),
+    });
+  }
+
+  const mismatchedAccounts = accounts.flatMap((account, index) => {
+    const delegatedValidator = readDelegatedValidator(delegationAccounts[index]);
+
+    if (!delegatedValidator || delegatedValidator.equals(validator)) {
+      return [];
+    }
+
+    return [{
+      role: account.role,
+      owner: account.owner.toBase58(),
+      mint: account.mint.toBase58(),
+      ata: account.ata.toBase58(),
+      eata: account.eata.toBase58(),
+      delegationRecord: account.delegationRecord.toBase58(),
+      currentValidator: delegatedValidator.toBase58(),
+      selectedValidator: validator.toBase58(),
+    }];
+  });
+
+  if (mismatchedAccounts.length > 0) {
+    throw new ApiError(
+      400,
+      "EATA_VALIDATOR_MISMATCH",
+      "Projected token account is delegated to another validator",
+      { accounts: mismatchedAccounts },
+    );
+  }
+}
+
 function createRandomShuttleId() {
   return crypto.getRandomValues(new Uint32Array(1))[0] & 0x7fffffff;
 }
@@ -472,11 +720,10 @@ async function resolveRequiredValidator(config: RpcConfig, explicitValidator?: s
   return validator;
 }
 
-async function getBlockhash(config: RpcConfig, source: SendTarget, authToken?: string): Promise<BlockhashResult> {
-  const connection = source === "base"
-    ? getBaseConnection(config)
-    : getEphemeralConnection(config, authToken);
-
+async function getBlockhashFromConnection(
+  connection: Connection,
+  source: SendTarget,
+): Promise<BlockhashResult> {
   try {
     const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash("confirmed");
     return { blockhash, lastValidBlockHeight };
@@ -486,6 +733,25 @@ async function getBlockhash(config: RpcConfig, source: SendTarget, authToken?: s
       message: getSanitizedErrorMessage(error),
     });
   }
+}
+
+async function getBlockhash(config: RpcConfig, source: SendTarget, authToken?: string): Promise<BlockhashResult> {
+  const connection = source === "base"
+    ? getBaseConnection(config)
+    : getEphemeralConnection(config, authToken);
+
+  return getBlockhashFromConnection(connection, source);
+}
+
+async function getBlockhashFromRpcEndpoint(
+  rpcEndpoint: string,
+  source: SendTarget,
+  authToken?: string,
+): Promise<BlockhashResult> {
+  return getBlockhashFromConnection(
+    getConnectionWithOptionalAuthToken(rpcEndpoint, authToken),
+    source,
+  );
 }
 
 function decodeTransactionBase64(value: string) {
@@ -960,6 +1226,48 @@ export async function buildInitializeMintTransaction(
   }
 }
 
+export async function buildUndelegateEphemeralAtaTransaction(
+  env: AppEnv,
+  input: UndelegateEphemeralAtaRequest,
+  authToken?: string,
+): Promise<UndelegateEphemeralAtaResponse> {
+  try {
+    const config = resolveRpcConfig(env, input.cluster);
+    const payer = parsePublicKey(input.payer, "payer");
+    const mint = parsePublicKey(input.mint, "mint");
+    await resolveMintTokenProgram(config, mint);
+    const [ephemeralAta] = deriveEphemeralAta(payer, mint);
+    const sendRpcEndpoint = await resolveUndelegateEphemeralRpcEndpoint(config, ephemeralAta);
+    const blockhash = await getBlockhashFromRpcEndpoint(sendRpcEndpoint, "ephemeral", authToken);
+    const instructions = [
+      undelegateIx(payer, mint),
+    ];
+
+    const response = serializeTransaction(
+      "undelegateEphemeralAta",
+      "ephemeral",
+      instructions,
+      payer,
+      blockhash,
+    );
+
+    return {
+      ...response,
+      kind: "undelegateEphemeralAta",
+      version: "legacy",
+      sendTo: "ephemeral",
+      sendRpcEndpoint,
+      recentBlockhash: blockhash.blockhash,
+      lastValidBlockHeight: blockhash.lastValidBlockHeight,
+      instructionCount: instructions.length,
+      requiredSigners: response.requiredSigners,
+      transactionBase64: response.transactionBase64,
+    };
+  } catch (error) {
+    throwTransactionBuildError(error);
+  }
+}
+
 export async function buildTransferTransaction(env: AppEnv, input: TransferRequest, authToken?: string) {
   try {
     const config = resolveRpcConfig(env, input.cluster);
@@ -1056,6 +1364,23 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
       : undefined;
 
     const tokenProgram = await resolveMintTokenProgram(config, mint);
+    if (validator && isPrivateBaseToBaseTransfer(input)) {
+      const sourceAta = getAssociatedTokenAddressSync(mint, from, true, tokenProgram);
+      const [sourceEata] = deriveEphemeralAta(from, mint);
+      await assertProjectedWritableAtaValidators(
+        config,
+        [{
+          role: "source",
+          owner: from,
+          mint,
+          ata: sourceAta,
+          eata: sourceEata,
+          delegationRecord: delegationRecordPdaFromDelegatedAccount(sourceEata),
+        }],
+        validator,
+      );
+    }
+
     const gaslessFeeInstructions = sponsor
       ? [
           createTokenTransferInstruction(

--- a/api/src/lib/solana.ts
+++ b/api/src/lib/solana.ts
@@ -754,6 +754,33 @@ async function getBlockhashFromRpcEndpoint(
   );
 }
 
+function getTransactionSendRpcEndpoint(config: RpcConfig, input: SendTransactionRequest) {
+  if (input.sendRpcEndpoint !== undefined) {
+    if (input.sendTo !== "ephemeral") {
+      throw new ApiError(
+        400,
+        "INVALID_SEND_RPC_ENDPOINT",
+        "sendRpcEndpoint can only be used when sendTo is ephemeral",
+      );
+    }
+
+    const endpoint = normalizeRpcEndpoint(input.sendRpcEndpoint);
+    if (!endpoint) {
+      throw new ApiError(
+        400,
+        "INVALID_SEND_RPC_ENDPOINT",
+        "sendRpcEndpoint must be a valid http(s) URL",
+      );
+    }
+
+    return endpoint;
+  }
+
+  return input.sendTo === "base"
+    ? config.baseRpcUrl
+    : config.ephemeralRpcUrl;
+}
+
 function decodeTransactionBase64(value: string) {
   const transactionBase64 = value.trim();
 
@@ -787,12 +814,11 @@ export async function sendSignedTransaction(
   authToken?: string,
 ): Promise<SendTransactionResponse> {
   const config = resolveRpcConfig(env, input.cluster);
+  const rpcEndpoint = getTransactionSendRpcEndpoint(config, input);
   const connection = input.sendTo === "base"
     ? getBaseConnection(config)
-    : getEphemeralConnection(config, authToken);
-  const confirmationRpcEndpoint = input.sendTo === "base"
-    ? config.baseRpcUrl
-    : config.ephemeralRpcUrl;
+    : getConnectionWithOptionalAuthToken(rpcEndpoint, authToken);
+  const confirmationRpcEndpoint = rpcEndpoint;
   const confirmationRequiresAuthToken = input.sendTo === "ephemeral";
   const transaction = decodeTransactionBase64(input.transactionBase64);
   const options: SendOptions = {

--- a/api/src/routes/spl/spl.handlers.ts
+++ b/api/src/routes/spl/spl.handlers.ts
@@ -5,6 +5,7 @@ import {
   buildDepositTransaction,
   buildInitializeMintTransaction,
   buildTransferTransaction,
+  buildUndelegateEphemeralAtaTransaction,
   buildWithdrawTransaction,
   getBaseBalance,
   getMintInitializationStatus,
@@ -19,6 +20,7 @@ import {
   mintInitializationRoute,
   privateBalanceRoute,
   transferRoute,
+  undelegateEphemeralAtaRoute,
   withdrawRoute,
 } from "./spl.routes";
 import {
@@ -29,6 +31,7 @@ import {
   LoginRequest,
   MintInitializationRequest,
   TransferRequest,
+  UndelegateEphemeralAtaRequest,
   WithdrawRequest,
 } from "./spl.schemas";
 import { getChallenge, login, parseAuthToken } from "../../lib/auth";
@@ -72,6 +75,14 @@ export const transferHandler: RouteHandler<typeof transferRoute, RouteEnv> = asy
   const body = c.req.valid("json") as TransferRequest;
   const authToken = parseAuthToken(c.req.header());
   const response = await buildTransferTransaction(env, body, authToken);
+  return c.json(response, 200);
+};
+
+export const undelegateEphemeralAtaHandler: RouteHandler<typeof undelegateEphemeralAtaRoute, RouteEnv> = async (c) => {
+  const env = getEnv(c.env);
+  const body = c.req.valid("json") as UndelegateEphemeralAtaRequest;
+  const authToken = parseAuthToken(c.req.header());
+  const response = await buildUndelegateEphemeralAtaTransaction(env, body, authToken);
   return c.json(response, 200);
 };
 

--- a/api/src/routes/spl/spl.index.ts
+++ b/api/src/routes/spl/spl.index.ts
@@ -11,6 +11,7 @@ import {
   mintInitializationHandler,
   privateBalanceHandler,
   transferHandler,
+  undelegateEphemeralAtaHandler,
   withdrawHandler,
 } from "./spl.handlers";
 import {
@@ -22,6 +23,7 @@ import {
   mintInitializationRoute,
   privateBalanceRoute,
   transferRoute,
+  undelegateEphemeralAtaRoute,
   withdrawRoute,
 } from "./spl.routes";
 
@@ -33,6 +35,7 @@ app.openapi(depositRoute, depositHandler);
 app.openapi(withdrawRoute, withdrawHandler);
 app.openapi(initializeMintRoute, initializeMintHandler);
 app.openapi(transferRoute, transferHandler);
+app.openapi(undelegateEphemeralAtaRoute, undelegateEphemeralAtaHandler);
 app.openapi(balanceRoute, balanceHandler);
 app.openapi(privateBalanceRoute, privateBalanceHandler);
 app.openapi(mintInitializationRoute, mintInitializationHandler);

--- a/api/src/routes/spl/spl.routes.ts
+++ b/api/src/routes/spl/spl.routes.ts
@@ -28,6 +28,9 @@ import {
   TransactionResponse,
   transactionResponseSchema,
   transferRequestSchema,
+  undelegateEphemeralAtaRequestSchema,
+  UndelegateEphemeralAtaResponse,
+  undelegateEphemeralAtaResponseSchema,
   withdrawRequestSchema,
 } from "./spl.schemas";
 import { optionalAuthTokenSchema, requiredAuthTokenSchema } from "../../schema";
@@ -87,6 +90,17 @@ const initializeMintResponseExample: InitializeMintResponse = {
   validator: "MAS1Dt9qreoRMQ14YQuhg8UTZMMzDdKhmkZMECCzk57",
   transferQueue: "BuBHLbaPmYmgvMiZ8uZb96RjBtmWzJY52u7Di5urNf6M",
   rentPda: "Bt9oNR5cCtnfuMmXgWELd6q5i974PdEMQDUE55nBC57L",
+};
+const undelegateEphemeralAtaResponseExample: UndelegateEphemeralAtaResponse = {
+  kind: "undelegateEphemeralAta" as const,
+  version: "legacy" as const,
+  transactionBase64: "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAIDKmcfsS5XfSOLaLlaBHJry50iH2Ufk2TMz4STC2fHzIcFKkerg3q2DD3Yn8TISmGeKoxSLz+BiP7iQ4pYqXYXsgu8D8C7R8ovdMQRLpSrE8+jxjTl3BfqywPNGiPNfnh8AazZ0ixOauLjpxaRgDCv6MChaoMAZAJg8BnPbZl31jECAgEBBAECAwQCAQEEAgIDBA==",
+  sendTo: "ephemeral" as const,
+  sendRpcEndpoint: "https://devnet-tee.magicblock.app",
+  recentBlockhash: "7YH7nE6qj8vH3L9pR5uM2cD1xK4sT8wQ6bN3fJ2mP9z",
+  lastValidBlockHeight: 284512451,
+  instructionCount: 1,
+  requiredSigners: ["3rXKwQ1kpjBd5tdcco32qsvqUh1BnZjcYnS5kYrP7AYE"],
 };
 const challengeResponseExample: ChallengeResponse = {
   challenge: "1234567890",
@@ -151,6 +165,22 @@ export const transferRoute = createRoute({
   },
   responses: {
     200: jsonContent(transactionResponseSchema, "Unsigned serialized transaction"),
+    400: jsonContent(errorResponseSchema, "Build error"),
+    422: jsonContent(validationErrorResponseSchema, "Validation error"),
+  },
+});
+
+export const undelegateEphemeralAtaRoute = createRoute({
+  path: "/v1/spl/undelegate-ephemeral-ata",
+  method: "post",
+  tags,
+  description: "Build an unsigned ephemeral-rollup transaction that undelegates a wallet eATA for a mint.",
+  request: {
+    body: jsonContentRequired(undelegateEphemeralAtaRequestSchema, "Undelegate eATA request"),
+    headers: optionalAuthTokenSchema,
+  },
+  responses: {
+    200: jsonContent(undelegateEphemeralAtaResponseSchema, "Unsigned serialized transaction", undelegateEphemeralAtaResponseExample),
     400: jsonContent(errorResponseSchema, "Build error"),
     422: jsonContent(validationErrorResponseSchema, "Validation error"),
   },

--- a/api/src/routes/spl/spl.schemas.ts
+++ b/api/src/routes/spl/spl.schemas.ts
@@ -22,7 +22,7 @@ export const transferFeesSchema = z.object({
 export type TransferFees = z.infer<typeof transferFeesSchema>;
 
 export const transactionResponseSchema = z.object({
-  kind: z.enum(["deposit", "withdraw", "transfer", "initializeMint"]),
+  kind: z.enum(["deposit", "withdraw", "transfer", "initializeMint", "undelegateEphemeralAta"]),
   version: z.enum(["legacy", "v0"]),
   transactionBase64: z.string(),
   sendTo: balanceLocationSchema,
@@ -98,6 +98,31 @@ export const initializeMintResponseSchema = transactionResponseSchema.extend({
   rentPda: publicKeySchema,
 }).openapi("InitializeMintResponse");
 export type InitializeMintResponse = z.infer<typeof initializeMintResponseSchema>;
+
+export const undelegateEphemeralAtaRequestSchema = z.object({
+  payer: publicKeySchema.openapi({
+    example: DEPOSIT_EXAMPLE_OWNER,
+  }),
+  mint: publicKeySchema.openapi({
+    example: DEFAULT_DEPOSIT_MINT,
+    description: "SPL mint for the eATA to undelegate.",
+  }),
+  cluster: clusterSchema.optional(),
+}).openapi("UndelegateEphemeralAtaRequest", {
+  example: {
+    payer: DEPOSIT_EXAMPLE_OWNER,
+    mint: DEFAULT_DEPOSIT_MINT,
+  },
+});
+export type UndelegateEphemeralAtaRequest = z.infer<typeof undelegateEphemeralAtaRequestSchema>;
+
+export const undelegateEphemeralAtaResponseSchema = transactionResponseSchema.extend({
+  kind: z.literal("undelegateEphemeralAta"),
+  sendRpcEndpoint: z.string().url().openapi({
+    description: "Exact ephemeral RPC endpoint where the signed undelegation transaction should be submitted.",
+  }),
+}).openapi("UndelegateEphemeralAtaResponse");
+export type UndelegateEphemeralAtaResponse = z.infer<typeof undelegateEphemeralAtaResponseSchema>;
 
 export const depositRequestSchema = z.object({
   owner: publicKeySchema.openapi({

--- a/api/src/routes/transaction.schemas.ts
+++ b/api/src/routes/transaction.schemas.ts
@@ -10,6 +10,9 @@ export const sendTransactionRequestSchema = z.object({
   sendTo: balanceLocationSchema.openapi({
     description: "RPC target for submission. Use the `sendTo` value returned by transaction-builder endpoints.",
   }),
+  sendRpcEndpoint: z.string().url().optional().openapi({
+    description: "Optional exact ephemeral RPC endpoint returned by transaction-builder endpoints. Only valid when `sendTo` is `ephemeral`.",
+  }),
   cluster: clusterSchema.optional(),
   confirm: z.boolean().optional().openapi({
     example: false,

--- a/e-token-api/src/error.rs
+++ b/e-token-api/src/error.rs
@@ -15,6 +15,8 @@ pub enum EphemeralSplError {
     VaultTokenAccountMismatch = 5,
     // too many accounts were passed to the instruction
     TooManyAccountKeys = 6,
+    // ephemeral ATA is already delegated to another validator
+    EphemeralAtaValidatorMismatch = 7,
     // internal invariant / unreachable conversion failure
     InfallibleError = 255,
 }
@@ -36,6 +38,7 @@ impl ToStr for EphemeralSplError {
             MintMismatch => "EphemeralSplError::MintMismatch",
             VaultTokenAccountMismatch => "EphemeralSplError::VaultTokenAccountMismatch",
             TooManyAccountKeys => "EphemeralSplError::TooManyAccountKeys",
+            EphemeralAtaValidatorMismatch => "EphemeralSplError::EphemeralAtaValidatorMismatch",
             InfallibleError => "EphemeralSplError::InfallibleError",
         }
     }
@@ -51,6 +54,7 @@ impl core::convert::TryFrom<u32> for EphemeralSplError {
             4 => Ok(EphemeralSplError::MintMismatch),
             5 => Ok(EphemeralSplError::VaultTokenAccountMismatch),
             6 => Ok(EphemeralSplError::TooManyAccountKeys),
+            7 => Ok(EphemeralSplError::EphemeralAtaValidatorMismatch),
             255 => Ok(EphemeralSplError::InfallibleError),
             _ => Err(ProgramError::InvalidArgument),
         }

--- a/e-token/src/processor/delegate_ephemeral_ata.rs
+++ b/e-token/src/processor/delegate_ephemeral_ata.rs
@@ -1,12 +1,47 @@
+use alloc::string::ToString;
 use alloc::vec;
 use alloc::vec::Vec;
 use data_layout::variable_offset_layout;
+use dlp_api::{requires::require_initialized_delegation_record, state::DelegationRecord};
 use ephemeral_rollups_pinocchio::instruction::DelegateAccountCpiBuilder;
 use ephemeral_rollups_pinocchio::types::DelegateConfig;
-use ephemeral_spl_api::debug_log;
 use ephemeral_spl_api::require_n_accounts;
 use ephemeral_spl_api::state::{ephemeral_ata::EphemeralAta, load_initialized};
-use pinocchio::{AccountView, Address, ProgramResult};
+use ephemeral_spl_api::{debug_log, error::EphemeralSplError};
+use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
+
+fn validate_existing_delegation(
+    ephemeral_ata_info: &AccountView,
+    delegation_record: &AccountView,
+    requested_validator: Option<&[u8; 32]>,
+) -> ProgramResult {
+    let Some(requested_validator) = requested_validator else {
+        return Ok(());
+    };
+
+    require_initialized_delegation_record(ephemeral_ata_info, delegation_record, true)?;
+
+    let delegation_record_data = delegation_record.try_borrow()?;
+    let delegation_record =
+        DelegationRecord::try_from_bytes_with_discriminator(&delegation_record_data)
+            .map_err(|_| ProgramError::InvalidAccountData)?;
+    let current_validator = Address::new_from_array(delegation_record.authority.to_bytes());
+    let requested_validator = Address::new_from_array(*requested_validator);
+
+    if current_validator == requested_validator {
+        return Ok(());
+    }
+
+    let current = current_validator.to_string();
+    let requested = requested_validator.to_string();
+    pinocchio_log::log!(
+        "Ephemeral ATA is already delegated to validator {}, requested validator {}",
+        current.as_str(),
+        requested.as_str(),
+    );
+
+    Err(EphemeralSplError::EphemeralAtaValidatorMismatch.into())
+}
 
 ///
 /// Executes on:
@@ -43,6 +78,7 @@ pub fn process_delegate_ephemeral_ata(
 
     let delegation_program = ephemeral_spl_api::program::DELEGATION_PROGRAM_ID;
     if ephemeral_ata_info.owned_by(&delegation_program) {
+        validate_existing_delegation(ephemeral_ata_info, delegation_record, args.validator())?;
         return Ok(());
     }
 

--- a/e-token/tests/delegate_ephemeral_ata.rs
+++ b/e-token/tests/delegate_ephemeral_ata.rs
@@ -2,14 +2,16 @@ use ephemeral_rollups_pinocchio::pda::{
     delegate_buffer_pda_from_delegated_account_and_owner_program,
     delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
 };
+use ephemeral_spl_api::error::EphemeralSplError;
 use ephemeral_spl_api::state::RawType;
 use ephemeral_spl_api::ID as PROGRAM;
 use ephemeral_spl_api::{instruction, state::ephemeral_ata::EphemeralAta};
 use ephemeral_token_program::DelegateArgs;
 use solana_instruction::{AccountMeta, Instruction};
+use solana_program::instruction::InstructionError;
 use solana_program_test::tokio;
 use solana_signer::Signer;
-use solana_transaction::Transaction;
+use solana_transaction::{Transaction, TransactionError};
 
 mod common;
 mod utils;
@@ -24,6 +26,8 @@ async fn delegate_ephemeral_ata_succeeds() {
 
     let mint_kp = utils::test_keypair("delegate_ephemeral_ata_succeeds::mint");
     let mint = mint_kp.pubkey();
+    let validator = utils::test_pubkey("delegate_ephemeral_ata_succeeds::validator");
+    let other_validator = utils::test_pubkey("delegate_ephemeral_ata_succeeds::other_validator");
 
     // Derive the PDAs for our program and setup token accounts
     let pdas = utils::derive_pdas(PROGRAM, user, mint);
@@ -104,8 +108,13 @@ async fn delegate_ephemeral_ata_succeeds() {
             AccountMeta::new_readonly(ephemeral_rollups_pinocchio::ID, false), // delegation program
             AccountMeta::new_readonly(solana_system_interface::program::ID, false), // system program
         ],
-        data: instruction::ESplInstruction::DelegateEphemeralAta
-            .with_data(&DelegateArgs { validator: None }.encode().unwrap()),
+        data: instruction::ESplInstruction::DelegateEphemeralAta.with_data(
+            &DelegateArgs {
+                validator: Some(validator.to_bytes()),
+            }
+            .encode()
+            .unwrap(),
+        ),
     };
 
     let tx = Transaction::new_signed_with_payer(
@@ -122,7 +131,7 @@ async fn delegate_ephemeral_ata_succeeds() {
     let redelegate_blockhash = context.banks_client.get_latest_blockhash().await.unwrap();
 
     let tx_redelegate = Transaction::new_signed_with_payer(
-        &[ix_delegate],
+        &[ix_delegate.clone()],
         Some(&payer),
         &[&payer_kp],
         redelegate_blockhash,
@@ -131,10 +140,50 @@ async fn delegate_ephemeral_ata_succeeds() {
     common::metrics::process_transaction_record_cu(
         &context.banks_client,
         tx_redelegate,
-        "del_eata::redelegate",
+        "del_eata::redelegate_same_validator",
     )
     .await
     .unwrap();
+
+    let ix_redelegate_other_validator = Instruction {
+        data: instruction::ESplInstruction::DelegateEphemeralAta.with_data(
+            &DelegateArgs {
+                validator: Some(other_validator.to_bytes()),
+            }
+            .encode()
+            .unwrap(),
+        ),
+        ..ix_delegate
+    };
+
+    let redelegate_other_blockhash = context.banks_client.get_latest_blockhash().await.unwrap();
+
+    let tx_redelegate_other = Transaction::new_signed_with_payer(
+        &[ix_redelegate_other_validator],
+        Some(&payer),
+        &[&payer_kp],
+        redelegate_other_blockhash,
+    );
+
+    let redelegate_other_result = common::metrics::process_transaction_with_metadata_recorded(
+        &context.banks_client,
+        tx_redelegate_other,
+        "del_eata::redelegate_other_validator",
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        redelegate_other_result.result.unwrap_err(),
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(EphemeralSplError::EphemeralAtaValidatorMismatch as u32),
+        )
+    );
+    let logs = redelegate_other_result
+        .metadata
+        .expect("failed transaction should include metadata")
+        .log_messages;
+    assert!(logs.iter().any(|log| log.contains(&validator.to_string())));
 
     // Assert ATA is owned by delegation program after delegation
     let ata_account = context


### PR DESCRIPTION
## Summary
- add an undelegate eATA API endpoint that returns the exact ephemeral RPC endpoint to submit against
- resolve delegated endpoints through the router first, then the known TEE validator fallback
- reject validator-mismatched delegated eATA flows instead of silently treating them as usable