### PR TITLE
Add private clusters and updated LUTs

### DIFF
--- a/api/.dev.vars
+++ b/api/.dev.vars
@@ -1,9 +1,13 @@
 CLUSTER=custom
-BASE_RPC_URL=https://rpc.magicblock.app/devnet
-EPHEMERAL_RPC_URL=https://devnet-tee.magicblock.app
+BASE_RPC_URL=https://rpc.magicblock.app/mainnet
+EPHEMERAL_RPC_URL=https://as.magicblock.app
+EPHEMERAL_TEE_RPC_URL=https://mainnet-tee.magicblock.app
 GASLESS_SPONSOR_SECRET_KEY=[114,224,209,25,48,159,240,82,196,182,158,173,208,186,82,245,141,146,106,250,224,208,67,165,134,2,179,26,0,22,235,115,228,230,1,190,192,92,140,220,185,176,151,196,217,59,205,155,237,114,219,161,110,119,164,99,176,28,5,5,155,177,91,49]
 BASE_DEVNET_RPC_URL=https://rpc.magicblock.app/devnet
-EPHEMERAL_DEVNET_RPC_URL=https://devnet-tee.magicblock.app
+EPHEMERAL_DEVNET_RPC_URL=https://devnet.magicblock.app
+EPHEMERAL_DEVNET_TEE_RPC_URL=https://devnet-tee.magicblock.app
+PRIVATE_BASE_TO_BASE_TRANSFER_MAINNET_LOOKUP_TABLE=54M1BrqVSg1UGTmhH44gQPsPVyuMpmcVBkaY2wYNSVZB
+PRIVATE_BASE_TO_BASE_TRANSFER_DEVNET_LOOKUP_TABLE=E26JGdRsdKkGe6oRU4Un24agZjBF2Bg9z1ctfZByETRo
 CORS_ORIGIN=*
 # Optional: if omitted, the API resolves the validator from the ephemeral RPC via getIdentity.
 VALIDATOR_PUBKEY=

--- a/api/.dev.vars.example
+++ b/api/.dev.vars.example
@@ -2,13 +2,15 @@ BASE_RPC_URL=https://rpc.magicblock.app/mainnet
 EPHEMERAL_RPC_URL=https://as.magicblock.app
 BASE_DEVNET_RPC_URL=https://rpc.magicblock.app/devnet
 EPHEMERAL_DEVNET_RPC_URL=https://devnet-tee.magicblock.app
+EPHEMERAL_TEE_RPC_URL=https://mainnet-tee.magicblock.app
+EPHEMERAL_DEVNET_TEE_RPC_URL=https://devnet-tee.magicblock.app
 # Optional: RPC used only by the API to submit transfer queue crank transactions.
 # TRANSFER_QUEUE_CRANK_RPC_URL=
 # TRANSFER_QUEUE_DEVNET_CRANK_RPC_URL=
 # METIS_SWAP_API_URL=https://<endpoint>.rpcpool.com/<private_token>/metis
 # Optional: override the built-in private base -> base transfer LUT addresses.
-# PRIVATE_BASE_TO_BASE_TRANSFER_MAINNET_LOOKUP_TABLE=
-# PRIVATE_BASE_TO_BASE_TRANSFER_DEVNET_LOOKUP_TABLE=
+PRIVATE_BASE_TO_BASE_TRANSFER_MAINNET_LOOKUP_TABLE=54M1BrqVSg1UGTmhH44gQPsPVyuMpmcVBkaY2wYNSVZB
+PRIVATE_BASE_TO_BASE_TRANSFER_DEVNET_LOOKUP_TABLE=E26JGdRsdKkGe6oRU4Un24agZjBF2Bg9z1ctfZByETRo
 # Optional: JSON-encoded sponsor secret key array for gasless transfers.
 # GASLESS_SPONSOR_SECRET_KEY=
 CORS_ORIGIN=*

--- a/api/README.md
+++ b/api/README.md
@@ -48,6 +48,8 @@ Important behavior:
 - every SPL endpoint accepts an optional `cluster` parameter
 - `cluster=mainnet` uses `BASE_RPC_URL` and `EPHEMERAL_RPC_URL`
 - `cluster=devnet` uses `BASE_DEVNET_RPC_URL` and `EPHEMERAL_DEVNET_RPC_URL`
+- `cluster=mainnet-private` uses `BASE_RPC_URL` and `EPHEMERAL_TEE_RPC_URL`
+- `cluster=devnet-private` uses `BASE_DEVNET_RPC_URL` and `EPHEMERAL_DEVNET_TEE_RPC_URL`
 - any other valid `cluster` value is treated as a custom RPC URL and used only for the base RPC, while the configured ephemeral RPC is kept
 - the API fetches the recent blockhash itself
 - if `fromBalance` is `"base"`, the blockhash is fetched from the base RPC
@@ -93,6 +95,8 @@ Variables:
 - `EPHEMERAL_RPC_URL`: mainnet ephemeral RPC used when `cluster` is omitted or set to `mainnet`
 - `BASE_DEVNET_RPC_URL`: devnet base Solana RPC used when `cluster=devnet`
 - `EPHEMERAL_DEVNET_RPC_URL`: devnet ephemeral RPC used when `cluster=devnet`
+- `EPHEMERAL_TEE_RPC_URL`: mainnet TEE ephemeral RPC used when `cluster=mainnet-private`
+- `EPHEMERAL_DEVNET_TEE_RPC_URL`: devnet TEE ephemeral RPC used when `cluster=devnet-private`
 - `TRANSFER_QUEUE_CRANK_RPC_URL`: optional RPC used only to submit background transfer queue crank transactions for mainnet
 - `TRANSFER_QUEUE_DEVNET_CRANK_RPC_URL`: optional RPC used only to submit background transfer queue crank transactions for devnet
 - `METIS_SWAP_API_URL`: optional Triton Metis Swap API base URL, including your private token and the `/metis` suffix
@@ -108,11 +112,13 @@ BASE_RPC_URL=https://rpc.magicblock.app/mainnet
 EPHEMERAL_RPC_URL=https://mainnet.magicblock.app
 BASE_DEVNET_RPC_URL=https://rpc.magicblock.app/devnet
 EPHEMERAL_DEVNET_RPC_URL=https://devnet-tee.magicblock.app
+EPHEMERAL_TEE_RPC_URL=https://mainnet-tee.magicblock.app
+EPHEMERAL_DEVNET_TEE_RPC_URL=https://devnet-tee.magicblock.app
 # TRANSFER_QUEUE_CRANK_RPC_URL=
 # TRANSFER_QUEUE_DEVNET_CRANK_RPC_URL=
 METIS_SWAP_API_URL=https://<endpoint>.rpcpool.com/<private_token>/metis
-# PRIVATE_BASE_TO_BASE_TRANSFER_MAINNET_LOOKUP_TABLE=
-# PRIVATE_BASE_TO_BASE_TRANSFER_DEVNET_LOOKUP_TABLE=
+PRIVATE_BASE_TO_BASE_TRANSFER_MAINNET_LOOKUP_TABLE=54M1BrqVSg1UGTmhH44gQPsPVyuMpmcVBkaY2wYNSVZB
+PRIVATE_BASE_TO_BASE_TRANSFER_DEVNET_LOOKUP_TABLE=E26JGdRsdKkGe6oRU4Un24agZjBF2Bg9z1ctfZByETRo
 # GASLESS_SPONSOR_SECRET_KEY=
 CORS_ORIGIN=*
 ```
@@ -131,7 +137,7 @@ Create local env:
 cp .dev.vars.example .dev.vars
 ```
 
-If you see `CONFIG_ERROR`, check that `.dev.vars` exists in this directory and contains `BASE_RPC_URL` and `EPHEMERAL_RPC_URL`. If you use `cluster=devnet`, also set `BASE_DEVNET_RPC_URL` and `EPHEMERAL_DEVNET_RPC_URL`.
+If you see `CONFIG_ERROR`, check that `.dev.vars` exists in this directory and contains `BASE_RPC_URL` and `EPHEMERAL_RPC_URL`. If you use `cluster=devnet`, also set `BASE_DEVNET_RPC_URL` and `EPHEMERAL_DEVNET_RPC_URL`. If you use `cluster=mainnet-private` or `cluster=devnet-private`, also set `EPHEMERAL_TEE_RPC_URL` or `EPHEMERAL_DEVNET_TEE_RPC_URL`.
 
 Start the worker locally:
 
@@ -169,7 +175,7 @@ curl http://127.0.0.1:8787/reference
 - `yarn typecheck`: TypeScript check
 - `yarn test`: run Vitest suite
 - `yarn deploy`: deploy with Wrangler, uploading Worker secrets from `.prod.vars`
-- `yarn create:private-transfer-lut -- [options]`: create a reusable address lookup table for private `base -> base` transfers covering SOL and USDC
+- `yarn create:private-transfer-lut -- [options]`: create a reusable address lookup table for private `base -> base` transfers covering SOL, USDC, and USDT
 
 ## Private Transfer LUT Script
 
@@ -179,11 +185,12 @@ Defaults:
 
 - loads RPC URLs from `.dev.vars`
 - targets `mainnet` unless `--cluster devnet` is passed
-- resolves `validator` from the selected ephemeral RPC unless `--validator` is provided
-- includes SOL and USDC mint-specific accounts plus the shared program/global accounts
+- resolves validators from both the regular and TEE ephemeral RPCs for the selected base cluster unless `--validator` is provided
+- accepts multiple `--validator` values, either repeated or comma-separated
+- includes SOL, USDC, and USDT mint-specific accounts for every resolved validator, including queue ATA/eATA and queue permission/eATA permission PDAs, plus the shared program/global accounts
 - leaves the LUT mutable by default; pass `--freeze` to freeze it after extending
 
-After the script succeeds, copy the `lookupTable` value from its JSON output into `PRIVATE_BASE_TO_BASE_TRANSFER_LOOKUP_TABLES` in `src/lib/solana.ts`, or set the matching `PRIVATE_BASE_TO_BASE_TRANSFER_<CLUSTER>_LOOKUP_TABLE` worker env var before redeploying. Until one of those is updated, the API will not use the new LUT.
+After the script succeeds, copy the `lookupTable` value from its JSON output into `PRIVATE_BASE_TO_BASE_TRANSFER_LOOKUP_TABLES` in `src/lib/solana.ts`, or set the matching `PRIVATE_BASE_TO_BASE_TRANSFER_MAINNET_LOOKUP_TABLE` or `PRIVATE_BASE_TO_BASE_TRANSFER_DEVNET_LOOKUP_TABLE` worker env var before redeploying. Until one of those is updated, the API will not use the new LUT.
 
 Examples:
 
@@ -200,7 +207,8 @@ yarn create:private-transfer-lut -- \
   --cluster mainnet \
   --payer ~/.config/solana/id.json \
   --authority ~/.config/solana/lut-authority.json \
-  --validator <VALIDATOR_PUBKEY>
+  --validator <VALIDATOR_PUBKEY> \
+  --validator <TEE_VALIDATOR_PUBKEY>
 ```
 
 ## API Documentation
@@ -465,6 +473,8 @@ http://127.0.0.1:6274
 - `cluster` is optional:
   - omit it or use `mainnet` to use `BASE_RPC_URL` and `EPHEMERAL_RPC_URL`
   - use `devnet` to use `BASE_DEVNET_RPC_URL` and `EPHEMERAL_DEVNET_RPC_URL`
+  - use `mainnet-private` to use `BASE_RPC_URL` and `EPHEMERAL_TEE_RPC_URL`
+  - use `devnet-private` to use `BASE_DEVNET_RPC_URL` and `EPHEMERAL_DEVNET_TEE_RPC_URL`
   - use any other valid http(s) URL to override only the base RPC and keep the configured ephemeral RPC
 - amount encoding depends on the route:
   - deposit, withdraw, and transfer: integer JSON values with minimum `1`, for example `1` or `1000000`

--- a/api/package.json
+++ b/api/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@hono/zod-openapi": "^1.0.2",
-    "@magicblock-labs/ephemeral-rollups-sdk": "0.15.0",
+    "@magicblock-labs/ephemeral-rollups-sdk": "0.15.3",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@scalar/hono-api-reference": "^0.9.13",
     "@solana/web3.js": "^1.98.0",

--- a/api/scripts/create-private-transfer-lut.js
+++ b/api/scripts/create-private-transfer-lut.js
@@ -19,10 +19,13 @@ import {
   delegationMetadataPdaFromDelegatedAccount,
   delegationRecordPdaFromDelegatedAccount,
   deriveEphemeralAta,
+  deriveQueueEphemeralAta,
+  deriveQueueVaultAta,
   deriveRentPda,
   deriveTransferQueue,
   deriveVault,
   deriveVaultAta,
+  permissionPdaFromAccount,
 } from "@magicblock-labs/ephemeral-rollups-sdk";
 
 const TOKEN_PROGRAM_ID = new PublicKey(
@@ -46,11 +49,19 @@ const MAINNET_USDC_MINT = new PublicKey(
 const DEVNET_USDC_MINT = new PublicKey(
   "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
 );
+const MAINNET_USDT_MINT = new PublicKey(
+  "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+);
+const DEVNET_USDT_MINT = new PublicKey(
+  "BQnB36y4tTb9K1fTXkU71Q8WQa4HSNNqYw4T3agViD1y",
+);
 const QUEUE_REFILL_STATE_SEED = Buffer.from("queue-refill");
 const LAMPORTS_PDA_SEED = Buffer.from("lamports");
 const DEFAULT_ENV_FILE = ".dev.vars";
 const DEFAULT_KEYPAIR_PATH = resolve(homedir(), ".config/solana/id.json");
 const MAX_EXTEND_ADDRESSES = 20;
+const MAX_LOOKUP_TABLE_ADDRESSES = 256;
+const CLUSTERS = ["mainnet", "devnet", "mainnet-private", "devnet-private"];
 
 function usage() {
   return [
@@ -58,13 +69,15 @@ function usage() {
     "  yarn create:private-transfer-lut -- [options]",
     "",
     "Options:",
-    "  --cluster <mainnet|devnet>   Cluster to target. Default: mainnet",
+    "  --cluster <mainnet|devnet>   Base cluster to target. Default: mainnet",
     `  --env-file <path>            Env file to load when process env is unset. Default: ${DEFAULT_ENV_FILE}`,
     `  --payer <path>               Payer keypair JSON path. Default: ${DEFAULT_KEYPAIR_PATH}`,
     "  --authority <path>           LUT authority keypair JSON path. Default: payer",
-    "  --validator <pubkey>         Validator pubkey. Defaults to getIdentity on the selected ephemeral RPC",
+    "  --validator <pubkey[,pubkey]>",
+    "                               Validator pubkey(s). May be repeated. Defaults to getIdentity on base and TEE ephemeral RPCs",
     "  --base-rpc-url <url>         Override the selected base RPC URL",
-    "  --ephemeral-rpc-url <url>    Override the selected ephemeral RPC URL",
+    "  --ephemeral-rpc-url <url[,url]>",
+    "                               Override ephemeral RPC URL(s) used for validator resolution. May be repeated",
     "  --freeze                     Freeze the LUT after extending it",
     "  --help                       Show this help",
   ].join("\n");
@@ -76,9 +89,9 @@ function parseArgs(argv) {
     envFile: DEFAULT_ENV_FILE,
     payerPath: DEFAULT_KEYPAIR_PATH,
     authorityPath: undefined,
-    validator: undefined,
+    validators: [],
     baseRpcUrl: undefined,
-    ephemeralRpcUrl: undefined,
+    ephemeralRpcUrls: [],
     freeze: false,
   };
 
@@ -119,13 +132,13 @@ function parseArgs(argv) {
         options.authorityPath = nextValue;
         break;
       case "--validator":
-        options.validator = nextValue;
+        options.validators.push(...parseList(nextValue, arg));
         break;
       case "--base-rpc-url":
         options.baseRpcUrl = nextValue;
         break;
       case "--ephemeral-rpc-url":
-        options.ephemeralRpcUrl = nextValue;
+        options.ephemeralRpcUrls.push(...parseList(nextValue, arg));
         break;
       default:
         throw new Error(`Unknown argument: ${arg}`);
@@ -134,8 +147,10 @@ function parseArgs(argv) {
     index += 2;
   }
 
-  if (!["mainnet", "devnet"].includes(options.cluster)) {
-    throw new Error("cluster must be either \"mainnet\" or \"devnet\"");
+  if (!CLUSTERS.includes(options.cluster)) {
+    throw new Error(
+      "cluster must be \"mainnet\", \"devnet\", \"mainnet-private\", or \"devnet-private\"",
+    );
   }
 
   return options;
@@ -150,6 +165,19 @@ function stripWrappingQuotes(value) {
   }
 
   return value;
+}
+
+function parseList(value, arg) {
+  const values = value
+    .split(",")
+    .map(part => part.trim())
+    .filter(Boolean);
+
+  if (values.length === 0) {
+    throw new Error(`Missing value for ${arg}`);
+  }
+
+  return values;
 }
 
 function parseEnvFile(filePath) {
@@ -192,19 +220,74 @@ function readRequiredEnv(env, key) {
   return value;
 }
 
-function resolveRpcUrls(options, env) {
-  if (options.cluster === "devnet") {
-    return {
-      baseRpcUrl: options.baseRpcUrl ?? readRequiredEnv(env, "BASE_DEVNET_RPC_URL"),
-      ephemeralRpcUrl:
-        options.ephemeralRpcUrl ?? readRequiredEnv(env, "EPHEMERAL_DEVNET_RPC_URL"),
-    };
+function getBaseCluster(cluster) {
+  return cluster === "devnet" || cluster === "devnet-private" ? "devnet" : "mainnet";
+}
+
+function resolveBaseRpcUrl(options, env, baseCluster) {
+  if (baseCluster === "devnet") {
+    return options.baseRpcUrl ?? readRequiredEnv(env, "BASE_DEVNET_RPC_URL");
   }
 
-  return {
-    baseRpcUrl: options.baseRpcUrl ?? readRequiredEnv(env, "BASE_RPC_URL"),
-    ephemeralRpcUrl: options.ephemeralRpcUrl ?? readRequiredEnv(env, "EPHEMERAL_RPC_URL"),
-  };
+  return options.baseRpcUrl ?? readRequiredEnv(env, "BASE_RPC_URL");
+}
+
+function dedupeRpcConfigs(configs) {
+  const byUrl = new Map();
+
+  for (const config of configs) {
+    const current = byUrl.get(config.url);
+
+    if (current) {
+      current.labels.push(config.label);
+      continue;
+    }
+
+    byUrl.set(config.url, {
+      labels: [config.label],
+      url: config.url,
+    });
+  }
+
+  return [...byUrl.values()].map(config => ({
+    label: config.labels.join("+"),
+    url: config.url,
+  }));
+}
+
+function resolveEphemeralRpcConfigs(options, env, baseCluster) {
+  if (options.ephemeralRpcUrls.length > 0) {
+    return dedupeRpcConfigs(
+      options.ephemeralRpcUrls.map((url, index) => ({
+        label: `rpc${index + 1}`,
+        url,
+      })),
+    );
+  }
+
+  if (baseCluster === "devnet") {
+    return dedupeRpcConfigs([
+      {
+        label: "ephemeral",
+        url: readRequiredEnv(env, "EPHEMERAL_DEVNET_RPC_URL"),
+      },
+      {
+        label: "tee",
+        url: readRequiredEnv(env, "EPHEMERAL_DEVNET_TEE_RPC_URL"),
+      },
+    ]);
+  }
+
+  return dedupeRpcConfigs([
+    {
+      label: "ephemeral",
+      url: readRequiredEnv(env, "EPHEMERAL_RPC_URL"),
+    },
+    {
+      label: "tee",
+      url: readRequiredEnv(env, "EPHEMERAL_TEE_RPC_URL"),
+    },
+  ]);
 }
 
 function readKeypair(path) {
@@ -214,12 +297,8 @@ function readKeypair(path) {
   return Keypair.fromSecretKey(secretKey);
 }
 
-async function resolveValidator(ephemeralRpcUrl, validatorOverride) {
-  if (validatorOverride) {
-    return new PublicKey(validatorOverride);
-  }
-
-  const response = await fetch(ephemeralRpcUrl, {
+async function resolveValidatorFromRpc({ label, url }) {
+  const response = await fetch(url, {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -233,20 +312,76 @@ async function resolveValidator(ephemeralRpcUrl, validatorOverride) {
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to resolve validator identity: HTTP ${response.status}`);
+    throw new Error(`Failed to resolve ${label} validator identity: HTTP ${response.status}`);
   }
 
   const payload = await response.json();
   const identity = payload?.result?.identity;
 
   if (typeof identity !== "string" || identity.length === 0) {
-    throw new Error("Failed to resolve validator identity from ephemeral RPC");
+    throw new Error(`Failed to resolve ${label} validator identity from ephemeral RPC`);
   }
 
-  return new PublicKey(identity);
+  return {
+    label,
+    pubkey: new PublicKey(identity),
+  };
+}
+
+function dedupeValidatorConfigs(configs) {
+  const byAddress = new Map();
+
+  for (const config of configs) {
+    const address = config.pubkey.toBase58();
+    const current = byAddress.get(address);
+
+    if (current) {
+      current.labels.push(config.label);
+      current.rpcUrls.push(...config.rpcUrls);
+      continue;
+    }
+
+    byAddress.set(address, {
+      labels: [config.label],
+      pubkey: config.pubkey,
+      rpcUrls: config.rpcUrls,
+    });
+  }
+
+  return [...byAddress.values()].map(config => ({
+    label: config.labels.join("+"),
+    pubkey: config.pubkey,
+    rpcUrls: [...new Set(config.rpcUrls)],
+  }));
+}
+
+async function resolveValidators(options, ephemeralRpcConfigs) {
+  if (options.validators.length > 0) {
+    return dedupeValidatorConfigs(
+      options.validators.map((validator, index) => ({
+        label: `validator${index + 1}`,
+        pubkey: new PublicKey(validator),
+        rpcUrls: [],
+      })),
+    );
+  }
+
+  const resolvedValidators = await Promise.all(
+    ephemeralRpcConfigs.map(async (config) => {
+      const validator = await resolveValidatorFromRpc(config);
+      return {
+        ...validator,
+        rpcUrls: [config.url],
+      };
+    }),
+  );
+
+  return dedupeValidatorConfigs(resolvedValidators);
 }
 
 function getMintConfigs(cluster) {
+  const baseCluster = getBaseCluster(cluster);
+
   return [
     {
       label: "sol",
@@ -254,7 +389,11 @@ function getMintConfigs(cluster) {
     },
     {
       label: "usdc",
-      mint: cluster === "devnet" ? DEVNET_USDC_MINT : MAINNET_USDC_MINT,
+      mint: baseCluster === "devnet" ? DEVNET_USDC_MINT : MAINNET_USDC_MINT,
+    },
+    {
+      label: "usdt",
+      mint: baseCluster === "devnet" ? DEVNET_USDT_MINT : MAINNET_USDT_MINT,
     },
   ];
 }
@@ -265,6 +404,10 @@ function createEntry(label, pubkey) {
 
 function buildMintEntries(label, mint, validator) {
   const [queue] = deriveTransferQueue(mint, validator);
+  const queueAta = deriveQueueVaultAta(mint, validator);
+  const [queueEphemeralAta] = deriveQueueEphemeralAta(mint, validator);
+  const queuePermission = permissionPdaFromAccount(queue);
+  const queueEphemeralAtaPermission = permissionPdaFromAccount(queueEphemeralAta);
   const [vault] = deriveVault(mint);
   const vaultAta = deriveVaultAta(mint, vault);
   const [vaultEphemeralAta] = deriveEphemeralAta(vault, mint);
@@ -284,6 +427,9 @@ function buildMintEntries(label, mint, validator) {
     createEntry(`${label}.vaultAta`, vaultAta),
     createEntry(`${label}.vaultEphemeralAta`, vaultEphemeralAta),
     createEntry(`${label}.queue`, queue),
+    createEntry(`${label}.queueAta`, queueAta),
+    createEntry(`${label}.queueEphemeralAta`, queueEphemeralAta),
+    createEntry(`${label}.queuePermission`, queuePermission),
     createEntry(`${label}.refillState`, refillState),
     createEntry(`${label}.lamportsPda`, lamportsPda),
     createEntry(
@@ -302,8 +448,53 @@ function buildMintEntries(label, mint, validator) {
       delegationMetadataPdaFromDelegatedAccount(lamportsPda),
     ),
     createEntry(
+      `${label}.queueDelegateBuffer`,
+      delegateBufferPdaFromDelegatedAccountAndOwnerProgram(
+        queue,
+        EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+      ),
+    ),
+    createEntry(
       `${label}.queueDelegationRecord`,
       delegationRecordPdaFromDelegatedAccount(queue),
+    ),
+    createEntry(
+      `${label}.queueDelegationMetadata`,
+      delegationMetadataPdaFromDelegatedAccount(queue),
+    ),
+    createEntry(
+      `${label}.queueEphemeralAtaDelegateBuffer`,
+      delegateBufferPdaFromDelegatedAccountAndOwnerProgram(
+        queueEphemeralAta,
+        EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+      ),
+    ),
+    createEntry(
+      `${label}.queueEphemeralAtaDelegationRecord`,
+      delegationRecordPdaFromDelegatedAccount(queueEphemeralAta),
+    ),
+    createEntry(
+      `${label}.queueEphemeralAtaDelegationMetadata`,
+      delegationMetadataPdaFromDelegatedAccount(queueEphemeralAta),
+    ),
+    createEntry(
+      `${label}.queueEphemeralAtaPermission`,
+      queueEphemeralAtaPermission,
+    ),
+    createEntry(
+      `${label}.queueEphemeralAtaPermissionDelegateBuffer`,
+      delegateBufferPdaFromDelegatedAccountAndOwnerProgram(
+        queueEphemeralAtaPermission,
+        PERMISSION_PROGRAM_ID,
+      ),
+    ),
+    createEntry(
+      `${label}.queueEphemeralAtaPermissionDelegationRecord`,
+      delegationRecordPdaFromDelegatedAccount(queueEphemeralAtaPermission),
+    ),
+    createEntry(
+      `${label}.queueEphemeralAtaPermissionDelegationMetadata`,
+      delegationMetadataPdaFromDelegatedAccount(queueEphemeralAtaPermission),
     ),
     createEntry(
       `${label}.vaultDelegateBuffer`,
@@ -390,16 +581,31 @@ async function main() {
     ...parseEnvFile(resolve(process.cwd(), options.envFile)),
     ...process.env,
   };
-  const { baseRpcUrl, ephemeralRpcUrl } = resolveRpcUrls(options, env);
+  const baseCluster = getBaseCluster(options.cluster);
+  const baseRpcUrl = resolveBaseRpcUrl(options, env, baseCluster);
+  const ephemeralRpcConfigs = options.validators.length > 0
+    ? []
+    : resolveEphemeralRpcConfigs(options, env, baseCluster);
   const payer = readKeypair(options.payerPath);
   const authority = readKeypair(options.authorityPath ?? options.payerPath);
-  const validator = await resolveValidator(ephemeralRpcUrl, options.validator);
-  const mintConfigs = getMintConfigs(options.cluster);
+  const validators = await resolveValidators(options, ephemeralRpcConfigs);
+  const mintConfigs = getMintConfigs(baseCluster);
   const entries = dedupeEntries([
     ...buildSharedEntries(),
-    ...mintConfigs.flatMap(({ label, mint }) => buildMintEntries(label, mint, validator)),
+    ...validators.flatMap(validator =>
+      mintConfigs.flatMap(({ label, mint }) =>
+        buildMintEntries(`${validator.label}.${label}`, mint, validator.pubkey),
+      ),
+    ),
   ]);
   const addresses = entries.map(entry => entry.pubkey);
+
+  if (addresses.length > MAX_LOOKUP_TABLE_ADDRESSES) {
+    throw new Error(
+      `Lookup table would contain ${addresses.length} addresses, exceeding the ${MAX_LOOKUP_TABLE_ADDRESSES} address limit`,
+    );
+  }
+
   const connection = new Connection(baseRpcUrl, "confirmed");
   const recentSlot = await connection.getSlot("finalized");
   const signers = getSignerSet(payer, authority);
@@ -411,10 +617,18 @@ async function main() {
     });
   const summary = {
     status: "prepared",
-    cluster: options.cluster,
+    cluster: baseCluster,
+    requestedCluster: options.cluster,
     baseRpcUrl,
-    ephemeralRpcUrl,
-    validator: validator.toBase58(),
+    ephemeralRpcUrls: ephemeralRpcConfigs.map(config => ({
+      label: config.label,
+      url: config.url,
+    })),
+    validators: validators.map(validator => ({
+      label: validator.label,
+      pubkey: validator.pubkey.toBase58(),
+      rpcUrls: validator.rpcUrls,
+    })),
     lookupTable: lookupTableAddress.toBase58(),
     frozen: false,
     addressCount: entries.length,

--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -341,6 +341,13 @@ describe("app", () => {
       kind: "deposit",
       instructionCount: 3,
     });
+    const depositRequestSchema = (
+      json.components?.schemas as Record<string, any>
+    )?.DepositRequest;
+    expect(depositRequestSchema?.properties?.private).toMatchObject({
+      type: "boolean",
+      example: true,
+    });
     const transferRequestSchema = (
       json.components?.schemas as Record<string, any>
     )?.TransferRequest;
@@ -364,6 +371,7 @@ describe("app", () => {
       json.components?.schemas as Record<string, any>
     )?.UnsignedTransactionResponse;
     expect(transactionResponseSchema?.properties?.fees).toBeDefined();
+    expect(transactionResponseSchema?.properties?.sendRpcEndpoint).toBeDefined();
     const sendTransactionRequestSchema = (
       json.components?.schemas as Record<string, any>
     )?.SendTransactionRequest;
@@ -1899,10 +1907,53 @@ describe("app", () => {
       Buffer.from(json.transactionBase64, "base64"),
     );
     expect(transaction.instructions.length).toBeGreaterThan(0);
+    const privatePermissionIx = transaction.instructions.find(
+      ix => ix.programId.equals(EPHEMERAL_SPL_TOKEN_PROGRAM_ID) && ix.data[0] === 6,
+    );
     const depositIx
       = transaction.instructions[transaction.instructions.length - 1]!;
+    expect(privatePermissionIx).toBeDefined();
     expect(depositIx.data[0]).toBe(24);
     expect(depositIx.data.length).toBe(45);
+  });
+
+  it("builds a public deposit transaction when private is false", async () => {
+    vi.spyOn(Connection.prototype, "getLatestBlockhash").mockResolvedValue({
+      blockhash: "11111111111111111111111111111111",
+      lastValidBlockHeight: 123,
+    });
+
+    const response = await app.request(
+      "/v1/spl/deposit",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          owner,
+          amount: 1,
+          validator: resolvedValidator,
+          idempotent: true,
+          private: false,
+        }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(200);
+
+    const json = (await response.json()) as {
+      transactionBase64: string;
+    };
+    const transaction = Transaction.from(
+      Buffer.from(json.transactionBase64, "base64"),
+    );
+    const privatePermissionIx = transaction.instructions.find(
+      ix => ix.programId.equals(EPHEMERAL_SPL_TOKEN_PROGRAM_ID) && ix.data[0] === 6,
+    );
+
+    expect(privatePermissionIx).toBeUndefined();
   });
 
   it("uses the mint token program when building a deposit", async () => {
@@ -2480,6 +2531,109 @@ describe("app", () => {
     ).toBe(true);
   });
 
+  it("uses the devnet TEE RPC endpoint when cluster=devnet-private", async () => {
+    const devnetPrivateEnv = {
+      ...env,
+      EPHEMERAL_DEVNET_RPC_URL: "https://ephemeral.deposit.devnet.rpc.test",
+      EPHEMERAL_DEVNET_TEE_RPC_URL: "https://ephemeral-tee.deposit.devnet.rpc.test",
+    };
+
+    vi.spyOn(Connection.prototype, "getLatestBlockhash").mockImplementation(
+      async function getLatestBlockhash(
+        this: Connection & { _rpcEndpoint: string },
+      ) {
+        const endpoint = (this as Connection & { _rpcEndpoint: string })
+          ._rpcEndpoint;
+        return endpoint.includes("base.devnet.rpc.test")
+          ? {
+              blockhash: "So11111111111111111111111111111111111111112",
+              lastValidBlockHeight: 321,
+            }
+          : {
+              blockhash: "11111111111111111111111111111111",
+              lastValidBlockHeight: 123,
+            };
+      },
+    );
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      expect(String(input)).toBe(devnetPrivateEnv.EPHEMERAL_DEVNET_TEE_RPC_URL);
+      return createIdentityResponse(resolvedValidator);
+    });
+
+    const response = await app.request(
+      "/v1/spl/deposit",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          owner,
+          amount: 1,
+          cluster: "devnet-private",
+        }),
+      },
+      devnetPrivateEnv,
+    );
+
+    expect(response.status).toBe(200);
+
+    const json = (await response.json()) as {
+      recentBlockhash: string;
+      validator: string;
+      transactionBase64: string;
+    };
+
+    expect(json.recentBlockhash).toBe(
+      "So11111111111111111111111111111111111111112",
+    );
+    expect(json.validator).toBe(resolvedValidator);
+
+    const transaction = Transaction.from(
+      Buffer.from(json.transactionBase64, "base64"),
+    );
+    expect(
+      transaction.instructions.some(instruction =>
+        instruction.keys.some(
+          key => key.pubkey.toBase58() === DEVNET_USDC_MINT,
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("uses the mainnet TEE RPC endpoint when cluster=mainnet-private", async () => {
+    const mainnetPrivateEnv = {
+      ...env,
+      EPHEMERAL_TEE_RPC_URL: "https://ephemeral-tee.challenge.rpc.test",
+    };
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      expect(String(input)).toBe(
+        `${mainnetPrivateEnv.EPHEMERAL_TEE_RPC_URL}/auth/challenge?pubkey=${owner}`,
+      );
+      return new Response(
+        JSON.stringify({ challenge: "mainnet-private-challenge" }),
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      );
+    });
+
+    const response = await app.request(
+      `/v1/spl/challenge?pubkey=${owner}&cluster=mainnet-private`,
+      {},
+      mainnetPrivateEnv,
+    );
+
+    expect(response.status).toBe(200);
+
+    const json = (await response.json()) as { challenge: string };
+    expect(json.challenge).toBe("mainnet-private-challenge");
+  });
+
   it("defaults the worker cluster binding to mainnet when it is omitted", async () => {
     vi.spyOn(Connection.prototype, "getAccountInfo").mockResolvedValue(
       createAccountInfo(3n),
@@ -2923,6 +3077,38 @@ describe("app", () => {
     );
   });
 
+  it("returns a config error when devnet-private TEE RPC env vars are missing", async () => {
+    const response = await app.request(
+      `/v1/spl/challenge?pubkey=${owner}&cluster=devnet-private`,
+      {},
+      env,
+    );
+
+    expect(response.status).toBe(500);
+
+    const json = (await response.json()) as {
+      error: {
+        code: string;
+        message: string;
+        details?: {
+          issues?: Array<{
+            path?: string[];
+          }>;
+        };
+      };
+    };
+
+    expect(json.error.code).toBe("CONFIG_ERROR");
+    expect(json.error.message).toBe(
+      "Missing worker environment variables for cluster=devnet-private",
+    );
+    expect(json.error.details?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: ["EPHEMERAL_DEVNET_TEE_RPC_URL"] }),
+      ]),
+    );
+  });
+
   it("exposes the SPL tools over MCP", async () => {
     vi.spyOn(Connection.prototype, "getLatestBlockhash").mockResolvedValue({
       blockhash: "11111111111111111111111111111111",
@@ -3013,6 +3199,7 @@ describe("app", () => {
 
     const json = (await response.json()) as {
       sendTo: string;
+      sendRpcEndpoint: string;
       from: string;
       recentBlockhash: string;
       instructionCount: number;
@@ -3023,6 +3210,7 @@ describe("app", () => {
     };
 
     expect(json.sendTo).toBe("ephemeral");
+    expect(json.sendRpcEndpoint).toBe(env.EPHEMERAL_RPC_URL);
     expect(json.from).toBe("ephemeral");
     expect(json.recentBlockhash).toBe("11111111111111111111111111111111");
     expect(json.instructionCount).toBe(1);
@@ -3784,7 +3972,7 @@ describe("app", () => {
             EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
             SystemProgram.programId,
           ],
-          new PublicKey("HFmj4QbofPjhXP2vdnDARDQFw1AucSQTKVAs8df4tkUy"),
+          new PublicKey("E26JGdRsdKkGe6oRU4Un24agZjBF2Bg9z1ctfZByETRo"),
         ),
       ),
     );
@@ -4378,6 +4566,65 @@ describe("app", () => {
     expect(json.error.code).toBe("UNSUPPORTED_TRANSFER_ROUTE");
   });
 
+  it("builds a zero-amount private base-to-ephemeral setup transfer", async () => {
+    const setupEnv = {
+      ...env,
+      EPHEMERAL_RPC_URL: "https://ephemeral.zero-setup.rpc.test",
+    };
+
+    vi.spyOn(Connection.prototype, "getLatestBlockhash").mockResolvedValue({
+      blockhash: "11111111111111111111111111111111",
+      lastValidBlockHeight: 123,
+    });
+    vi.spyOn(Connection.prototype, "getAccountInfo").mockResolvedValue(
+      createMintAccountInfo(TOKEN_PROGRAM_ID),
+    );
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      expect(String(input)).toBe(setupEnv.EPHEMERAL_RPC_URL);
+      return createIdentityResponse(resolvedValidator);
+    });
+
+    const response = await app.request(
+      "/v1/spl/transfer",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          from: owner,
+          to: destination,
+          mint: "So11111111111111111111111111111111111111112",
+          amount: 0,
+          visibility: "private",
+          fromBalance: "base",
+          toBalance: "ephemeral",
+          initIfMissing: true,
+          initAtasIfMissing: true,
+          initVaultIfMissing: true,
+        }),
+      },
+      setupEnv,
+    );
+
+    expect(response.status).toBe(200);
+
+    const json = (await response.json()) as {
+      sendTo: string;
+      transactionBase64: string;
+    };
+    const transaction = Transaction.from(
+      Buffer.from(json.transactionBase64, "base64"),
+    );
+    const setupInstruction = transaction.instructions.find(
+      ix => ix.programId.equals(EPHEMERAL_SPL_TOKEN_PROGRAM_ID) && ix.data[0] === 24,
+    );
+
+    expect(json.sendTo).toBe("base");
+    expect(setupInstruction).toBeDefined();
+    expect(setupInstruction?.data.readBigUInt64LE(5)).toBe(0n);
+  });
+
   it("returns base and private balances from different RPCs", async () => {
     const mint = "So11111111111111111111111111111111111111112";
     const balanceEnv = {
@@ -4748,6 +4995,46 @@ describe("app", () => {
 
     const json = (await response.json()) as { token: string };
     expect(json.token).toBe(MOCK_AUTH_TOKEN);
+  });
+
+  it("maps upstream login rate limits to 429", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      expect(String(input)).toBe(`${env.EPHEMERAL_RPC_URL}/auth/login`);
+      return new Response(
+        JSON.stringify({
+          error:
+            "Unexpected Range status: 429 Too Many Requests; body={\"message\":\"Too many requests\",\"statusCode\":429}",
+        }),
+        {
+          status: 400,
+          statusText: "Bad Request",
+          headers: {
+            "content-type": "text/plain",
+          },
+        },
+      );
+    });
+
+    const response = await app.request(
+      "/v1/spl/login",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          pubkey: owner,
+          challenge: "c1",
+          signature: "s1",
+        }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(429);
+
+    const json = (await response.json()) as { error: { message: string } };
+    expect(json.error.message).toBe("Failed to login: Too Many Requests");
   });
 
   it("redacts RPC URLs from balance error details", async () => {

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -17,11 +17,13 @@ const optionalString = z
 const optionalUrl = optionalString.pipe(z.string().url().optional());
 
 export const envSchema = z.object({
-  CLUSTER: z.literal(["mainnet", "devnet", "custom"]).default("mainnet"),
+  CLUSTER: z.literal(["mainnet", "devnet", "mainnet-private", "devnet-private", "custom"]).default("mainnet"),
   BASE_RPC_URL: z.string().url(),
   EPHEMERAL_RPC_URL: z.string().url(),
   BASE_DEVNET_RPC_URL: optionalUrl,
   EPHEMERAL_DEVNET_RPC_URL: optionalUrl,
+  EPHEMERAL_TEE_RPC_URL: optionalUrl,
+  EPHEMERAL_DEVNET_TEE_RPC_URL: optionalUrl,
   TRANSFER_QUEUE_CRANK_RPC_URL: optionalUrl,
   TRANSFER_QUEUE_DEVNET_CRANK_RPC_URL: optionalUrl,
   METIS_SWAP_API_URL: optionalUrl,
@@ -37,6 +39,8 @@ export type AppBindings = {
   EPHEMERAL_RPC_URL?: string;
   BASE_DEVNET_RPC_URL?: string;
   EPHEMERAL_DEVNET_RPC_URL?: string;
+  EPHEMERAL_TEE_RPC_URL?: string;
+  EPHEMERAL_DEVNET_TEE_RPC_URL?: string;
   TRANSFER_QUEUE_CRANK_RPC_URL?: string;
   TRANSFER_QUEUE_DEVNET_CRANK_RPC_URL?: string;
   METIS_SWAP_API_URL?: string;
@@ -64,7 +68,7 @@ export function getEnv(bindings: AppBindings): AppEnv {
             ),
             message: issue.message,
           })),
-          hint: "Create .dev.vars from .dev.vars.example and set BASE_RPC_URL and EPHEMERAL_RPC_URL before running wrangler dev. If you want cluster=devnet, also set BASE_DEVNET_RPC_URL and EPHEMERAL_DEVNET_RPC_URL. To enable gasless private transfers, also set GASLESS_SPONSOR_SECRET_KEY to a JSON-encoded secret key array.",
+          hint: "Create .dev.vars from .dev.vars.example and set BASE_RPC_URL and EPHEMERAL_RPC_URL before running wrangler dev. If you want cluster=devnet, also set BASE_DEVNET_RPC_URL and EPHEMERAL_DEVNET_RPC_URL. If you want cluster=mainnet-private or cluster=devnet-private, also set EPHEMERAL_TEE_RPC_URL or EPHEMERAL_DEVNET_TEE_RPC_URL. To enable gasless private transfers, also set GASLESS_SPONSOR_SECRET_KEY to a JSON-encoded secret key array.",
         },
       );
     }

--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -29,6 +29,10 @@ async function fetchAuth(url: URL, init?: RequestInit) {
   }
 }
 
+function isUpstreamRateLimit(status: number, body: string) {
+  return status === 429 || (body.includes("429") && body.toLowerCase().includes("too many requests"));
+}
+
 export function parseAuthToken(
   headers: Record<string, string>,
 ): string | undefined {
@@ -100,10 +104,14 @@ export async function login(
   });
 
   if (!loginResponse.ok) {
+    const body = await loginResponse.text().catch(() => "");
+    const status = isUpstreamRateLimit(loginResponse.status, body)
+      ? 429
+      : loginResponse.status;
     throw new ApiError(
-      loginResponse.status,
+      status,
       "RPC_ERROR",
-      `Failed to login: ${loginResponse.statusText}`,
+      `Failed to login: ${status === 429 ? "Too Many Requests" : loginResponse.statusText}`,
     );
   }
 

--- a/api/src/lib/solana.ts
+++ b/api/src/lib/solana.ts
@@ -75,8 +75,8 @@ const TRANSFER_QUEUE_AUTH_ERROR_FORCE_INTERVAL = 100;
 const SOLANA_WIRE_TRANSACTION_SIZE_LIMIT = 1232;
 // Keep these defaults aligned with scripts/create-private-transfer-lut.js. Updating them requires a redeploy.
 const PRIVATE_BASE_TO_BASE_TRANSFER_LOOKUP_TABLES = {
-  mainnet: new PublicKey("2J2Pw639kU7U6rj7qUXY5sVXdJqyt4DjEcVxzqmFrFds"),
-  devnet: new PublicKey("HFmj4QbofPjhXP2vdnDARDQFw1AucSQTKVAs8df4tkUy"),
+  mainnet: new PublicKey("54M1BrqVSg1UGTmhH44gQPsPVyuMpmcVBkaY2wYNSVZB"),
+  devnet: new PublicKey("E26JGdRsdKkGe6oRU4Un24agZjBF2Bg9z1ctfZByETRo"),
 } as const;
 const PRIVATE_TRANSFER_SETUP_LAMPORTS = 2_039_280n;
 const PRIVATE_TRANSFER_FEE_BASIS_POINTS = 10n;
@@ -99,7 +99,14 @@ type RpcConfig = {
   ephemeralRpcUrl: string;
   transferQueueCrankRpcUrl: string;
   cluster: "mainnet" | "devnet" | "custom";
+  teeRpcUrl?: string;
 };
+
+type ClusterConfigEnvVar
+  = "BASE_DEVNET_RPC_URL"
+    | "EPHEMERAL_DEVNET_RPC_URL"
+    | "EPHEMERAL_TEE_RPC_URL"
+    | "EPHEMERAL_DEVNET_TEE_RPC_URL";
 
 type RpcIdentityResponse = {
   result?: {
@@ -196,17 +203,17 @@ async function resolveMintTokenProgram(config: RpcConfig, mint: PublicKey) {
   });
 }
 
-function createClusterConfigError(missingVars: Array<"BASE_DEVNET_RPC_URL" | "EPHEMERAL_DEVNET_RPC_URL">) {
+function createClusterConfigError(cluster: string, missingVars: ClusterConfigEnvVar[]) {
   return new ApiError(
     500,
     "CONFIG_ERROR",
-    "Missing worker environment variables for cluster=devnet",
+    `Missing worker environment variables for cluster=${cluster}`,
     {
       issues: missingVars.map(name => ({
         path: [name],
-        message: "Required for cluster=devnet",
+        message: `Required for cluster=${cluster}`,
       })),
-      hint: "Set BASE_DEVNET_RPC_URL and EPHEMERAL_DEVNET_RPC_URL before using cluster=devnet.",
+      hint: `Set ${missingVars.join(" and ")} before using cluster=${cluster}.`,
     },
   );
 }
@@ -251,15 +258,7 @@ function getGaslessSponsorKeypair(env: AppEnv) {
 }
 
 export function resolveRpcConfig(env: AppEnv, cluster?: string): RpcConfig {
-  if (!cluster) {
-    return {
-      baseRpcUrl: env.BASE_RPC_URL,
-      ephemeralRpcUrl: env.EPHEMERAL_RPC_URL,
-      transferQueueCrankRpcUrl: env.TRANSFER_QUEUE_CRANK_RPC_URL ?? env.EPHEMERAL_RPC_URL,
-      cluster: env.CLUSTER,
-    };
-  }
-  const value = cluster.trim();
+  const value = (cluster ?? env.CLUSTER).trim();
   const normalized = value?.toLowerCase();
   if (!value || normalized === "mainnet") {
     return {
@@ -270,6 +269,24 @@ export function resolveRpcConfig(env: AppEnv, cluster?: string): RpcConfig {
     };
   }
 
+  if (normalized === "mainnet-private") {
+    const missingVars = [
+      ...(!env.EPHEMERAL_TEE_RPC_URL ? ["EPHEMERAL_TEE_RPC_URL" as const] : []),
+    ];
+
+    if (missingVars.length > 0) {
+      throw createClusterConfigError("mainnet-private", missingVars);
+    }
+
+    return {
+      baseRpcUrl: env.BASE_RPC_URL,
+      ephemeralRpcUrl: env.EPHEMERAL_TEE_RPC_URL!,
+      transferQueueCrankRpcUrl: env.TRANSFER_QUEUE_CRANK_RPC_URL ?? env.EPHEMERAL_TEE_RPC_URL!,
+      cluster: "mainnet",
+      teeRpcUrl: env.EPHEMERAL_TEE_RPC_URL!,
+    };
+  }
+
   if (normalized === "devnet") {
     const missingVars = [
       ...(!env.BASE_DEVNET_RPC_URL ? ["BASE_DEVNET_RPC_URL" as const] : []),
@@ -277,7 +294,7 @@ export function resolveRpcConfig(env: AppEnv, cluster?: string): RpcConfig {
     ];
 
     if (missingVars.length > 0) {
-      throw createClusterConfigError(missingVars);
+      throw createClusterConfigError("devnet", missingVars);
     }
 
     return {
@@ -285,6 +302,34 @@ export function resolveRpcConfig(env: AppEnv, cluster?: string): RpcConfig {
       ephemeralRpcUrl: env.EPHEMERAL_DEVNET_RPC_URL!,
       transferQueueCrankRpcUrl: env.TRANSFER_QUEUE_DEVNET_CRANK_RPC_URL ?? env.EPHEMERAL_DEVNET_RPC_URL!,
       cluster: "devnet",
+    };
+  }
+
+  if (normalized === "devnet-private") {
+    const missingVars = [
+      ...(!env.BASE_DEVNET_RPC_URL ? ["BASE_DEVNET_RPC_URL" as const] : []),
+      ...(!env.EPHEMERAL_DEVNET_TEE_RPC_URL ? ["EPHEMERAL_DEVNET_TEE_RPC_URL" as const] : []),
+    ];
+
+    if (missingVars.length > 0) {
+      throw createClusterConfigError("devnet-private", missingVars);
+    }
+
+    return {
+      baseRpcUrl: env.BASE_DEVNET_RPC_URL!,
+      ephemeralRpcUrl: env.EPHEMERAL_DEVNET_TEE_RPC_URL!,
+      transferQueueCrankRpcUrl: env.TRANSFER_QUEUE_DEVNET_CRANK_RPC_URL ?? env.EPHEMERAL_DEVNET_TEE_RPC_URL!,
+      cluster: "devnet",
+      teeRpcUrl: env.EPHEMERAL_DEVNET_TEE_RPC_URL!,
+    };
+  }
+
+  if (cluster === undefined && normalized === "custom") {
+    return {
+      baseRpcUrl: env.BASE_RPC_URL,
+      ephemeralRpcUrl: env.EPHEMERAL_RPC_URL,
+      transferQueueCrankRpcUrl: env.TRANSFER_QUEUE_CRANK_RPC_URL ?? env.EPHEMERAL_RPC_URL,
+      cluster: "custom",
     };
   }
 
@@ -302,7 +347,7 @@ export function resolveRpcConfig(env: AppEnv, cluster?: string): RpcConfig {
       cluster: "custom",
     };
   } catch {
-    throw new ApiError(400, "INVALID_CLUSTER", "cluster must be \"mainnet\", \"devnet\", or a valid http(s) URL");
+    throw new ApiError(400, "INVALID_CLUSTER", "cluster must be \"mainnet\", \"devnet\", \"mainnet-private\", \"devnet-private\", or a valid http(s) URL");
   }
 }
 
@@ -328,24 +373,35 @@ function parsePublicKey(value: string, fieldName: string) {
   }
 }
 
-function parseAmount(value: string | number, fieldName: string) {
+function parseAmount(
+  value: string | number,
+  fieldName: string,
+  options?: { allowZero?: boolean },
+) {
   try {
+    const allowZero = options?.allowZero ?? false;
     const amount = typeof value === "number"
       ? (() => {
-          if (!Number.isSafeInteger(value) || value <= 0) {
-            throw new Error("non-positive");
+          if (!Number.isSafeInteger(value) || value < 0 || (!allowZero && value === 0)) {
+            throw new Error("invalid amount");
           }
 
           return BigInt(value);
         })()
       : BigInt(value);
 
-    if (amount <= 0n) {
-      throw new Error("non-positive");
+    if (amount < 0n || (!allowZero && amount === 0n)) {
+      throw new Error("invalid amount");
     }
     return amount;
   } catch {
-    throw new ApiError(400, "INVALID_AMOUNT", `${fieldName} must be a positive integer string`);
+    throw new ApiError(
+      400,
+      "INVALID_AMOUNT",
+      options?.allowZero
+        ? `${fieldName} must be a non-negative integer string`
+        : `${fieldName} must be a positive integer string`,
+    );
   }
 }
 
@@ -547,16 +603,20 @@ async function tryResolveDelegationEndpointFromRouter(
   }
 }
 
-function getHardcodedTeeRpcEndpoint(cluster: RpcConfig["cluster"], validator: PublicKey | undefined) {
+function getHardcodedTeeRpcEndpoint(config: RpcConfig, validator: PublicKey | undefined) {
   if (!validator?.equals(TEE_VALIDATOR)) {
     return undefined;
   }
 
-  if (cluster === "devnet") {
+  if (config.teeRpcUrl) {
+    return config.teeRpcUrl;
+  }
+
+  if (config.cluster === "devnet") {
     return DEVNET_TEE_RPC_URL;
   }
 
-  if (cluster === "mainnet") {
+  if (config.cluster === "mainnet") {
     return MAINNET_TEE_RPC_URL;
   }
 
@@ -586,7 +646,7 @@ async function resolveUndelegateEphemeralRpcEndpoint(
   }
 
   const delegatedValidator = readDelegatedValidator(delegationAccount);
-  const hardcodedEndpoint = getHardcodedTeeRpcEndpoint(config.cluster, delegatedValidator);
+  const hardcodedEndpoint = getHardcodedTeeRpcEndpoint(config, delegatedValidator);
 
   if (hardcodedEndpoint) {
     return hardcodedEndpoint;
@@ -1021,6 +1081,7 @@ function serializeTransaction(
   partialSigners: Keypair[] = [],
   from?: SendTarget,
   fees?: TransferFees,
+  sendRpcEndpoint?: string,
 ): TransactionResponse {
   const transaction = createUnsignedTransaction(instructions, feePayer, blockhash);
   if (partialSigners.length > 0) {
@@ -1037,6 +1098,7 @@ function serializeTransaction(
       }),
     ).toString("base64"),
     sendTo,
+    sendRpcEndpoint,
     from,
     recentBlockhash: blockhash.blockhash,
     lastValidBlockHeight: blockhash.lastValidBlockHeight,
@@ -1149,6 +1211,7 @@ export async function buildDepositTransaction(env: AppEnv, input: DepositRequest
       shuttleId: createRandomShuttleId(),
       escrowIndex: 0,
       idempotent: input.idempotent,
+      private: input.private ?? true,
     });
 
     return serializeTransaction(
@@ -1321,7 +1384,12 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
     const from = parsePublicKey(input.from, "from");
     const to = parsePublicKey(input.to, "to");
     const mint = parsePublicKey(input.mint, "mint");
-    const amount = parseAmount(input.amount, "amount");
+    const allowZeroAmount = input.visibility === "private"
+      && input.fromBalance === "base"
+      && input.toBalance === "ephemeral";
+    const amount = parseAmount(input.amount, "amount", {
+      allowZero: allowZeroAmount,
+    });
     const shuttleId = createRandomShuttleId();
 
     const minDelayMs = parseOptionalAmount(input.minDelayMs, "minDelayMs");
@@ -1329,8 +1397,6 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
     const clientRefId = parseOptionalAmount(input.clientRefId, "clientRefId");
     const split = input.split;
     const exactOut = input.exactOut;
-
-    console.log("input: ", input);
 
     if (minDelayMs !== undefined && minDelayMs < 0n) {
       throw new ApiError(400, "INVALID_PRIVATE_TRANSFER", "minDelayMs must be non-negative");
@@ -1505,8 +1571,6 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
         return versionedResponse;
       }
     }
-    console.log("instructions: ", instructions);
-
     return serializeTransaction(
       "transfer",
       sendTo,
@@ -1517,6 +1581,7 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
       sponsor ? [sponsor] : [],
       input.fromBalance,
       fees,
+      sendTo === "ephemeral" ? config.ephemeralRpcUrl : undefined,
     );
   } catch (error) {
     throwTransactionBuildError(error);

--- a/api/src/routes/mcp.route.ts
+++ b/api/src/routes/mcp.route.ts
@@ -91,6 +91,7 @@ const mcpToolCallRequestExample = {
       initAtasIfMissing: true,
       initVaultIfMissing: false,
       idempotent: true,
+      private: true,
     },
   },
 };

--- a/api/src/routes/spl/spl.schemas.ts
+++ b/api/src/routes/spl/spl.schemas.ts
@@ -26,6 +26,9 @@ export const transactionResponseSchema = z.object({
   version: z.enum(["legacy", "v0"]),
   transactionBase64: z.string(),
   sendTo: balanceLocationSchema,
+  sendRpcEndpoint: z.string().url().optional().openapi({
+    description: "Exact ephemeral RPC endpoint where the signed transaction should be submitted. Present when `sendTo` is `ephemeral`.",
+  }),
   from: balanceLocationSchema.optional(),
   recentBlockhash: z.string(),
   lastValidBlockHeight: z.number().int(),
@@ -131,7 +134,7 @@ export const depositRequestSchema = z.object({
   cluster: clusterSchema.optional(),
   mint: publicKeySchema.openapi({
     example: DEFAULT_DEPOSIT_MINT,
-    description: `Optional. Defaults to Solana USDC on mainnet: ${DEFAULT_DEPOSIT_MINT}. On devnet it defaults to devnet USDC: ${DEFAULT_DEPOSIT_DEVNET_MINT}.`,
+    description: `Optional. Defaults to Solana USDC on mainnet: ${DEFAULT_DEPOSIT_MINT}. On devnet and devnet-private it defaults to devnet USDC: ${DEFAULT_DEPOSIT_DEVNET_MINT}.`,
   }).optional(),
   amount: depositAmountSchema,
   validator: publicKeySchema.openapi({
@@ -142,6 +145,10 @@ export const depositRequestSchema = z.object({
   initVaultIfMissing: z.boolean().optional(),
   initAtasIfMissing: z.boolean().optional(),
   idempotent: z.boolean().optional(),
+  private: z.boolean().openapi({
+    example: true,
+    description: "Optional. Defaults to true. When true, adds the private eATA permission instruction.",
+  }).optional(),
 }).openapi("DepositRequest", {
   example: {
     owner: DEPOSIT_EXAMPLE_OWNER,
@@ -150,6 +157,7 @@ export const depositRequestSchema = z.object({
     initVaultIfMissing: false,
     initAtasIfMissing: true,
     idempotent: true,
+    private: true,
   },
 });
 export type DepositRequest = z.infer<typeof depositRequestSchema>;

--- a/api/src/schema.ts
+++ b/api/src/schema.ts
@@ -30,9 +30,9 @@ export const publicKeySchema = z
     example: "So11111111111111111111111111111111111111112",
   });
 
-export const amountSchema = z.number().int().safe().min(1).openapi({
+export const amountSchema = z.number().int().safe().nonnegative().openapi({
   example: 1000000,
-  description: "Base-unit amount as an integer JSON value with minimum 1.",
+  description: "Base-unit amount as a non-negative integer JSON value.",
 });
 
 export const depositAmountSchema = z.number().int().safe().min(1).openapi({
@@ -87,7 +87,7 @@ export const optionalBooleanSchema = z.preprocess((value) => {
 
 export const clusterSchema = z
   .union([
-    z.enum(["mainnet", "devnet"]),
+    z.enum(["mainnet", "devnet", "mainnet-private", "devnet-private"]),
     z
       .string()
       .url()
@@ -102,7 +102,7 @@ export const clusterSchema = z
   .openapi({
     example: "mainnet",
     description:
-      "Optional. Use `mainnet` for BASE_RPC_URL and EPHEMERAL_RPC_URL, `devnet` for BASE_DEVNET_RPC_URL and EPHEMERAL_DEVNET_RPC_URL, or provide a custom http(s) RPC URL to override the base RPC while keeping the configured ephemeral RPC.",
+      "Optional. Use `mainnet` for BASE_RPC_URL and EPHEMERAL_RPC_URL, `devnet` for BASE_DEVNET_RPC_URL and EPHEMERAL_DEVNET_RPC_URL, `mainnet-private` for BASE_RPC_URL and EPHEMERAL_TEE_RPC_URL, `devnet-private` for BASE_DEVNET_RPC_URL and EPHEMERAL_DEVNET_TEE_RPC_URL, or provide a custom http(s) RPC URL to override the base RPC while keeping the configured ephemeral RPC.",
   });
 
 export const visibilitySchema = z

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -591,10 +591,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@magicblock-labs/ephemeral-rollups-sdk@0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@magicblock-labs/ephemeral-rollups-sdk/-/ephemeral-rollups-sdk-0.15.0.tgz#2260106ac7f6c1c9124d35b59548640ea461ec9f"
-  integrity sha512-zCm/eqFCqVqK1E18WtipxCwNAVTovb+KbEoG0dA8rQtbJSCSki+luMxg4f9vl7tHSGcN4WC6dp0atRgg+/QUIw==
+"@magicblock-labs/ephemeral-rollups-sdk@0.15.3":
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/@magicblock-labs/ephemeral-rollups-sdk/-/ephemeral-rollups-sdk-0.15.3.tgz#40934d8f0f8a3a81d47c5905cc45042d08a3a48a"
+  integrity sha512-UsKrw+3UYpHTvCdCKmvhUBakVWVRq3YHJkMAK0P/ZeAw0BSlij/FVUww0XeVxrjvlsorCm57p5pd16i3EHycBw==
   dependencies:
     "@noble/curves" "^1.4.2"
     "@noble/hashes" "^1.4.0"

--- a/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
+++ b/e-token/src/processor/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
@@ -16,6 +16,8 @@ use ephemeral_spl_api::debug_log;
 use ephemeral_spl_api::instruction::ESplInstruction;
 use ephemeral_spl_api::state::transfer_queue::{queue_views, TransferQueue};
 use ephemeral_spl_api::{consts, require, require_eq_keys, require_n_accounts};
+#[cfg(feature = "logging")]
+use pinocchio::Address;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 #[cfg(not(feature = "no-fees"))]
 use solana_instruction::{AccountMeta, Instruction};
@@ -195,12 +197,17 @@ pub(crate) fn process_with_merge_and_private_transfer_inner(
 
     let total_amount = private_transfer_amount + fee_amount;
 
-    debug_log!(
-        "exact_out:  {}, fee_amount: {}, private_transfer_amount: {}",
-        exact_out,
-        fee_amount,
-        private_transfer_amount
-    );
+    debug_log!({
+        let validator = validator.map(|validator| Address::new_from_array(*validator).to_string());
+        let validator = validator.as_deref().unwrap_or("none");
+        pinocchio_log::log!(
+            "exact_out:  {}, fee_amount: {}, private_transfer_amount: {}, validator: {}",
+            exact_out,
+            fee_amount,
+            private_transfer_amount,
+            validator
+        );
+    });
 
     let actions = {
         let private_transfer = private_transfer_action_encrypted(


### PR DESCRIPTION
## Summary

- Add `mainnet-private` and `devnet-private` cluster handling for TEE RPC endpoints.
- Update private base-to-base transfer lookup table defaults and env examples.
- Expand the private transfer LUT creation script to include USDC/USDT and queue ATA/eATA permission-related accounts.
- Surface send RPC endpoints for ephemeral submissions and improve related API/docs coverage.
- Include validator pubkey in the private transfer debug log when available.