### PR TITLE
Lower gasless transfer minimum

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -633,7 +633,7 @@ curl -X POST http://127.0.0.1:8787/v1/spl/transfer \
     "from": "FROM_OWNER_PUBKEY",
     "to": "TO_OWNER_PUBKEY",
     "mint": "MINT_PUBKEY",
-    "amount": 5000000,
+    "amount": 500000,
     "visibility": "private",
     "fromBalance": "base",
     "toBalance": "base",
@@ -690,7 +690,7 @@ Gasless transfer validation:
 - the configured sponsor becomes the transaction fee payer and signs the transaction
 - the API prepends a 0.2 USDC/USDT relay-fee token transfer from the sender to the sponsor ATA
 - gasless transfers require an approved stablecoin mint: mainnet USDC, mainnet USDT, or devnet USDC
-- gasless transfers must be at least 5 USDC/USDT
+- gasless transfers must be at least 0.5 USDC/USDT
 - if `from` is an off-curve PDA owner, `gasless: true` is ignored because gasless transfers require a supported wallet sender
 
 Relevant fields:

--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -399,7 +399,7 @@ describe("app", () => {
       "stealth handle",
     );
     expect(transferRequestSchema?.example).toMatchObject({
-      amount: 5000000,
+      amount: 500000,
       gasless: true,
     });
     expect(transferRequestSchema?.example).not.toHaveProperty("initIfMissing");
@@ -4473,7 +4473,7 @@ describe("app", () => {
   it("builds a gasless private transfer with the sponsor as fee payer", async () => {
     const sponsor = Keypair.generate();
     const mint = DEVNET_USDC_MINT;
-    const amount = 5_000_000;
+    const amount = 500_000;
     const ownerAta = deriveAssociatedTokenAddress(mint, owner);
     const sponsorAta = deriveAssociatedTokenAddress(
       mint,
@@ -4545,7 +4545,7 @@ describe("app", () => {
     };
     expect(json.fees).toEqual({
       lamports: "2039280",
-      tokens: "205000",
+      tokens: "200500",
     });
     expect(json.requiredSigners).toEqual(
       expect.arrayContaining([owner, sponsor.publicKey.toBase58()]),

--- a/api/src/lib/solana.ts
+++ b/api/src/lib/solana.ts
@@ -122,7 +122,7 @@ const PRIVATE_TRANSFER_SETUP_LAMPORTS = 2_039_280n;
 const PRIVATE_TRANSFER_FEE_BASIS_POINTS = 10n;
 const BASIS_POINTS_FACTOR = 10_000n;
 const GASLESS_RELAY_FEE_MICRO_USDC = 200_000n; // 0.2 USDC/USDT
-const GASLESS_STABLECOIN_MIN_AMOUNT = BigInt(5 * 1_000_000); // 5 USDC/USDT
+const GASLESS_STABLECOIN_MIN_AMOUNT = 500_000n; // 0.5 USDC/USDT
 
 const validatorCache = new Map<string, Promise<PublicKey | undefined>>();
 const transferQueueAuthErrorCounts = new Map<string, number>();

--- a/api/src/routes/spl/spl.schemas.ts
+++ b/api/src/routes/spl/spl.schemas.ts
@@ -334,7 +334,7 @@ export const transferRequestSchema = z.object({
   }).optional(),
   gasless: z.boolean().openapi({
     example: true,
-    description: "Optional. When true, the API uses the configured sponsor as transaction fee payer and prepends a 0.2 USDC/USDT relay-fee token transfer to the sponsor ATA. Requires GASLESS_SPONSOR_SECRET_KEY, an approved stablecoin mint (mainnet USDC/USDT or devnet USDC), and at least 5 USDC/USDT.",
+    description: "Optional. When true, the API uses the configured sponsor as transaction fee payer and prepends a 0.2 USDC/USDT relay-fee token transfer to the sponsor ATA. Requires GASLESS_SPONSOR_SECRET_KEY, an approved stablecoin mint (mainnet USDC/USDT or devnet USDC), and at least 0.5 USDC/USDT.",
   }).optional(),
   legacy: z.boolean().openapi({
     description: "Optional. Defaults to false. When true, skips lookup-table compilation and returns a legacy transaction.",
@@ -344,7 +344,7 @@ export const transferRequestSchema = z.object({
     from: DEPOSIT_EXAMPLE_OWNER,
     to: TRANSFER_EXAMPLE_TO,
     mint: DEFAULT_DEPOSIT_MINT,
-    amount: 5000000,
+    amount: 500000,
     visibility: "private",
     fromBalance: "base",
     toBalance: "base",


### PR DESCRIPTION
## Summary
- Lower the gasless stablecoin transfer minimum from 5 USDC/USDT to 0.5 USDC/USDT.
- Update the API docs/OpenAPI example to match the new minimum.
- Adjust an existing gasless transfer test to cover the 0.5 USDC/USDT floor.