### PR TITLE
refactor(api): use /v1/spl/transfer for stealth transfers as well, and remove /v1/spl/transfer-stealth

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -20,7 +20,6 @@ The API exposes:
 - `POST /v1/spl/deposit`
 - `POST /v1/spl/withdraw`
 - `POST /v1/spl/transfer`
-- `POST /v1/spl/transfer-stealth`
 - `POST /v1/spl/stealth-pool`
 - `GET /v1/spl/stealth-pool`
 - `GET /v1/spl/balance`
@@ -49,7 +48,7 @@ Important behavior:
 - `withdraw` uses `withdrawSpl(...)`
 - `transfer` uses `transferSpl(...)`
 - stealth handles are derived exactly as provided from UTF-8 bytes and capped at 255 bytes; handles over 64 bytes use a bounded hash seed for PDA derivation
-- `transfer-stealth` uses the derived stealth-pool PDA as the virtual destination owner
+- `transfer` accepts an initialized stealth handle in `to` and uses the derived stealth-pool PDA as the virtual destination owner
 - every SPL endpoint accepts an optional `cluster` parameter
 - `cluster=mainnet` uses `BASE_RPC_URL` and `EPHEMERAL_RPC_URL`
 - `cluster=devnet` uses `BASE_DEVNET_RPC_URL` and `EPHEMERAL_DEVNET_RPC_URL`
@@ -623,6 +622,8 @@ The returned `sendTo` value is:
 Transfer responses also include `from`, which mirrors the request `fromBalance`, and `fees`.
 `fees.lamports` and `fees.tokens` are total fee strings and return `"0"` when that fee type is not charged. `fees.tokens` uses mint base units. Private `base -> base` transfers report the on-chain private-transfer token fee and shuttle setup lamport fee. Gasless transfers add the relay fee to `fees.tokens` only when gasless is honored.
 
+When `to` is not a Solana public key, the API treats it as a stealth handle. The handle must be initialized through `/v1/spl/stealth-pool`; the API derives the stealth-pool PDA, verifies that the base account exists, and builds a private `base -> base` transfer to that PDA. Stealth handle transfers require `visibility: "private"`, `fromBalance: "base"`, and `toBalance: "base"`; those are the defaults when omitted.
+
 Example:
 
 ```bash
@@ -640,6 +641,21 @@ curl -X POST http://127.0.0.1:8787/v1/spl/transfer \
     "minDelayMs": "0",
     "maxDelayMs": "0",
     "gasless": true
+  }'
+```
+
+Stealth handle transfer:
+
+```bash
+curl -X POST http://127.0.0.1:8787/v1/spl/transfer \
+  -H 'content-type: application/json' \
+  -d '{
+    "from": "FROM_OWNER_PUBKEY",
+    "to": "john.doe@magicblock.id",
+    "mint": "MINT_PUBKEY",
+    "amount": 5000000,
+    "minDelayMs": "0",
+    "maxDelayMs": "0"
   }'
 ```
 
@@ -680,7 +696,7 @@ Gasless transfer validation:
 Relevant fields:
 
 - `from`
-- `to`
+- `to` public key or initialized stealth handle
 - `cluster`
 - `mint`
 - `amount`
@@ -731,31 +747,6 @@ Derives the stealth-pool PDA for a handle and reports whether the base account e
 ```bash
 curl "http://127.0.0.1:8787/v1/spl/stealth-pool?handle=john.doe%40magicblock.id"
 ```
-
-### `POST /v1/spl/transfer-stealth`
-
-Builds an unsigned private transfer addressed to a handle. The API derives the stealth-pool PDA from `toHandle`, verifies the pool account exists, and passes that PDA as the private transfer destination owner.
-
-Missing or wrong handles are rejected before an unsigned transaction is returned.
-
-```bash
-curl -X POST http://127.0.0.1:8787/v1/spl/transfer-stealth \
-  -H 'content-type: application/json' \
-  -d '{
-    "from": "FROM_OWNER_PUBKEY",
-    "toHandle": "john.doe@magicblock.id",
-    "mint": "MINT_PUBKEY",
-    "amount": 5000000,
-    "fromBalance": "base",
-    "minDelayMs": "0",
-    "maxDelayMs": "0"
-  }'
-```
-
-Supported stealth transfer routes:
-
-- `base -> base` private transfer, submitted to base
-- `ephemeral -> base` private transfer, submitted to ER and requiring an auth token
 
 ### `GET /v1/spl/balance`
 

--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -269,7 +269,7 @@ describe("app", () => {
     expect(json.paths["/v1/spl/transfer-queue/ensure-crank"]).toBeDefined();
     expect(json.paths["/v1/spl/undelegate-ephemeral-ata"]).toBeDefined();
     expect(json.paths["/v1/spl/stealth-pool"]).toBeDefined();
-    expect(json.paths["/v1/spl/transfer-stealth"]).toBeDefined();
+    expect(json.paths["/v1/spl/transfer-stealth"]).toBeUndefined();
     expect(json.paths["/v1/swap/quote"]).toBeDefined();
     expect(json.paths["/v1/swap/swap"]).toBeDefined();
     expect(json.tags).toEqual(
@@ -387,6 +387,9 @@ describe("app", () => {
       type: "boolean",
       example: true,
     });
+    expect(transferRequestSchema?.properties?.to?.description).toContain(
+      "stealth handle",
+    );
     expect(transferRequestSchema?.example).toMatchObject({
       amount: 5000000,
       gasless: true,
@@ -408,14 +411,9 @@ describe("app", () => {
       json.components?.schemas as Record<string, any>
     )?.SendTransactionRequest;
     expect(sendTransactionRequestSchema?.properties?.sendRpcEndpoint).toBeDefined();
-    const stealthTransferRequestSchema = (
-      json.components?.schemas as Record<string, any>
-    )?.StealthTransferRequest;
-    expect(stealthTransferRequestSchema?.properties?.toHandle).toBeDefined();
-    expect(stealthTransferRequestSchema?.example).toMatchObject({
-      toHandle: "john.doe@magicblock.id",
-      fromBalance: "base",
-    });
+    expect(
+      (json.components?.schemas as Record<string, any>)?.StealthTransferRequest,
+    ).toBeUndefined();
     expect(
       json.paths["/v1/spl/withdraw"]?.post?.responses?.["200"]?.content?.[
         "application/json"
@@ -3716,7 +3714,7 @@ describe("app", () => {
 
   it("rejects stealth transfers from ephemeral balance", async () => {
     const response = await app.request(
-      "/v1/spl/transfer-stealth",
+      "/v1/spl/transfer",
       {
         method: "POST",
         headers: {
@@ -3725,10 +3723,12 @@ describe("app", () => {
         },
         body: JSON.stringify({
           from: owner,
-          toHandle: stealthHandle,
+          to: stealthHandle,
           mint: "So11111111111111111111111111111111111111112",
           amount: 2,
+          visibility: "private",
           fromBalance: "ephemeral",
+          toBalance: "base",
           minDelayMs: "0",
           maxDelayMs: "0",
           split: 1,
@@ -3737,13 +3737,15 @@ describe("app", () => {
       env,
     );
 
-    expect(response.status).toBe(422);
+    expect(response.status).toBe(400);
 
     const json = (await response.json()) as {
       error: { code: string; message: string };
     };
-    expect(json.error.code).toBe("VALIDATION_ERROR");
-    expect(json.error.message).toBe("Request validation failed");
+    expect(json.error.code).toBe("INVALID_STEALTH_TRANSFER");
+    expect(json.error.message).toBe(
+      "Stealth handle transfers require visibility=private, fromBalance=base, and toBalance=base",
+    );
   });
 
   it("rejects stealth transfers when the derived pool PDA is missing", async () => {
@@ -3762,7 +3764,7 @@ describe("app", () => {
     );
 
     const response = await app.request(
-      "/v1/spl/transfer-stealth",
+      "/v1/spl/transfer",
       {
         method: "POST",
         headers: {
@@ -3770,10 +3772,9 @@ describe("app", () => {
         },
         body: JSON.stringify({
           from: owner,
-          toHandle: stealthHandle,
+          to: stealthHandle,
           mint: mint.toBase58(),
           amount: 2,
-          fromBalance: "base",
           minDelayMs: "0",
           maxDelayMs: "0",
           split: 1,
@@ -3819,7 +3820,7 @@ describe("app", () => {
           return createMintAccountInfo(TOKEN_PROGRAM_ID);
         }
 
-        throw new Error(`Unexpected transfer-stealth account lookup: ${address.toBase58()}`);
+        throw new Error(`Unexpected stealth transfer account lookup: ${address.toBase58()}`);
       },
     );
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
@@ -3828,7 +3829,7 @@ describe("app", () => {
     });
 
     const response = await app.request(
-      "/v1/spl/transfer-stealth",
+      "/v1/spl/transfer",
       {
         method: "POST",
         headers: {
@@ -3836,10 +3837,9 @@ describe("app", () => {
         },
         body: JSON.stringify({
           from: owner,
-          toHandle: stealthHandle,
+          to: stealthHandle,
           mint: mint.toBase58(),
           amount: 2,
-          fromBalance: "base",
           minDelayMs: "0",
           maxDelayMs: "0",
           split: 1,

--- a/api/src/lib/solana.ts
+++ b/api/src/lib/solana.ts
@@ -49,7 +49,6 @@ import {
   StealthPoolResponse,
   StealthPoolStatusRequest,
   StealthPoolStatusResponse,
-  StealthTransferRequest,
   TransactionResponse,
   TransferRequest,
   TransferQueueEnsureCrankRequest,
@@ -413,6 +412,14 @@ function parsePublicKey(value: string, fieldName: string) {
   }
 }
 
+function tryParsePublicKey(value: string) {
+  try {
+    return new PublicKey(value);
+  } catch {
+    return undefined;
+  }
+}
+
 function parseAmount(
   value: string | number,
   fieldName: string,
@@ -600,6 +607,30 @@ async function assertStealthPoolExists(
       owner: accountInfo?.owner.toBase58(),
     });
   }
+}
+
+async function resolveTransferDestination(config: RpcConfig, input: TransferRequest) {
+  const to = tryParsePublicKey(input.to);
+  if (to) {
+    return to;
+  }
+
+  if (
+    input.visibility !== "private"
+    || input.fromBalance !== "base"
+    || input.toBalance !== "base"
+  ) {
+    throw new ApiError(
+      400,
+      "INVALID_STEALTH_TRANSFER",
+      "Stealth handle transfers require visibility=private, fromBalance=base, and toBalance=base",
+      { to: input.to },
+    );
+  }
+
+  const { stealthPool } = resolveStealthPool(input.to);
+  await assertStealthPoolExists(config, input.to, stealthPool);
+  return stealthPool;
 }
 
 function updateStealthPoolInstruction(
@@ -1717,7 +1748,7 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
   try {
     const config = resolveRpcConfig(env, input.cluster);
     const from = parsePublicKey(input.from, "from");
-    const to = parsePublicKey(input.to, "to");
+    const to = await resolveTransferDestination(config, input);
     const mint = parsePublicKey(input.mint, "mint");
     const allowZeroAmount = input.visibility === "private"
       && input.fromBalance === "base"
@@ -1919,43 +1950,6 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
   } catch (error) {
     throwTransactionBuildError(error);
   }
-}
-
-export async function buildStealthTransferTransaction(
-  env: AppEnv,
-  input: StealthTransferRequest,
-  authToken?: string,
-) {
-  console.log("buildStealthTransferTransaction invoked: ", input);
-
-  const config = resolveRpcConfig(env, input.cluster);
-  const { stealthPool } = await resolveStealthPool(input.toHandle);
-  await assertStealthPoolExists(config, input.toHandle, stealthPool);
-
-  const transferInput: TransferRequest = {
-    from: input.from,
-    to: stealthPool.toBase58(),
-    cluster: input.cluster,
-    mint: input.mint,
-    amount: input.amount,
-    visibility: "private",
-    fromBalance: input.fromBalance,
-    toBalance: "base",
-    validator: input.validator,
-    initIfMissing: input.initIfMissing,
-    initAtasIfMissing: input.initAtasIfMissing,
-    initVaultIfMissing: input.initVaultIfMissing,
-    memo: input.memo,
-    minDelayMs: input.minDelayMs,
-    maxDelayMs: input.maxDelayMs,
-    clientRefId: input.clientRefId,
-    split: input.split,
-    exactOut: input.exactOut,
-    gasless: input.gasless,
-    legacy: input.legacy,
-  };
-
-  return buildTransferTransaction(env, transferInput, authToken);
 }
 
 async function getBalanceInternal(

--- a/api/src/routes/spl/spl.handlers.ts
+++ b/api/src/routes/spl/spl.handlers.ts
@@ -5,7 +5,6 @@ import {
   buildDepositTransaction,
   buildInitializeMintTransaction,
   buildUpdateStealthPoolTransaction,
-  buildStealthTransferTransaction,
   buildTransferTransaction,
   buildUndelegateEphemeralAtaTransaction,
   buildWithdrawTransaction,
@@ -25,7 +24,6 @@ import {
   privateBalanceRoute,
   stealthPoolRoute,
   stealthPoolStatusRoute,
-  stealthTransferRoute,
   transferQueueEnsureCrankRoute,
   transferRoute,
   undelegateEphemeralAtaRoute,
@@ -40,7 +38,6 @@ import {
   MintInitializationRequest,
   StealthPoolRequest,
   StealthPoolStatusRequest,
-  StealthTransferRequest,
   TransferRequest,
   TransferQueueEnsureCrankRequest,
   UndelegateEphemeralAtaRequest,
@@ -95,14 +92,6 @@ export const undelegateEphemeralAtaHandler: RouteHandler<typeof undelegateEpheme
   const body = c.req.valid("json") as UndelegateEphemeralAtaRequest;
   const authToken = parseAuthToken(c.req.header());
   const response = await buildUndelegateEphemeralAtaTransaction(env, body, authToken);
-  return c.json(response, 200);
-};
-
-export const stealthTransferHandler: RouteHandler<typeof stealthTransferRoute, RouteEnv> = async (c) => {
-  const env = getEnv(c.env);
-  const body = c.req.valid("json") as StealthTransferRequest;
-  const authToken = parseAuthToken(c.req.header());
-  const response = await buildStealthTransferTransaction(env, body, authToken);
   return c.json(response, 200);
 };
 

--- a/api/src/routes/spl/spl.index.ts
+++ b/api/src/routes/spl/spl.index.ts
@@ -12,7 +12,6 @@ import {
   privateBalanceHandler,
   stealthPoolHandler,
   stealthPoolStatusHandler,
-  stealthTransferHandler,
   transferQueueEnsureCrankHandler,
   transferHandler,
   undelegateEphemeralAtaHandler,
@@ -28,7 +27,6 @@ import {
   privateBalanceRoute,
   stealthPoolRoute,
   stealthPoolStatusRoute,
-  stealthTransferRoute,
   transferQueueEnsureCrankRoute,
   transferRoute,
   undelegateEphemeralAtaRoute,
@@ -44,7 +42,6 @@ app.openapi(withdrawRoute, withdrawHandler);
 app.openapi(initializeMintRoute, initializeMintHandler);
 app.openapi(transferRoute, transferHandler);
 app.openapi(undelegateEphemeralAtaRoute, undelegateEphemeralAtaHandler);
-app.openapi(stealthTransferRoute, stealthTransferHandler);
 app.openapi(stealthPoolRoute, stealthPoolHandler);
 app.openapi(stealthPoolStatusRoute, stealthPoolStatusHandler);
 app.openapi(balanceRoute, balanceHandler);

--- a/api/src/routes/spl/spl.routes.ts
+++ b/api/src/routes/spl/spl.routes.ts
@@ -30,7 +30,6 @@ import {
   stealthPoolResponseSchema,
   stealthPoolStatusRequestSchema,
   stealthPoolStatusResponseSchema,
-  stealthTransferRequestSchema,
   TransferQueueEnsureCrankResponse,
   transferQueueEnsureCrankRequestSchema,
   transferQueueEnsureCrankResponseSchema,
@@ -195,7 +194,7 @@ export const transferRoute = createRoute({
   path: "/v1/spl/transfer",
   method: "post",
   tags,
-  description: "Transfer SPL tokens publicly or privately trough an ephemeral rollup.",
+  description: "Transfer SPL tokens publicly, privately, or to an initialized stealth handle through an ephemeral rollup.",
   request: {
     body: jsonContentRequired(transferRequestSchema, "Transfer request"),
     headers: optionalAuthTokenSchema,
@@ -218,22 +217,6 @@ export const undelegateEphemeralAtaRoute = createRoute({
   },
   responses: {
     200: jsonContent(undelegateEphemeralAtaResponseSchema, "Unsigned serialized transaction", undelegateEphemeralAtaResponseExample),
-    400: jsonContent(errorResponseSchema, "Build error"),
-    422: jsonContent(validationErrorResponseSchema, "Validation error"),
-  },
-});
-
-export const stealthTransferRoute = createRoute({
-  path: "/v1/spl/transfer-stealth",
-  method: "post",
-  tags,
-  description: "Build an unsigned private transfer transaction addressed to an initialized stealth handle.",
-  request: {
-    body: jsonContentRequired(stealthTransferRequestSchema, "Stealth transfer request"),
-    headers: optionalAuthTokenSchema,
-  },
-  responses: {
-    200: jsonContent(transactionResponseSchema, "Unsigned serialized transaction"),
     400: jsonContent(errorResponseSchema, "Build error"),
     422: jsonContent(validationErrorResponseSchema, "Validation error"),
   },

--- a/api/src/routes/spl/spl.schemas.ts
+++ b/api/src/routes/spl/spl.schemas.ts
@@ -162,6 +162,14 @@ export const stealthHandleSchema = z.string().min(1).refine(
   description: "Exact canonical handle string, up to 255 UTF-8 bytes. The API derives the stealth-pool PDA from these UTF-8 bytes as-is; it does not trim, lowercase, or normalize.",
 });
 
+const transferDestinationSchema = z.string().min(1).refine(
+  destination => textEncoder.encode(destination).length <= MAX_STEALTH_HANDLE_BYTES,
+  `Destination must be a public key or a stealth handle of ${MAX_STEALTH_HANDLE_BYTES} UTF-8 bytes or fewer.`,
+).openapi({
+  example: TRANSFER_EXAMPLE_TO,
+  description: "Destination owner public key, or an initialized stealth handle for private base-to-base transfers.",
+});
+
 export const stealthPoolRequestSchema = z.object({
   payer: publicKeySchema.openapi({
     example: DEPOSIT_EXAMPLE_OWNER,
@@ -286,13 +294,13 @@ export type WithdrawRequest = z.infer<typeof withdrawRequestSchema>;
 
 export const transferRequestSchema = z.object({
   from: publicKeySchema,
-  to: publicKeySchema,
+  to: transferDestinationSchema,
   cluster: clusterSchema.optional(),
   mint: publicKeySchema,
   amount: amountSchema,
-  visibility: visibilitySchema,
-  fromBalance: balanceLocationSchema,
-  toBalance: balanceLocationSchema,
+  visibility: visibilitySchema.default("private"),
+  fromBalance: balanceLocationSchema.default("base"),
+  toBalance: balanceLocationSchema.default("base"),
   validator: publicKeySchema.openapi({
     example: DEFAULT_DEPOSIT_VALIDATOR,
     description: "Optional. When this transfer route needs a validator and none is provided, the API resolves it from the selected ephemeral RPC via `getIdentity`.",
@@ -348,69 +356,6 @@ export const transferRequestSchema = z.object({
   },
 });
 export type TransferRequest = z.infer<typeof transferRequestSchema>;
-
-export const stealthTransferRequestSchema = z.object({
-  from: publicKeySchema,
-  toHandle: stealthHandleSchema,
-  cluster: clusterSchema.optional(),
-  mint: publicKeySchema,
-  amount: amountSchema,
-  fromBalance: z.literal("base").openapi({
-    example: "base",
-    description: "Stealth transfers are base-chain source only.",
-  }).default("base"),
-  validator: publicKeySchema.openapi({
-    example: DEFAULT_DEPOSIT_VALIDATOR,
-    description: "Optional. When none is provided, the API resolves it from the selected ephemeral RPC via `getIdentity`.",
-  }).optional(),
-  initIfMissing: z.boolean().optional(),
-  initAtasIfMissing: z.boolean().optional(),
-  initVaultIfMissing: z.boolean().optional(),
-  memo: z.string().openapi({
-    example: "Order #1042",
-    description: "Optional. Appends a final Memo Program instruction with this UTF-8 message.",
-  }).optional(),
-  minDelayMs: optionalBigIntStringSchema.openapi({
-    example: "0",
-    description: "Optional. Defaults to 0.",
-  }).optional(),
-  maxDelayMs: optionalBigIntStringSchema.openapi({
-    example: "0",
-    description: "Optional. Defaults to 0 when omitted, or to minDelayMs when minDelayMs is set.",
-  }).optional(),
-  clientRefId: optionalBigIntStringSchema.openapi({
-    example: "42",
-    description: "Optional. Encrypted client reference ID that can be used to confirm a payment.",
-  }).optional(),
-  split: z.int().positive().max(15).openapi({
-    example: 1,
-    description: "Optional. Defaults to 1. Must be between 1 and 15.",
-  }).optional(),
-  exactOut: z.boolean().openapi({
-    example: boolean,
-    description: "Optional. If true, the fees are deducted from the sender, else from the recipient amount.",
-  }).optional(),
-  gasless: z.boolean().openapi({
-    example: true,
-    description: "Optional. Same gasless policy as `/v1/spl/transfer`.",
-  }).optional(),
-  legacy: z.boolean().openapi({
-    description: "Optional. Defaults to false. When true, skips lookup-table compilation and returns a legacy transaction.",
-  }).optional(),
-}).openapi("StealthTransferRequest", {
-  example: {
-    from: DEPOSIT_EXAMPLE_OWNER,
-    toHandle: "john.doe@magicblock.id",
-    mint: DEFAULT_DEPOSIT_MINT,
-    amount: 5000000,
-    fromBalance: "base",
-    minDelayMs: "0",
-    maxDelayMs: "0",
-    clientRefId: "42",
-    gasless: true,
-  },
-});
-export type StealthTransferRequest = z.infer<typeof stealthTransferRequestSchema>;
 
 export const balanceRequestSchema = z.object({
   address: publicKeySchema,


### PR DESCRIPTION
Received this feedback on previous PR

> #95: Adding new endpoints and a different building path sounds like unnecessary extra complexity for clients. IMO, we should just include this functionality in transferSpl and build the transaction accordingly when the destination is a stealth domain.
 
This PR uses `/v1/spl/transfer` for stealth-address as well. 

**Removed** `/v1/spl/transfer-stealth`.