### PR TITLE
Fix private transfer fee vault account

### DIFF
--- a/e-token/src/processor/internal/private_transfer.rs
+++ b/e-token/src/processor/internal/private_transfer.rs
@@ -142,6 +142,11 @@ pub(crate) fn process_with_merge_and_private_transfer_inner(
     };
 
     let total_amount = private_transfer_amount + fee_amount;
+    let queue_vault_token_info = get_associated_token_address(
+        queue_info.address(),
+        common_accounts.mint_info.address(),
+        common_accounts.token_program_info.address(),
+    );
 
     debug_log!(
         "exact_out:  {}, fee_amount: {}, private_transfer_amount: {}",
@@ -154,6 +159,7 @@ pub(crate) fn process_with_merge_and_private_transfer_inner(
         let private_transfer = private_transfer_action_encrypted(
             &common_accounts,
             queue_info,
+            &queue_vault_token_info,
             encrypted_destination,
             encrypted_data_suffix,
             private_transfer_amount,
@@ -167,7 +173,12 @@ pub(crate) fn process_with_merge_and_private_transfer_inner(
         #[cfg(not(feature = "no-fees"))]
         {
             let mint_decimals = read_mint_decimals(common_accounts.mint_info, common_accounts.token_program_info)?;
-            post_actions.push(private_transfer_fee_action(&common_accounts, fee_amount, mint_decimals));
+            post_actions.push(private_transfer_fee_action(
+                &common_accounts,
+                &queue_vault_token_info,
+                fee_amount,
+                mint_decimals,
+            ));
         }
 
         post_actions.push(undelegate_and_close_shuttle_action(&common_accounts, close_stash));
@@ -189,6 +200,7 @@ pub(crate) fn process_with_merge_and_private_transfer_inner(
 fn private_transfer_action_encrypted(
     common_accounts: &DepositAndDelegateShuttleAccounts<'_>,
     queue_info: &AccountView,
+    queue_vault_token_info: &Address,
     encrypted_destination: &[u8; 80],
     encrypted_data_suffix: &[u8],
     amount: u64,
@@ -201,11 +213,6 @@ fn private_transfer_action_encrypted(
     let group_id = u32::from(group_id_raw[0]) | (u32::from(group_id_raw[1]) << 8) | (u32::from(group_id_raw[2]) << 16);
     let group_receipt_info =
         derive_group_receipt_id(queue_info.address(), common_accounts.owner_info.address(), group_id).0;
-    let queue_vault_token_info = get_associated_token_address(
-        queue_info.address(),
-        common_accounts.mint_info.address(),
-        common_accounts.token_program_info.address(),
-    );
     Ok(PostDelegationActions {
         inserted_signers: 0,
         inserted_non_signers: 0,
@@ -261,6 +268,7 @@ fn private_transfer_fee_amount(amount: u64) -> Result<u64, ProgramError> {
 #[cfg(not(feature = "no-fees"))]
 fn private_transfer_fee_action(
     common_accounts: &DepositAndDelegateShuttleAccounts<'_>,
+    queue_vault_token_info: &Address,
     fee_amount: u64,
     mint_decimals: u8,
 ) -> Instruction {
@@ -273,7 +281,7 @@ fn private_transfer_fee_action(
         accounts: alloc::vec![
             AccountMeta::new(*common_accounts.owner_source_token_info.address(), false),
             AccountMeta::new_readonly(*common_accounts.mint_info.address(), false),
-            AccountMeta::new(*common_accounts.vault_token_info.address(), false),
+            AccountMeta::new(*queue_vault_token_info, false),
             AccountMeta::new_readonly(*common_accounts.owner_info.address(), true),
         ],
         data,

--- a/e-token/tests/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
+++ b/e-token/tests/deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer.rs
@@ -108,6 +108,7 @@ async fn deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_trans
     let vault_ata = utils::derive_associated_token_address(vault, mint);
     let owner_source_ata = owner_token.pubkey();
     let (queue, _) = TransferQueue::find_pda(&mint, &validator);
+    let queue_vault_ata = utils::derive_associated_token_address(queue, mint);
     let ix_init_rent = Instruction {
         program_id: PROGRAM,
         accounts: vec![
@@ -420,6 +421,20 @@ async fn deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_trans
             .windows(fee_transfer_data.len())
             .any(|window| window == fee_transfer_data.as_slice()),
         "expected stored post-delegation payload to include the fee transfer action"
+    );
+    #[cfg(not(feature = "no-fees"))]
+    assert!(
+        action_payload
+            .windows(queue_vault_ata.to_bytes().len())
+            .any(|window| window == queue_vault_ata.to_bytes()),
+        "expected stored post-delegation payload to include the validator-scoped queue vault ATA"
+    );
+    #[cfg(not(feature = "no-fees"))]
+    assert!(
+        !action_payload
+            .windows(vault_ata.to_bytes().len())
+            .any(|window| window == vault_ata.to_bytes()),
+        "expected stored post-delegation payload not to write the global vault ATA"
     );
     #[cfg(feature = "no-fees")]
     assert!(


### PR DESCRIPTION
## Summary
- derive the validator-scoped queue vault ATA once for private transfer post-actions
- use the queue vault as the fee transfer destination instead of the global vault ATA
- add regression coverage for the stored post-delegation payload vault account

## Tests
- cargo test-sbf --features logging --test deposit_and_delegate_shuttle_ephemeral_ata_with_merge_and_private_transfer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved private transfer handling so the correct token account is used consistently when building transfer and fee instructions.
  * Fixed post-transfer action details to ensure the expected account information is stored for queued transfers, reducing mismatches in fee-enabled flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->