### PR TITLE
minor: add stealth-pool authority to perm members and increase user-handle size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,6 +1838,7 @@ name = "ephemeral-spl-api"
 version = "0.0.0"
 dependencies = [
  "bytemuck",
+ "const-crypto",
  "ephemeral-rollups-pinocchio",
  "pinocchio 0.10.2",
  "pinocchio-log",

--- a/api/README.md
+++ b/api/README.md
@@ -48,7 +48,7 @@ Important behavior:
 - `deposit` always uses `escrowIndex = 0`
 - `withdraw` uses `withdrawSpl(...)`
 - `transfer` uses `transferSpl(...)`
-- stealth handles are derived exactly as provided from UTF-8 bytes, capped at 64 bytes and split into 32-byte PDA seed chunks when needed
+- stealth handles are derived exactly as provided from UTF-8 bytes and capped at 255 bytes; handles over 64 bytes use a bounded hash seed for PDA derivation
 - `transfer-stealth` uses the derived stealth-pool PDA as the virtual destination owner
 - every SPL endpoint accepts an optional `cluster` parameter
 - `cluster=mainnet` uses `BASE_RPC_URL` and `EPHEMERAL_RPC_URL`
@@ -703,7 +703,7 @@ Relevant fields:
 
 Builds an unsigned base-chain transaction that initializes or updates a stealth pool. The caller provides the exact handle string, payer, authority, and 1 to 10 destination owner keys.
 
-The API does not canonicalize the handle. For example, `John.Doe@magicblock.id` and `john.doe@magicblock.id` derive different pools. The update transaction stores the exact handle bytes in the stealth-pool PDA for off-chain display/lookup, capped at 64 UTF-8 bytes.
+The API does not canonicalize the handle. For example, `John.Doe@magicblock.id` and `john.doe@magicblock.id` derive different pools. The update transaction stores the exact handle bytes in the stealth-pool PDA for off-chain display/lookup, capped at 255 UTF-8 bytes.
 
 Temporary integration note: this setup transaction is currently built for base so the end-to-end handle flow can be exercised without ER auth. The ER is expected to read/clone the pool state for private transfer resolution.
 

--- a/api/package.json
+++ b/api/package.json
@@ -16,6 +16,7 @@
     "@hono/zod-openapi": "^1.0.2",
     "@magicblock-labs/ephemeral-rollups-sdk": "0.15.5",
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "@noble/hashes": "1.8.0",
     "@scalar/hono-api-reference": "^0.9.13",
     "@solana/web3.js": "^1.98.0",
     "hono": "^4.9.6",

--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -20,6 +20,7 @@ import {
   PERMISSION_PROGRAM_ID,
   permissionPdaFromAccount,
 } from "@magicblock-labs/ephemeral-rollups-sdk";
+import { sha256 } from "@noble/hashes/sha256";
 import {
   AddressLookupTableAccount,
   AddressLookupTableProgram,
@@ -62,7 +63,7 @@ const stealthPool = deriveStealthPoolFromHandle(stealthHandle)[0].toBase58();
 
 function createStealthHandleStorage(handle: string) {
   const handleBytes = Buffer.from(handle, "utf8");
-  const storage = Buffer.alloc(65);
+  const storage = Buffer.alloc(256);
   storage[0] = handleBytes.length;
   storage.set(handleBytes, 1);
   return storage;
@@ -3584,7 +3585,7 @@ describe("app", () => {
     expect(json).not.toHaveProperty("handleHash");
     expect(json.requiredSigners.sort()).toEqual([authority, payer].sort());
     expect(json.setupTransaction.sendTo).toBe("base");
-    expect(json.setupTransaction.requiredSigners).toEqual([payer]);
+    expect(json.setupTransaction.requiredSigners.sort()).toEqual([authority, payer].sort());
 
     const setupTransaction = Transaction.from(
       Buffer.from(json.setupTransaction.transactionBase64, "base64"),
@@ -3608,6 +3609,7 @@ describe("app", () => {
       DELEGATION_PROGRAM_ID.toBase58(),
       SystemProgram.programId.toBase58(),
       PERMISSION_PROGRAM_ID.toBase58(),
+      authority,
     ]);
     const handleStorage = createStealthHandleStorage(stealthHandle);
     expect([...setupInstruction.data]).toEqual([
@@ -3629,13 +3631,13 @@ describe("app", () => {
       authority,
       SystemProgram.programId.toBase58(),
     ]);
-    expect([...instruction.data.subarray(0, 68)]).toEqual([
+    expect([...instruction.data.subarray(0, 259)]).toEqual([
       21,
       ...handleStorage,
       1,
       1,
     ]);
-    const destinationsOffset = 68;
+    const destinationsOffset = 259;
     expect(instruction.data.subarray(destinationsOffset).toString("hex")).toBe(
       new PublicKey(destination).toBuffer().toString("hex"),
     );
@@ -3674,7 +3676,7 @@ describe("app", () => {
     expect(json.destinations).toBeUndefined();
   });
 
-  it("derives stealth pool PDAs with two handle seeds after 32 bytes", () => {
+  it("derives stealth pool PDAs with chunked handle seeds after 32 bytes", () => {
     const longHandle = "john.doe-long-handle-more-than-32.block";
     const handleBytes = Buffer.from(longHandle, "utf8");
     expect(handleBytes.length).toBeGreaterThan(32);
@@ -3685,6 +3687,26 @@ describe("app", () => {
         Buffer.from("stealth_pool"),
         handleBytes.subarray(0, 32),
         handleBytes.subarray(32),
+      ],
+      EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
+    );
+
+    expect(actual.toBase58()).toBe(expected.toBase58());
+  });
+
+  it("derives stealth pool PDAs for 255-byte handles", () => {
+    const longHandle = "a".repeat(255);
+    const handleBytes = Buffer.from(longHandle, "utf8");
+    const handleHashSeed = Buffer.from(
+      sha256(Buffer.concat([Buffer.from("stealth_pool_handle"), handleBytes])),
+    );
+
+    const [actual] = deriveStealthPoolFromHandle(longHandle);
+    const [expected] = PublicKey.findProgramAddressSync(
+      [
+        Buffer.from("stealth_pool"),
+        handleBytes.subarray(0, 32),
+        handleHashSeed,
       ],
       EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
     );

--- a/api/src/lib/solana.ts
+++ b/api/src/lib/solana.ts
@@ -22,6 +22,7 @@ import {
   undelegateIx,
   withdrawSpl, initVaultIx, initVaultAtaIx, delegateEphemeralAtaIx, deriveVault, deriveEphemeralAta, deriveVaultAta,
 } from "@magicblock-labs/ephemeral-rollups-sdk";
+import { sha256 } from "@noble/hashes/sha256";
 import {
   Connection,
   Keypair,
@@ -103,10 +104,12 @@ const SOLANA_WIRE_TRANSACTION_SIZE_LIMIT = 1232;
 const UPDATE_STEALTH_POOL_DISCRIMINATOR = 21;
 const ENSURE_STEALTH_POOL_DELEGATED_DISCRIMINATOR = 22;
 const STEALTH_POOL_SEED = Buffer.from("stealth_pool");
+const STEALTH_POOL_LONG_HANDLE_HASH_DOMAIN = Buffer.from("stealth_pool_handle");
 const STEALTH_POOL_SPLIT_ACROSS_KEYS_FLAG = 1 << 0;
-const MAX_STEALTH_HANDLE_BYTES = 64;
+const MAX_STEALTH_HANDLE_BYTES = 255;
 const STEALTH_HANDLE_STORAGE_BYTES = 1 + MAX_STEALTH_HANDLE_BYTES;
 const MAX_STEALTH_HANDLE_SEED_BYTES = 32;
+const MAX_INLINE_STEALTH_HANDLE_SEED_BYTES = 2 * MAX_STEALTH_HANDLE_SEED_BYTES;
 // Keep these defaults aligned with scripts/create-private-transfer-lut.js. Updating them requires a redeploy.
 const PRIVATE_BASE_TO_BASE_TRANSFER_LOOKUP_TABLES = {
   mainnet: new PublicKey("54M1BrqVSg1UGTmhH44gQPsPVyuMpmcVBkaY2wYNSVZB"),
@@ -537,13 +540,15 @@ function encodeStealthHandleStorage(handleBytes: Uint8Array) {
 
 function deriveStealthPoolFromHandleBytes(handleBytes: Uint8Array): [PublicKey, number] {
   const handleSeed = Buffer.from(handleBytes);
-  const seeds = handleBytes.length <= MAX_STEALTH_HANDLE_SEED_BYTES
-    ? [STEALTH_POOL_SEED, handleSeed]
+  const handleSeeds = handleSeed.length <= MAX_STEALTH_HANDLE_SEED_BYTES
+    ? [handleSeed]
     : [
-        STEALTH_POOL_SEED,
         handleSeed.subarray(0, MAX_STEALTH_HANDLE_SEED_BYTES),
-        handleSeed.subarray(MAX_STEALTH_HANDLE_SEED_BYTES),
+        handleSeed.length <= MAX_INLINE_STEALTH_HANDLE_SEED_BYTES
+          ? handleSeed.subarray(MAX_STEALTH_HANDLE_SEED_BYTES)
+          : Buffer.from(sha256(Buffer.concat([STEALTH_POOL_LONG_HANDLE_HASH_DOMAIN, handleSeed]))),
       ];
+  const seeds = [STEALTH_POOL_SEED, ...handleSeeds];
   return PublicKey.findProgramAddressSync(
     seeds,
     EPHEMERAL_SPL_TOKEN_PROGRAM_ID,
@@ -606,7 +611,7 @@ function updateStealthPoolInstruction(
   flags: number,
 ) {
   if (handleStorage.length !== STEALTH_HANDLE_STORAGE_BYTES) {
-    throw new ApiError(400, "INVALID_STEALTH_HANDLE", "handle storage must be 65 bytes");
+    throw new ApiError(400, "INVALID_STEALTH_HANDLE", "handle storage must be 256 bytes");
   }
 
   const data = Buffer.alloc(1 + STEALTH_HANDLE_STORAGE_BYTES + 1 + 1 + destinations.length * 32);
@@ -640,11 +645,12 @@ function updateStealthPoolInstruction(
 function ensureStealthPoolDelegatedInstruction(
   payer: PublicKey,
   stealthPool: PublicKey,
+  authority: PublicKey,
   handleStorage: Uint8Array,
   validator?: PublicKey,
 ) {
   if (handleStorage.length !== STEALTH_HANDLE_STORAGE_BYTES) {
-    throw new ApiError(400, "INVALID_STEALTH_HANDLE", "handle storage must be 65 bytes");
+    throw new ApiError(400, "INVALID_STEALTH_HANDLE", "handle storage must be 256 bytes");
   }
 
   const data = Buffer.alloc(1 + STEALTH_HANDLE_STORAGE_BYTES + (validator ? 32 : 0));
@@ -685,6 +691,7 @@ function ensureStealthPoolDelegatedInstruction(
       { pubkey: DELEGATION_PROGRAM_ID, isSigner: false, isWritable: false },
       { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
       { pubkey: PERMISSION_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: authority, isSigner: true, isWritable: false },
     ],
     data,
   });
@@ -1638,6 +1645,7 @@ export async function buildUpdateStealthPoolTransaction(
       ensureStealthPoolDelegatedInstruction(
         payer,
         stealthPool,
+        authority,
         handleStorage,
         validator,
       ),

--- a/api/src/routes/spl/spl.schemas.ts
+++ b/api/src/routes/spl/spl.schemas.ts
@@ -8,7 +8,7 @@ const DEFAULT_DEPOSIT_DEVNET_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncD
 const DEPOSIT_EXAMPLE_OWNER = "3rXKwQ1kpjBd5tdcco32qsvqUh1BnZjcYnS5kYrP7AYE";
 const TRANSFER_EXAMPLE_TO = "Bt9oNR5cCtnfuMmXgWELd6q5i974PdEMQDUE55nBC57L";
 const BALANCE_EXAMPLE_ADDRESS = "Bt9oNR5cCtnfuMmXgWELd6q5i974PdEMQDUE55nBC57L";
-const MAX_STEALTH_HANDLE_BYTES = 64;
+const MAX_STEALTH_HANDLE_BYTES = 255;
 const textEncoder = new TextEncoder();
 
 export const transferFeesSchema = z.object({
@@ -159,7 +159,7 @@ export const stealthHandleSchema = z.string().min(1).refine(
   `Handle must be ${MAX_STEALTH_HANDLE_BYTES} UTF-8 bytes or fewer.`,
 ).openapi({
   example: "john.doe@magicblock.id",
-  description: "Exact canonical handle string, up to 64 UTF-8 bytes. The API derives the stealth-pool PDA from these UTF-8 bytes as-is; it does not trim, lowercase, or normalize.",
+  description: "Exact canonical handle string, up to 255 UTF-8 bytes. The API derives the stealth-pool PDA from these UTF-8 bytes as-is; it does not trim, lowercase, or normalize.",
 });
 
 export const stealthPoolRequestSchema = z.object({

--- a/e-token-api/Cargo.toml
+++ b/e-token-api/Cargo.toml
@@ -19,6 +19,7 @@ solana-address = { workspace = true, features = ["bytemuck"] }
 solana-signature = { workspace = true, features = ["bytemuck"] }
 ephemeral-rollups-pinocchio = { workspace = true }
 bytemuck = { workspace = true }
+const-crypto = { workspace = true }
 static_assertions = { workspace = true }
 wheels = { workspace = true }
 

--- a/e-token-api/src/instruction.rs
+++ b/e-token-api/src/instruction.rs
@@ -113,7 +113,8 @@ pub enum ESplInstruction {
     /// 22 - EnsureStealthPoolDelegated: ensure the zeroed stealth-pool PDA
     ///      and its ACL permission PDA exist on base, then ensure the pool is
     ///      delegated. Destination keys are not part of this instruction; they
-    ///      are written later inside the ER via UpdateStealthPool.
+    ///      are written later inside the ER via UpdateStealthPool. The pool
+    ///      authority must sign and is added to the ACL permission account.
     EnsureStealthPoolDelegated = 22,
 
     /// 23 - InitializeRentPda: initialize the global rent-sponsoring PDA derived from ["rent"]

--- a/e-token-api/src/instructions/ensure_stealth_pool_delegated.rs
+++ b/e-token-api/src/instructions/ensure_stealth_pool_delegated.rs
@@ -3,8 +3,8 @@ use wheels::variable_offset_layout;
 
 #[variable_offset_layout(buffer_offset = 1, option = implicit)]
 pub struct EnsureStealthPoolDelegatedArgs {
-    pub handle: [u8; 65],
+    pub handle: [u8; 256],
     pub validator: Option<Address>,
 }
 
-static_assertions::const_assert!(matches!(EnsureStealthPoolDelegatedArgs::DATA_LENS, [65, 97]));
+static_assertions::const_assert!(matches!(EnsureStealthPoolDelegatedArgs::DATA_LENS, [256, 288]));

--- a/e-token-api/src/instructions/update_stealth_pool.rs
+++ b/e-token-api/src/instructions/update_stealth_pool.rs
@@ -5,12 +5,12 @@ use wheels::variable_offset_layout;
 
 #[variable_offset_layout(buffer_offset = 1)]
 pub struct UpdateStealthPoolArgs {
-    pub handle: [u8; 65],
+    pub handle: [u8; 256],
     // TODO (snawaz): support enum based flags in data-layout
     pub flags: u8,
     #[flexible = 1]
     pub destinations: Vec<Address>,
 }
 
-static_assertions::const_assert!(UpdateStealthPoolArgs::DATA_LEN_RANGE.0 == 67);
-static_assertions::const_assert!(UpdateStealthPoolArgs::DATA_LEN_RANGE.1 == 8227);
+static_assertions::const_assert!(UpdateStealthPoolArgs::DATA_LEN_RANGE.0 == 258);
+static_assertions::const_assert!(UpdateStealthPoolArgs::DATA_LEN_RANGE.1 == 8418);

--- a/e-token-api/src/state/stealth_pool.rs
+++ b/e-token-api/src/state/stealth_pool.rs
@@ -1,9 +1,10 @@
 use bytemuck::{Pod, Zeroable};
+use const_crypto::sha2::Sha256;
 use pinocchio::error::ProgramError;
-use solana_address::Address;
+use solana_address::{address_eq, Address};
 
 use crate::{
-    require, require_eq_keys,
+    require,
     state::{Initializable, RawType},
 };
 
@@ -26,8 +27,8 @@ pub struct StealthPool {
     pub authority: Address,
     //
     // Exact UTF-8 handle bytes used to derive this PDA. Byte 0 stores the
-    // handle length, followed by up to 64 handle bytes.
-    pub handle: [u8; 65],
+    // handle length, followed by up to 255 handle bytes.
+    pub handle: [u8; 256],
     pub destination_count: u8,
     pub destinations: [Address; 10],
 }
@@ -52,10 +53,14 @@ impl StealthPool {
     pub const DISCRIMINATOR: [u8; 8] = *b"stpool@1";
 
     pub const SEED: &'static [u8] = b"stealth_pool";
+    pub const LONG_HANDLE_HASH_DOMAIN: &'static [u8] = b"stealth_pool_handle";
 
-    pub const MAX_HANDLE_BYTES: usize = 64;
+    pub const MAX_HANDLE_BYTES: usize = u8::MAX as usize;
     pub const HANDLE_STORAGE_LEN: usize = 1 + Self::MAX_HANDLE_BYTES;
     pub const MAX_HANDLE_SEED_BYTES: usize = 32;
+    pub const MAX_INLINE_HANDLE_SEED_BYTES: usize = 2 * Self::MAX_HANDLE_SEED_BYTES;
+    pub const MAX_PDA_SEEDS: usize = 3;
+    pub const MAX_PDA_SIGNER_SEEDS: usize = Self::MAX_PDA_SEEDS + 1;
 
     pub const MAX_DESTINATIONS: usize = 10;
 
@@ -70,7 +75,7 @@ impl StealthPool {
     }
 
     #[inline(always)]
-    pub fn handle_from_storage(storage: &[u8; 65]) -> Result<&[u8], ProgramError> {
+    pub fn handle_from_storage(storage: &[u8; Self::HANDLE_STORAGE_LEN]) -> Result<&[u8], ProgramError> {
         let len = storage[0] as usize;
         require!(
             len != 0 && len <= Self::MAX_HANDLE_BYTES,
@@ -81,7 +86,7 @@ impl StealthPool {
     }
 
     #[inline(always)]
-    pub fn store_handle(handle: &[u8]) -> Result<[u8; 65], ProgramError> {
+    pub fn store_handle(handle: &[u8]) -> Result<[u8; Self::HANDLE_STORAGE_LEN], ProgramError> {
         Self::validate_handle(handle)?;
 
         let mut storage = [0u8; Self::HANDLE_STORAGE_LEN];
@@ -91,44 +96,142 @@ impl StealthPool {
     }
 
     #[inline(always)]
-    pub fn derive_pda(handle: &[u8], bump_seed: u8) -> Result<Address, ProgramError> {
+    pub fn long_handle_hash_seed(handle: &[u8]) -> Result<[u8; 32], ProgramError> {
         Self::validate_handle(handle)?;
-        let bump = [bump_seed];
 
-        if handle.len() <= Self::MAX_HANDLE_SEED_BYTES {
-            Ok(Address::create_program_address(
-                &[Self::SEED, handle, &bump],
-                &crate::ID,
-            )?)
+        Ok(Sha256::new()
+            .update(Self::LONG_HANDLE_HASH_DOMAIN)
+            .update(handle)
+            .finalize())
+    }
+
+    #[inline(always)]
+    pub fn seed_slices<'a>(
+        handle: &'a [u8],
+        long_handle_hash_seed: &'a mut [u8; 32],
+        out: &'a mut [&'a [u8]; Self::MAX_PDA_SEEDS],
+    ) -> Result<&'a [&'a [u8]], ProgramError> {
+        let hash_seed = if handle.len() > Self::MAX_INLINE_HANDLE_SEED_BYTES {
+            *long_handle_hash_seed = Self::long_handle_hash_seed(handle)?;
+            Some(&*long_handle_hash_seed)
         } else {
-            Ok(Address::create_program_address(
-                &[
-                    Self::SEED,
-                    &handle[..Self::MAX_HANDLE_SEED_BYTES],
-                    &handle[Self::MAX_HANDLE_SEED_BYTES..],
-                    &bump,
-                ],
-                &crate::ID,
-            )?)
+            None
+        };
+        Self::seed_slices_with_hash(handle, hash_seed, out)
+    }
+
+    #[inline(always)]
+    pub fn seed_slices_with_hash<'a>(
+        handle: &'a [u8],
+        long_handle_hash_seed: Option<&'a [u8; 32]>,
+        out: &'a mut [&'a [u8]; Self::MAX_PDA_SEEDS],
+    ) -> Result<&'a [&'a [u8]], ProgramError> {
+        Self::validate_handle(handle)?;
+
+        out[0] = Self::SEED;
+        if handle.len() <= Self::MAX_HANDLE_SEED_BYTES {
+            out[1] = handle;
+            return Ok(&out[..2]);
         }
+
+        out[1] = &handle[..Self::MAX_HANDLE_SEED_BYTES];
+        if handle.len() <= Self::MAX_INLINE_HANDLE_SEED_BYTES {
+            out[2] = &handle[Self::MAX_HANDLE_SEED_BYTES..];
+        } else {
+            let hash_seed = long_handle_hash_seed.ok_or(ProgramError::InvalidInstructionData)?;
+            let hash_seed: &'a [u8] = &hash_seed[..];
+            out[2] = hash_seed;
+        }
+
+        Ok(&out[..3])
+    }
+
+    #[inline(always)]
+    pub fn seed_slices_with_bump<'a>(
+        handle: &'a [u8],
+        bump: &'a [u8],
+        long_handle_hash_seed: &'a mut [u8; 32],
+        out: &'a mut [&'a [u8]; Self::MAX_PDA_SIGNER_SEEDS],
+    ) -> Result<&'a [&'a [u8]], ProgramError> {
+        let hash_seed = if handle.len() > Self::MAX_INLINE_HANDLE_SEED_BYTES {
+            *long_handle_hash_seed = Self::long_handle_hash_seed(handle)?;
+            Some(&*long_handle_hash_seed)
+        } else {
+            None
+        };
+        Self::seed_slices_with_bump_and_hash(handle, bump, hash_seed, out)
+    }
+
+    #[inline(always)]
+    pub fn seed_slices_with_bump_and_hash<'a>(
+        handle: &'a [u8],
+        bump: &'a [u8],
+        long_handle_hash_seed: Option<&'a [u8; 32]>,
+        out: &'a mut [&'a [u8]; Self::MAX_PDA_SIGNER_SEEDS],
+    ) -> Result<&'a [&'a [u8]], ProgramError> {
+        Self::validate_handle(handle)?;
+
+        out[0] = Self::SEED;
+        if handle.len() <= Self::MAX_HANDLE_SEED_BYTES {
+            out[1] = handle;
+            out[2] = bump;
+            return Ok(&out[..3]);
+        }
+
+        out[1] = &handle[..Self::MAX_HANDLE_SEED_BYTES];
+        if handle.len() <= Self::MAX_INLINE_HANDLE_SEED_BYTES {
+            out[2] = &handle[Self::MAX_HANDLE_SEED_BYTES..];
+        } else {
+            let hash_seed = long_handle_hash_seed.ok_or(ProgramError::InvalidInstructionData)?;
+            let hash_seed: &'a [u8] = &hash_seed[..];
+            out[2] = hash_seed;
+        }
+        out[3] = bump;
+
+        Ok(&out[..4])
+    }
+
+    #[inline(always)]
+    pub fn derive_pda(handle: &[u8], bump_seed: u8) -> Result<Address, ProgramError> {
+        let bump = [bump_seed];
+        let mut long_handle_hash_seed = [0u8; 32];
+        let mut seed_buf: [&[u8]; Self::MAX_PDA_SIGNER_SEEDS] = [&[]; Self::MAX_PDA_SIGNER_SEEDS];
+        let seeds = Self::seed_slices_with_bump(handle, &bump, &mut long_handle_hash_seed, &mut seed_buf)?;
+
+        Ok(Address::create_program_address(seeds, &crate::ID)?)
+    }
+
+    #[inline(always)]
+    pub fn derive_pda_with_hash(
+        handle: &[u8],
+        bump_seed: u8,
+        long_handle_hash_seed: Option<&[u8; 32]>,
+    ) -> Result<Address, ProgramError> {
+        let bump = [bump_seed];
+        let mut seed_buf: [&[u8]; Self::MAX_PDA_SIGNER_SEEDS] = [&[]; Self::MAX_PDA_SIGNER_SEEDS];
+        let seeds = Self::seed_slices_with_bump_and_hash(handle, &bump, long_handle_hash_seed, &mut seed_buf)?;
+
+        Ok(Address::create_program_address(seeds, &crate::ID)?)
     }
 
     #[inline(always)]
     pub fn find_pda(handle: &[u8]) -> Result<(Address, u8), ProgramError> {
-        Self::validate_handle(handle)?;
+        let mut long_handle_hash_seed = [0u8; 32];
+        let mut seed_buf: [&[u8]; Self::MAX_PDA_SEEDS] = [&[]; Self::MAX_PDA_SEEDS];
+        let seeds = Self::seed_slices(handle, &mut long_handle_hash_seed, &mut seed_buf)?;
 
-        if handle.len() <= Self::MAX_HANDLE_SEED_BYTES {
-            Ok(Address::find_program_address(&[Self::SEED, handle], &crate::ID))
-        } else {
-            Ok(Address::find_program_address(
-                &[
-                    Self::SEED,
-                    &handle[..Self::MAX_HANDLE_SEED_BYTES],
-                    &handle[Self::MAX_HANDLE_SEED_BYTES..],
-                ],
-                &crate::ID,
-            ))
-        }
+        Ok(Address::find_program_address(seeds, &crate::ID))
+    }
+
+    #[inline(always)]
+    pub fn find_pda_with_hash(
+        handle: &[u8],
+        long_handle_hash_seed: Option<&[u8; 32]>,
+    ) -> Result<(Address, u8), ProgramError> {
+        let mut seed_buf: [&[u8]; Self::MAX_PDA_SEEDS] = [&[]; Self::MAX_PDA_SEEDS];
+        let seeds = Self::seed_slices_with_hash(handle, long_handle_hash_seed, &mut seed_buf)?;
+
+        Ok(Address::find_program_address(seeds, &crate::ID))
     }
 
     #[inline(always)]
@@ -137,7 +240,7 @@ impl StealthPool {
 
         let derived = Self::derive_pda(self.handle_bytes(), self.bump)?;
 
-        require_eq_keys!(&derived, address_of_self, ProgramError::InvalidSeeds);
+        require!(address_eq(&derived, address_of_self), ProgramError::InvalidSeeds);
 
         Ok(())
     }
@@ -187,7 +290,39 @@ impl StealthPoolFlags {
 
 #[cfg(test)]
 mod tests {
-    use super::StealthPoolFlags;
+    use super::{StealthPool, StealthPoolFlags};
+
+    #[test]
+    fn stealth_pool_handle_storage_accepts_255_bytes() {
+        let handle = [b'a'; StealthPool::MAX_HANDLE_BYTES];
+        let storage = StealthPool::store_handle(&handle).unwrap();
+
+        assert_eq!(storage[0] as usize, StealthPool::MAX_HANDLE_BYTES);
+        assert_eq!(&storage[1..], &handle);
+        assert_eq!(StealthPool::handle_from_storage(&storage).unwrap(), &handle);
+    }
+
+    #[test]
+    fn stealth_pool_handle_storage_rejects_more_than_255_bytes() {
+        let handle = [b'a'; StealthPool::MAX_HANDLE_BYTES + 1];
+
+        assert!(StealthPool::store_handle(&handle).is_err());
+        assert!(StealthPool::find_pda(&handle).is_err());
+    }
+
+    #[test]
+    fn stealth_pool_pda_seeds_hash_255_byte_handles() {
+        let handle = [b'a'; StealthPool::MAX_HANDLE_BYTES];
+        let expected_hash = StealthPool::long_handle_hash_seed(&handle).unwrap();
+        let mut long_handle_hash_seed = [0u8; 32];
+        let mut seeds = [&[][..]; StealthPool::MAX_PDA_SEEDS];
+        let seeds = StealthPool::seed_slices(&handle, &mut long_handle_hash_seed, &mut seeds).unwrap();
+
+        assert_eq!(seeds.len(), StealthPool::MAX_PDA_SEEDS);
+        assert_eq!(seeds[0], StealthPool::SEED);
+        assert_eq!(seeds[1], &handle[..StealthPool::MAX_HANDLE_SEED_BYTES]);
+        assert_eq!(seeds[2], &expected_hash);
+    }
 
     #[test]
     fn stealth_pool_flags_accept_empty_and_known_bits() {

--- a/e-token/src/processor/ensure_stealth_pool_delegated.rs
+++ b/e-token/src/processor/ensure_stealth_pool_delegated.rs
@@ -1,15 +1,18 @@
 use ephemeral_rollups_pinocchio::{
     acl::{
-        consts::PERMISSION_PROGRAM_ID, instruction::CreatePermissionCpiBuilder,
-        pda::permission_pda_from_permissioned_account, types::MembersArgs,
+        consts::PERMISSION_PROGRAM_ID,
+        instruction::CreatePermissionCpiBuilder,
+        pda::permission_pda_from_permissioned_account,
+        types::{Member, MemberFlags, MembersArgs},
     },
     instruction::DelegateAccountCpiBuilder,
     types::DelegateConfig,
+    utils::make_seed_buf,
 };
 use ephemeral_spl_api::{
     instructions::EnsureStealthPoolDelegatedArgs,
     require, require_eq_keys, require_n_accounts,
-    state::{stealth_pool::StealthPool, RawType},
+    state::{stealth_pool::StealthPool, Initializable, RawType},
 };
 use pinocchio::{
     cpi::{Seed, Signer},
@@ -35,6 +38,7 @@ use wheels::layout::Decodable as _;
 ///  7: []                  - Program : Delegation program.
 ///  8: []                  - Builtin : System program.
 ///  9: []                  - Program : Permission program (ACL).
+/// 10: [signer]            - Keypair : Pool authority.
 ///
 /// Instruction Data: EnsureStealthPoolDelegatedArgs
 ///
@@ -50,14 +54,22 @@ pub fn process_ensure_stealth_pool_delegated(accounts: &[AccountView], instructi
         delegation_program_info,
         system_program,
         permission_program,
-    ] = require_n_accounts!(accounts, 10);
+        authority_info,
+    ] = require_n_accounts!(accounts, 11);
 
     let args = EnsureStealthPoolDelegatedArgs::decode(instruction_data)?;
 
     require!(payer_info.is_signer(), ProgramError::MissingRequiredSignature);
+    require!(authority_info.is_signer(), ProgramError::MissingRequiredSignature);
 
     let handle = StealthPool::handle_from_storage(args.handle())?;
-    let (derived_pool, bump) = StealthPool::find_pda(handle)?;
+    let long_handle_hash_seed = if handle.len() > StealthPool::MAX_INLINE_HANDLE_SEED_BYTES {
+        Some(StealthPool::long_handle_hash_seed(handle)?)
+    } else {
+        None
+    };
+    let long_handle_hash_seed_ref = long_handle_hash_seed.as_ref();
+    let (derived_pool, bump) = StealthPool::find_pda_with_hash(handle, long_handle_hash_seed_ref)?;
     require_eq_keys!(&derived_pool, stealth_pool_info.address(), ProgramError::InvalidSeeds);
 
     let delegation_program = ephemeral_spl_api::program::DELEGATION_PROGRAM_ID;
@@ -85,45 +97,44 @@ pub fn process_ensure_stealth_pool_delegated(accounts: &[AccountView], instructi
         let rent = Rent::get()?;
         let lamports = rent.try_minimum_balance(StealthPool::LEN)?;
         let bump_seed = [bump];
-        if handle.len() <= StealthPool::MAX_HANDLE_SEED_BYTES {
-            let signer_seeds = [
-                Seed::from(StealthPool::SEED),
-                Seed::from(handle),
-                Seed::from(&bump_seed),
-            ];
-            let signer = Signer::from(&signer_seeds);
-
-            CreateAccount {
-                from: payer_info,
-                to: stealth_pool_info,
-                space: StealthPool::LEN as u64,
-                lamports,
-                owner: &crate::ID,
-            }
-            .invoke_signed(&[signer])?;
-        } else {
-            let signer_seeds = [
-                Seed::from(StealthPool::SEED),
-                Seed::from(&handle[..StealthPool::MAX_HANDLE_SEED_BYTES]),
-                Seed::from(&handle[StealthPool::MAX_HANDLE_SEED_BYTES..]),
-                Seed::from(&bump_seed),
-            ];
-            let signer = Signer::from(&signer_seeds);
-
-            CreateAccount {
-                from: payer_info,
-                to: stealth_pool_info,
-                space: StealthPool::LEN as u64,
-                lamports,
-                owner: &crate::ID,
-            }
-            .invoke_signed(&[signer])?;
+        let mut seed_slices: [&[u8]; StealthPool::MAX_PDA_SIGNER_SEEDS] = [&[]; StealthPool::MAX_PDA_SIGNER_SEEDS];
+        let signer_seed_slices = StealthPool::seed_slices_with_bump_and_hash(
+            handle,
+            &bump_seed,
+            long_handle_hash_seed_ref,
+            &mut seed_slices,
+        )?;
+        let mut signer_seed_buf = make_seed_buf();
+        for (i, seed) in signer_seed_slices.iter().enumerate() {
+            signer_seed_buf[i] = Seed::from(*seed);
         }
+        let signer = Signer::from(&signer_seed_buf[..signer_seed_slices.len()]);
+
+        CreateAccount {
+            from: payer_info,
+            to: stealth_pool_info,
+            space: StealthPool::LEN as u64,
+            lamports,
+            owner: &crate::ID,
+        }
+        .invoke_signed(&[signer])?;
     } else if !stealth_pool_delegated {
         require!(
             stealth_pool_info.data_len() == StealthPool::LEN,
             ProgramError::InvalidAccountData
         );
+    }
+
+    if stealth_pool_info.data_len() == StealthPool::LEN {
+        let data = unsafe { stealth_pool_info.borrow_unchecked() };
+        let existing = bytemuck::try_from_bytes::<StealthPool>(data).map_err(|_| ProgramError::InvalidAccountData)?;
+        if existing.is_initialized() {
+            require_eq_keys!(
+                &existing.authority,
+                authority_info.address(),
+                ProgramError::IncorrectAuthority
+            );
+        }
     }
 
     let expected_permission = permission_pda_from_permissioned_account(stealth_pool_info.address());
@@ -140,37 +151,27 @@ pub fn process_ensure_stealth_pool_delegated(accounts: &[AccountView], instructi
     );
 
     if !stealth_pool_permission_exists {
-        if handle.len() <= StealthPool::MAX_HANDLE_SEED_BYTES {
-            let seeds = [StealthPool::SEED, handle];
-            CreatePermissionCpiBuilder::new(
-                stealth_pool_info,
-                stealth_pool_permission_info,
-                payer_info,
-                system_program,
-                &PERMISSION_PROGRAM_ID,
-            )
-            .members(MembersArgs { members: Some(&[]) })
-            .seeds(&seeds)
-            .bump(bump)
-            .invoke()?;
-        } else {
-            let seeds = [
-                StealthPool::SEED,
-                &handle[..StealthPool::MAX_HANDLE_SEED_BYTES],
-                &handle[StealthPool::MAX_HANDLE_SEED_BYTES..],
-            ];
-            CreatePermissionCpiBuilder::new(
-                stealth_pool_info,
-                stealth_pool_permission_info,
-                payer_info,
-                system_program,
-                &PERMISSION_PROGRAM_ID,
-            )
-            .members(MembersArgs { members: Some(&[]) })
-            .seeds(&seeds)
-            .bump(bump)
-            .invoke()?;
-        }
+        let mut authority_flags = MemberFlags::new();
+        authority_flags.set(MemberFlags::AUTHORITY);
+        let members = [Member {
+            flags: authority_flags,
+            pubkey: *authority_info.address(),
+        }];
+        let mut seed_slices: [&[u8]; StealthPool::MAX_PDA_SEEDS] = [&[]; StealthPool::MAX_PDA_SEEDS];
+        let seeds = StealthPool::seed_slices_with_hash(handle, long_handle_hash_seed_ref, &mut seed_slices)?;
+        CreatePermissionCpiBuilder::new(
+            stealth_pool_info,
+            stealth_pool_permission_info,
+            payer_info,
+            system_program,
+            &PERMISSION_PROGRAM_ID,
+        )
+        .members(MembersArgs {
+            members: Some(&members),
+        })
+        .seeds(seeds)
+        .bump(bump)
+        .invoke()?;
     }
 
     if stealth_pool_delegated {
@@ -186,41 +187,20 @@ pub fn process_ensure_stealth_pool_delegated(accounts: &[AccountView], instructi
         validator: args.validator().copied(),
         ..DelegateConfig::default()
     };
-    if handle.len() <= StealthPool::MAX_HANDLE_SEED_BYTES {
-        let seeds = [StealthPool::SEED, handle];
+    let mut seed_slices: [&[u8]; StealthPool::MAX_PDA_SEEDS] = [&[]; StealthPool::MAX_PDA_SEEDS];
+    let seeds = StealthPool::seed_slices_with_hash(handle, long_handle_hash_seed_ref, &mut seed_slices)?;
 
-        DelegateAccountCpiBuilder::new(
-            payer_info,
-            stealth_pool_info,
-            owner_program,
-            buffer_acc,
-            delegation_record,
-            delegation_metadata,
-            system_program,
-        )
-        .seeds(&seeds)
-        .bump(bump)
-        .config(config)
-        .invoke()
-    } else {
-        let seeds = [
-            StealthPool::SEED,
-            &handle[..StealthPool::MAX_HANDLE_SEED_BYTES],
-            &handle[StealthPool::MAX_HANDLE_SEED_BYTES..],
-        ];
-
-        DelegateAccountCpiBuilder::new(
-            payer_info,
-            stealth_pool_info,
-            owner_program,
-            buffer_acc,
-            delegation_record,
-            delegation_metadata,
-            system_program,
-        )
-        .seeds(&seeds)
-        .bump(bump)
-        .config(config)
-        .invoke()
-    }
+    DelegateAccountCpiBuilder::new(
+        payer_info,
+        stealth_pool_info,
+        owner_program,
+        buffer_acc,
+        delegation_record,
+        delegation_metadata,
+        system_program,
+    )
+    .seeds(seeds)
+    .bump(bump)
+    .config(config)
+    .invoke()
 }

--- a/e-token/tests/ensure_stealth_pool_delegated.rs
+++ b/e-token/tests/ensure_stealth_pool_delegated.rs
@@ -1,5 +1,5 @@
 use ephemeral_rollups_pinocchio::{
-    acl::{permission_pda_from_permissioned_account, PERMISSION_PROGRAM_ID},
+    acl::{permission_pda_from_permissioned_account, types::MemberFlags, PERMISSION_PROGRAM_ID},
     pda::{
         delegate_buffer_pda_from_delegated_account_and_owner_program, delegation_metadata_pda_from_delegated_account,
         delegation_record_pda_from_delegated_account,
@@ -24,6 +24,7 @@ mod utils;
 
 fn build_ensure_stealth_pool_delegated_ix(
     payer: solana_pubkey::Pubkey,
+    authority: solana_pubkey::Pubkey,
     handle: &[u8],
 ) -> (solana_pubkey::Pubkey, solana_pubkey::Pubkey, Instruction) {
     let (stealth_pool, _) = StealthPool::find_pda(handle).unwrap();
@@ -57,10 +58,29 @@ fn build_ensure_stealth_pool_delegated_ix(
                 AccountMeta::new_readonly(ephemeral_rollups_pinocchio::ID, false),
                 AccountMeta::new_readonly(solana_system_interface::program::ID, false),
                 AccountMeta::new_readonly(PERMISSION_PROGRAM_ID, false),
+                AccountMeta::new_readonly(authority, true),
             ],
             data,
         },
     )
+}
+
+fn find_member_flag(data: &[u8], member_pubkey: &solana_pubkey::Pubkey, expected: u8) -> Option<u8> {
+    let key_bytes = member_pubkey.as_ref();
+    if data.len() < key_bytes.len() {
+        return None;
+    }
+    for i in 0..=data.len() - key_bytes.len() {
+        if &data[i..i + key_bytes.len()] == key_bytes {
+            if i > 0 && data[i - 1] == expected {
+                return Some(data[i - 1]);
+            }
+            if i + key_bytes.len() < data.len() && data[i + key_bytes.len()] == expected {
+                return Some(data[i + key_bytes.len()]);
+            }
+        }
+    }
+    None
 }
 
 #[tokio::test]
@@ -69,7 +89,7 @@ async fn ensure_stealth_pool_delegated_creates_pool_permission() {
     let payer_kp = utils::fixed_payer_keypair();
     let payer = payer_kp.pubkey();
     let handle = b"ensure-stealth-pool.block";
-    let (stealth_pool, stealth_pool_permission, ix) = build_ensure_stealth_pool_delegated_ix(payer, handle);
+    let (stealth_pool, stealth_pool_permission, ix) = build_ensure_stealth_pool_delegated_ix(payer, payer, handle);
 
     let tx = Transaction::new_signed_with_payer(&[ix.clone()], Some(&payer), &[&payer_kp], context.last_blockhash);
     context.banks_client.process_transaction(tx).await.unwrap();
@@ -92,6 +112,10 @@ async fn ensure_stealth_pool_delegated_creates_pool_permission() {
         .unwrap()
         .expect("stealth pool permission account must exist");
     assert_eq!(permission_account.owner, PERMISSION_PROGRAM_ID);
+    assert_eq!(
+        find_member_flag(&permission_account.data, &payer, MemberFlags::AUTHORITY),
+        Some(MemberFlags::AUTHORITY)
+    );
 
     let blockhash = context.get_new_latest_blockhash().await.unwrap();
     let tx = Transaction::new_signed_with_payer(&[ix], Some(&payer), &[&payer_kp], blockhash);
@@ -104,7 +128,7 @@ async fn ensure_stealth_pool_delegated_creates_permission_when_pool_is_already_d
     let payer_kp = utils::fixed_payer_keypair();
     let payer = payer_kp.pubkey();
     let handle = b"ensure-stealth-pool-existing.block";
-    let (stealth_pool, stealth_pool_permission, ix) = build_ensure_stealth_pool_delegated_ix(payer, handle);
+    let (stealth_pool, stealth_pool_permission, ix) = build_ensure_stealth_pool_delegated_ix(payer, payer, handle);
     let data = vec![0u8; StealthPool::LEN];
     let rent = Rent::default();
 
@@ -122,6 +146,41 @@ async fn ensure_stealth_pool_delegated_creates_permission_when_pool_is_already_d
 
     let tx = Transaction::new_signed_with_payer(&[ix], Some(&payer), &[&payer_kp], context.last_blockhash);
     context.banks_client.process_transaction(tx).await.unwrap();
+
+    let permission_account = context
+        .banks_client
+        .get_account(stealth_pool_permission)
+        .await
+        .unwrap()
+        .expect("stealth pool permission account must exist");
+    assert_eq!(permission_account.owner, PERMISSION_PROGRAM_ID);
+    assert_eq!(
+        find_member_flag(&permission_account.data, &payer, MemberFlags::AUTHORITY),
+        Some(MemberFlags::AUTHORITY)
+    );
+}
+
+#[tokio::test]
+async fn ensure_stealth_pool_delegated_supports_255_byte_handles() {
+    let context = utils::start_program_test(PROGRAM).await;
+    let payer_kp = utils::fixed_payer_keypair();
+    let payer = payer_kp.pubkey();
+    let handle = [b'a'; StealthPool::MAX_HANDLE_BYTES];
+    let (stealth_pool, stealth_pool_permission, ix) = build_ensure_stealth_pool_delegated_ix(payer, payer, &handle);
+
+    let tx = Transaction::new_signed_with_payer(&[ix], Some(&payer), &[&payer_kp], context.last_blockhash);
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    let stealth_pool_account = context
+        .banks_client
+        .get_account(stealth_pool)
+        .await
+        .unwrap()
+        .expect("stealth pool account must exist");
+    assert_eq!(
+        stealth_pool_account.owner,
+        ephemeral_spl_api::program::DELEGATION_PROGRAM_ID
+    );
 
     let permission_account = context
         .banks_client


### PR DESCRIPTION
Received 3 feedbacks on the previous stack of PRs:
 
> #114: LGTM in general! We should add authority in the permission members

I added `authority` to the permission members.

> #113: LGTM, but we should support 255 as well (raw handle)

The size of the user-handle _now_ can be upto `255` bytes which is same as supported by `.sol` (see #113 for details).

--

and the third feedback is handled in #116.