### PR TITLE
fix: fix InvalidWritableAccount in group-receipt handling

### DIFF
--- a/e-token/src/processor/deposit_and_queue_transfer.rs
+++ b/e-token/src/processor/deposit_and_queue_transfer.rs
@@ -252,6 +252,18 @@ pub fn process_deposit_and_queue_transfer(
         args.split(),
     )?;
 
+    debug_log!({
+        use alloc::string::ToString;
+
+        pinocchio_log::log!(
+            256,
+            "DepositAndQueueTransfer group_receipt address: {} data_len: {} owner: {}",
+            group_receipt_info.address().to_string().as_str(),
+            group_receipt_info.data_len(),
+            unsafe { group_receipt_info.owner() }.to_string().as_str()
+        );
+    });
+
     Ok(())
 }
 

--- a/e-token/src/processor/execute_transfer_callback.rs
+++ b/e-token/src/processor/execute_transfer_callback.rs
@@ -38,17 +38,17 @@ pub fn process_execute_transfer_callback(
     instruction_data: &[u8],
 ) -> ProgramResult {
     let [
-        callback_signer,
+        callback_signer, // force multi-line
         group_receipt,
         queue_info,
-        _, // vault
+        _vault,
         mint,
-        _, // vault token account
+        _vault_token_account,
         source,
-        _, // source token account
-        _, // token program
+        _source_token_account,
+        _token_program,
         magic_vault,
-        magic_program
+        magic_program,
     ] = require_n_accounts!(accounts, 11);
 
     // Verify validator & queue info
@@ -122,6 +122,17 @@ fn handle_group_receipt(
     args: &TransferCallbackArgsView<'_>,
     response: &MagicResponseView,
 ) -> ProgramResult {
+    debug_log!({
+        use alloc::string::ToString;
+        pinocchio_log::log!(
+            256,
+            "ExecuteTransferCallback group_receipt address: {} data_len: {} owner: {}",
+            group_receipt_info.address().to_string().as_str(),
+            group_receipt_info.data_len(),
+            unsafe { group_receipt_info.owner() }.to_string().as_str()
+        );
+    });
+
     if !group_receipt_info.owned_by(&crate::ID) {
         debug_log!("Group receipt expected to be initialized");
         return Err(ProgramError::InvalidAccountOwner);

--- a/e-token/src/processor/transfer_queue_tick.rs
+++ b/e-token/src/processor/transfer_queue_tick.rs
@@ -443,7 +443,7 @@ fn create_action_callback_accounts(
         },
         ShortAccountMeta {
             pubkey: queued_transfer.source,
-            is_writable: true,
+            is_writable: false,
         },
         ShortAccountMeta {
             pubkey: source_token_account,


### PR DESCRIPTION
https://github.com/magicblock-labs/ephemeral-spl-token/pull/102 accidentally merged into wrong branch and lost.

_So this PR does the same thing again._

<img width="2260" height="748" alt="image" src="https://github.com/user-attachments/assets/e241d508-3dae-4dc0-a11a-2b846d7e9aa8" />

is fixed by https://github.com/magicblock-labs/magicblock-validator/pull/1301

and this PR fixes `InvalidWritableAccount` issue.