### PR TITLE
feat: create permission for stealthpool

### DIFF
--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -17,6 +17,8 @@ import {
   EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
   HYDRA_PROGRAM_ID,
   magicFeeVaultPdaFromValidator,
+  PERMISSION_PROGRAM_ID,
+  permissionPdaFromAccount,
 } from "@magicblock-labs/ephemeral-rollups-sdk";
 import {
   AddressLookupTableAccount,
@@ -3595,6 +3597,7 @@ describe("app", () => {
     expect(setupInstruction.keys.map(key => key.pubkey.toBase58())).toEqual([
       payer,
       stealthPool,
+      permissionPdaFromAccount(stealthPoolPubkey).toBase58(),
       EPHEMERAL_SPL_TOKEN_PROGRAM_ID.toBase58(),
       delegateBufferPdaFromDelegatedAccountAndOwnerProgram(
         stealthPoolPubkey,
@@ -3604,6 +3607,7 @@ describe("app", () => {
       delegationMetadataPdaFromDelegatedAccount(stealthPoolPubkey).toBase58(),
       DELEGATION_PROGRAM_ID.toBase58(),
       SystemProgram.programId.toBase58(),
+      PERMISSION_PROGRAM_ID.toBase58(),
     ]);
     const handleStorage = createStealthHandleStorage(stealthHandle);
     expect([...setupInstruction.data]).toEqual([

--- a/api/src/lib/solana.ts
+++ b/api/src/lib/solana.ts
@@ -16,6 +16,8 @@ import {
   initRentPdaIx,
   initTransferQueueIx,
   magicFeeVaultPdaFromValidator,
+  PERMISSION_PROGRAM_ID,
+  permissionPdaFromAccount,
   transferSpl,
   undelegateIx,
   withdrawSpl, initVaultIx, initVaultAtaIx, delegateEphemeralAtaIx, deriveVault, deriveEphemeralAta, deriveVaultAta,
@@ -660,6 +662,7 @@ function ensureStealthPoolDelegatedInstruction(
     keys: [
       { pubkey: payer, isSigner: true, isWritable: true },
       { pubkey: stealthPool, isSigner: false, isWritable: true },
+      { pubkey: permissionPdaFromAccount(stealthPool), isSigner: false, isWritable: true },
       { pubkey: EPHEMERAL_SPL_TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
       {
         pubkey: delegateBufferPdaFromDelegatedAccountAndOwnerProgram(
@@ -681,6 +684,7 @@ function ensureStealthPoolDelegatedInstruction(
       },
       { pubkey: DELEGATION_PROGRAM_ID, isSigner: false, isWritable: false },
       { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+      { pubkey: PERMISSION_PROGRAM_ID, isSigner: false, isWritable: false },
     ],
     data,
   });

--- a/e-token-api/src/instruction.rs
+++ b/e-token-api/src/instruction.rs
@@ -111,9 +111,9 @@ pub enum ESplInstruction {
     UpdateStealthPool = 21,
 
     /// 22 - EnsureStealthPoolDelegated: ensure the zeroed stealth-pool PDA
-    ///      exists on base and is delegated. Destination keys are not part of
-    ///      this instruction; they are written later inside the ER via
-    ///      UpdateStealthPool.
+    ///      and its ACL permission PDA exist on base, then ensure the pool is
+    ///      delegated. Destination keys are not part of this instruction; they
+    ///      are written later inside the ER via UpdateStealthPool.
     EnsureStealthPoolDelegated = 22,
 
     /// 23 - InitializeRentPda: initialize the global rent-sponsoring PDA derived from ["rent"]

--- a/e-token/src/processor/ensure_stealth_pool_delegated.rs
+++ b/e-token/src/processor/ensure_stealth_pool_delegated.rs
@@ -1,4 +1,11 @@
-use ephemeral_rollups_pinocchio::{instruction::DelegateAccountCpiBuilder, types::DelegateConfig};
+use ephemeral_rollups_pinocchio::{
+    acl::{
+        consts::PERMISSION_PROGRAM_ID, instruction::CreatePermissionCpiBuilder,
+        pda::permission_pda_from_permissioned_account, types::MembersArgs,
+    },
+    instruction::DelegateAccountCpiBuilder,
+    types::DelegateConfig,
+};
 use ephemeral_spl_api::{
     instructions::EnsureStealthPoolDelegatedArgs,
     require, require_eq_keys, require_n_accounts,
@@ -20,12 +27,14 @@ use wheels::layout::Decodable as _;
 ///
 ///  0: [signer]            - Keypair : Payer.
 ///  1: [writable]          - PDA     : Stealth pool account.
-///  2: []                  - Program : Owner program (this program).
-///  3: [writable]          - PDA     : Buffer account.
-///  4: [writable]          - PDA     : Delegation record account.
-///  5: [writable]          - PDA     : Delegation metadata account.
-///  6: []                  - Program : Delegation program.
-///  7: []                  - Builtin : System program.
+///  2: [writable]          - PDA     : Stealth pool permission account.
+///  3: []                  - Program : Owner program (this program).
+///  4: [writable]          - PDA     : Buffer account.
+///  5: [writable]          - PDA     : Delegation record account.
+///  6: [writable]          - PDA     : Delegation metadata account.
+///  7: []                  - Program : Delegation program.
+///  8: []                  - Builtin : System program.
+///  9: []                  - Program : Permission program (ACL).
 ///
 /// Instruction Data: EnsureStealthPoolDelegatedArgs
 ///
@@ -33,13 +42,15 @@ pub fn process_ensure_stealth_pool_delegated(accounts: &[AccountView], instructi
     let [
         payer_info, // force multi-line
         stealth_pool_info,
+        stealth_pool_permission_info,
         owner_program,
         buffer_acc,
         delegation_record,
         delegation_metadata,
-        _delegation_program,
+        delegation_program_info,
         system_program,
-    ] = require_n_accounts!(accounts, 8);
+        permission_program,
+    ] = require_n_accounts!(accounts, 10);
 
     let args = EnsureStealthPoolDelegatedArgs::decode(instruction_data)?;
 
@@ -50,11 +61,25 @@ pub fn process_ensure_stealth_pool_delegated(accounts: &[AccountView], instructi
     require_eq_keys!(&derived_pool, stealth_pool_info.address(), ProgramError::InvalidSeeds);
 
     let delegation_program = ephemeral_spl_api::program::DELEGATION_PROGRAM_ID;
-    if stealth_pool_info.owned_by(&delegation_program) {
-        return Ok(());
-    }
+    require_eq_keys!(owner_program.address(), &crate::ID, ProgramError::IncorrectProgramId);
+    require_eq_keys!(
+        delegation_program_info.address(),
+        &delegation_program,
+        ProgramError::IncorrectProgramId
+    );
+    require_eq_keys!(
+        system_program.address(),
+        &pinocchio_system::ID,
+        ProgramError::IncorrectProgramId
+    );
+    require_eq_keys!(
+        permission_program.address(),
+        &PERMISSION_PROGRAM_ID,
+        ProgramError::IncorrectProgramId
+    );
 
-    if !stealth_pool_info.owned_by(&crate::ID) {
+    let stealth_pool_delegated = stealth_pool_info.owned_by(&delegation_program);
+    if !stealth_pool_delegated && !stealth_pool_info.owned_by(&crate::ID) {
         require!(stealth_pool_info.lamports() == 0, ProgramError::IllegalOwner);
 
         let rent = Rent::get()?;
@@ -94,18 +119,67 @@ pub fn process_ensure_stealth_pool_delegated(accounts: &[AccountView], instructi
             }
             .invoke_signed(&[signer])?;
         }
-    } else {
+    } else if !stealth_pool_delegated {
         require!(
             stealth_pool_info.data_len() == StealthPool::LEN,
             ProgramError::InvalidAccountData
         );
     }
 
-    require_eq_keys!(owner_program.address(), &crate::ID, ProgramError::IncorrectProgramId);
+    let expected_permission = permission_pda_from_permissioned_account(stealth_pool_info.address());
     require_eq_keys!(
-        system_program.address(),
-        &pinocchio_system::ID,
+        &expected_permission,
+        stealth_pool_permission_info.address(),
+        ProgramError::InvalidSeeds
+    );
+
+    let stealth_pool_permission_exists = stealth_pool_permission_info.lamports() > 0;
+    require!(
+        !stealth_pool_permission_exists || stealth_pool_permission_info.owned_by(&PERMISSION_PROGRAM_ID),
         ProgramError::IncorrectProgramId
+    );
+
+    if !stealth_pool_permission_exists {
+        if handle.len() <= StealthPool::MAX_HANDLE_SEED_BYTES {
+            let seeds = [StealthPool::SEED, handle];
+            CreatePermissionCpiBuilder::new(
+                stealth_pool_info,
+                stealth_pool_permission_info,
+                payer_info,
+                system_program,
+                &PERMISSION_PROGRAM_ID,
+            )
+            .members(MembersArgs { members: Some(&[]) })
+            .seeds(&seeds)
+            .bump(bump)
+            .invoke()?;
+        } else {
+            let seeds = [
+                StealthPool::SEED,
+                &handle[..StealthPool::MAX_HANDLE_SEED_BYTES],
+                &handle[StealthPool::MAX_HANDLE_SEED_BYTES..],
+            ];
+            CreatePermissionCpiBuilder::new(
+                stealth_pool_info,
+                stealth_pool_permission_info,
+                payer_info,
+                system_program,
+                &PERMISSION_PROGRAM_ID,
+            )
+            .members(MembersArgs { members: Some(&[]) })
+            .seeds(&seeds)
+            .bump(bump)
+            .invoke()?;
+        }
+    }
+
+    if stealth_pool_delegated {
+        return Ok(());
+    }
+
+    require!(
+        stealth_pool_info.data_len() == StealthPool::LEN,
+        ProgramError::InvalidAccountData
     );
 
     let config = DelegateConfig {

--- a/e-token/tests/ensure_stealth_pool_delegated.rs
+++ b/e-token/tests/ensure_stealth_pool_delegated.rs
@@ -1,0 +1,133 @@
+use ephemeral_rollups_pinocchio::{
+    acl::{permission_pda_from_permissioned_account, PERMISSION_PROGRAM_ID},
+    pda::{
+        delegate_buffer_pda_from_delegated_account_and_owner_program, delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+    },
+};
+use ephemeral_spl_api::{
+    instruction,
+    instructions::EnsureStealthPoolDelegatedArgs,
+    state::{stealth_pool::StealthPool, RawType},
+    ID as PROGRAM,
+};
+use solana_account::Account;
+use solana_instruction::{AccountMeta, Instruction};
+use solana_program::rent::Rent;
+use solana_program_test::tokio;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+use wheels::layout::Encodable as _;
+
+mod common;
+mod utils;
+
+fn build_ensure_stealth_pool_delegated_ix(
+    payer: solana_pubkey::Pubkey,
+    handle: &[u8],
+) -> (solana_pubkey::Pubkey, solana_pubkey::Pubkey, Instruction) {
+    let (stealth_pool, _) = StealthPool::find_pda(handle).unwrap();
+    let stealth_pool_permission = permission_pda_from_permissioned_account(&stealth_pool);
+    let buffer_pda = delegate_buffer_pda_from_delegated_account_and_owner_program(&stealth_pool, &PROGRAM);
+    let delegation_record_pda = delegation_record_pda_from_delegated_account(&stealth_pool);
+    let delegation_metadata_pda = delegation_metadata_pda_from_delegated_account(&stealth_pool);
+
+    let data = instruction::ESplInstruction::EnsureStealthPoolDelegated.with_data(
+        &EnsureStealthPoolDelegatedArgs {
+            handle: StealthPool::store_handle(handle).unwrap(),
+            validator: None,
+        }
+        .encode()
+        .unwrap(),
+    );
+
+    (
+        stealth_pool,
+        stealth_pool_permission,
+        Instruction {
+            program_id: PROGRAM,
+            accounts: vec![
+                AccountMeta::new(payer, true),
+                AccountMeta::new(stealth_pool, false),
+                AccountMeta::new(stealth_pool_permission, false),
+                AccountMeta::new_readonly(PROGRAM, false),
+                AccountMeta::new(buffer_pda, false),
+                AccountMeta::new(delegation_record_pda, false),
+                AccountMeta::new(delegation_metadata_pda, false),
+                AccountMeta::new_readonly(ephemeral_rollups_pinocchio::ID, false),
+                AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+                AccountMeta::new_readonly(PERMISSION_PROGRAM_ID, false),
+            ],
+            data,
+        },
+    )
+}
+
+#[tokio::test]
+async fn ensure_stealth_pool_delegated_creates_pool_permission() {
+    let mut context = utils::start_program_test(PROGRAM).await;
+    let payer_kp = utils::fixed_payer_keypair();
+    let payer = payer_kp.pubkey();
+    let handle = b"ensure-stealth-pool.block";
+    let (stealth_pool, stealth_pool_permission, ix) = build_ensure_stealth_pool_delegated_ix(payer, handle);
+
+    let tx = Transaction::new_signed_with_payer(&[ix.clone()], Some(&payer), &[&payer_kp], context.last_blockhash);
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    let stealth_pool_account = context
+        .banks_client
+        .get_account(stealth_pool)
+        .await
+        .unwrap()
+        .expect("stealth pool account must exist");
+    assert_eq!(
+        stealth_pool_account.owner,
+        ephemeral_spl_api::program::DELEGATION_PROGRAM_ID
+    );
+
+    let permission_account = context
+        .banks_client
+        .get_account(stealth_pool_permission)
+        .await
+        .unwrap()
+        .expect("stealth pool permission account must exist");
+    assert_eq!(permission_account.owner, PERMISSION_PROGRAM_ID);
+
+    let blockhash = context.get_new_latest_blockhash().await.unwrap();
+    let tx = Transaction::new_signed_with_payer(&[ix], Some(&payer), &[&payer_kp], blockhash);
+    context.banks_client.process_transaction(tx).await.unwrap();
+}
+
+#[tokio::test]
+async fn ensure_stealth_pool_delegated_creates_permission_when_pool_is_already_delegated() {
+    let mut context = utils::start_program_test(PROGRAM).await;
+    let payer_kp = utils::fixed_payer_keypair();
+    let payer = payer_kp.pubkey();
+    let handle = b"ensure-stealth-pool-existing.block";
+    let (stealth_pool, stealth_pool_permission, ix) = build_ensure_stealth_pool_delegated_ix(payer, handle);
+    let data = vec![0u8; StealthPool::LEN];
+    let rent = Rent::default();
+
+    context.set_account(
+        &stealth_pool,
+        &Account {
+            lamports: rent.minimum_balance(data.len()),
+            data,
+            owner: ephemeral_spl_api::program::DELEGATION_PROGRAM_ID,
+            executable: false,
+            rent_epoch: 0,
+        }
+        .into(),
+    );
+
+    let tx = Transaction::new_signed_with_payer(&[ix], Some(&payer), &[&payer_kp], context.last_blockhash);
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    let permission_account = context
+        .banks_client
+        .get_account(stealth_pool_permission)
+        .await
+        .unwrap()
+        .expect("stealth pool permission account must exist");
+    assert_eq!(permission_account.owner, PERMISSION_PROGRAM_ID);
+}


### PR DESCRIPTION
This PR only creates the `permission account` for stealth pools during `EnsureStealthPoolDelegated`, but does not add delegate/reset/undelegate flows for that permission account. I’m not sure those lifecycle operations are needed. 

My understanding is that the TEE-side queue-filtering service only needs the permission account to exist so that it can enforce ACL behavior.

**Question: should we add authority the permission members?**
