### PR TITLE
Add transfer platform fees

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -620,7 +620,7 @@ The returned `sendTo` value is:
 - `"ephemeral"` when `fromBalance` is `"ephemeral"`
 
 Transfer responses also include `from`, which mirrors the request `fromBalance`, and `fees`.
-`fees.lamports` and `fees.tokens` are total fee strings and return `"0"` when that fee type is not charged. `fees.tokens` uses mint base units. Private `base -> base` transfers report the on-chain private-transfer token fee and shuttle setup lamport fee. Gasless transfers add the relay fee to `fees.tokens` only when gasless is honored.
+`fees.lamports` and `fees.tokens` are total fee strings and return `"0"` when that fee type is not charged. `fees.tokens` uses mint base units. Private `base -> base` transfers report the on-chain private-transfer token fee and shuttle setup lamport fee. Platform fees and gasless relay fees are added to `fees.tokens` only when charged.
 
 When `to` is not a Solana public key, the API treats it as a stealth handle. The handle must be initialized through `/v1/spl/stealth-pool`; the API derives the stealth-pool PDA, verifies that the base account exists, and builds a private `base -> base` transfer to that PDA. Stealth handle transfers require `visibility: "private"`, `fromBalance: "base"`, and `toBalance: "base"`; those are the defaults when omitted.
 
@@ -680,8 +680,18 @@ Private transfer validation:
 - `minDelayMs` must be an integer string
 - `maxDelayMs` must be an integer string
 - `split` must be an integer between `1` and `15`
-- `split` cannot exceed `amount`
+- `split` cannot exceed the transfer amount after platform-fee adjustment
 - if both delays are present, `maxDelayMs >= minDelayMs`
+
+Platform fee validation:
+
+- `platformFeeBps` is optional and defaults to `0`
+- `platformFeeBps` must be an integer between `0` and `10000`
+- when `platformFeeBps` is greater than `0`, `platformFeeAccount` is required
+- `platformFeeAccount` must be an initialized token account for the transferred mint
+- platform fees are supported only when `fromBalance` is `"base"`
+- with `exactOut: true`, the recipient receives `amount` and the sender pays `amount + platformFee`
+- with `exactOut: false`, the sender pays `amount` and the recipient receives `amount - platformFee`
 
 Gasless transfer validation:
 
@@ -712,6 +722,8 @@ Relevant fields:
 - `maxDelayMs`
 - `split`
 - `exactOut`
+- `platformFeeBps`
+- `platformFeeAccount`
 - `gasless`
 - `legacy`
 

--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -395,6 +395,8 @@ describe("app", () => {
       type: "boolean",
       example: true,
     });
+    expect(transferRequestSchema?.properties?.platformFeeBps).toBeDefined();
+    expect(transferRequestSchema?.properties?.platformFeeAccount).toBeDefined();
     expect(transferRequestSchema?.properties?.to?.description).toContain(
       "stealth handle",
     );
@@ -3536,6 +3538,164 @@ describe("app", () => {
     expect(json.version).toBe("legacy");
   });
 
+  it.each([
+    {
+      name: "exact-out",
+      exactOut: undefined,
+      expectedTransferAmount: 500_000n,
+    },
+    {
+      name: "exact-in",
+      exactOut: false,
+      expectedTransferAmount: 495_000n,
+    },
+  ])("builds a public transfer with an $name platform fee", async ({
+    exactOut,
+    expectedTransferAmount,
+  }) => {
+    const mint = DEVNET_USDC_MINT;
+    const amount = 500_000;
+    const ownerAta = deriveAssociatedTokenAddress(mint, owner);
+    const destinationAta = deriveAssociatedTokenAddress(mint, destination);
+    const platformFeeAccount = Keypair.generate().publicKey.toBase58();
+
+    vi.spyOn(Connection.prototype, "getLatestBlockhash").mockResolvedValue({
+      blockhash: "11111111111111111111111111111111",
+      lastValidBlockHeight: 123,
+    });
+    vi.spyOn(Connection.prototype, "getAccountInfo").mockResolvedValue(
+      createMintAccountInfo(TOKEN_PROGRAM_ID),
+    );
+
+    const response = await app.request(
+      "/v1/spl/transfer",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          from: owner,
+          to: destination,
+          mint,
+          amount,
+          cluster: "devnet",
+          validator: resolvedValidator,
+          visibility: "public",
+          fromBalance: "base",
+          toBalance: "base",
+          platformFeeBps: 100,
+          platformFeeAccount,
+          ...(exactOut === undefined ? {} : { exactOut }),
+        }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(200);
+
+    const json = (await response.json()) as {
+      transactionBase64: string;
+      fees: {
+        lamports: string;
+        tokens: string;
+      };
+    };
+    expect(json.fees).toEqual({
+      lamports: "0",
+      tokens: "5000",
+    });
+
+    const transaction = Transaction.from(
+      Buffer.from(json.transactionBase64, "base64"),
+    );
+    expect(transaction.instructions).toHaveLength(2);
+
+    const platformFeeIx = transaction.instructions[0]!;
+    expect(platformFeeIx.programId.toBase58()).toBe(TOKEN_PROGRAM_ID.toBase58());
+    expect(platformFeeIx.keys.map(key => key.pubkey.toBase58())).toEqual([
+      ownerAta,
+      platformFeeAccount,
+      owner,
+    ]);
+    expect(platformFeeIx.data[0]).toBe(3);
+    expect(platformFeeIx.data.readBigUInt64LE(1)).toBe(5_000n);
+
+    const publicTransferIx = transaction.instructions[1]!;
+    expect(publicTransferIx.programId.toBase58()).toBe(
+      TOKEN_PROGRAM_ID.toBase58(),
+    );
+    expect(publicTransferIx.keys.map(key => key.pubkey.toBase58())).toEqual([
+      ownerAta,
+      destinationAta,
+      owner,
+    ]);
+    expect(publicTransferIx.data[0]).toBe(3);
+    expect(publicTransferIx.data.readBigUInt64LE(1)).toBe(
+      expectedTransferAmount,
+    );
+  });
+
+  it("rejects platform fee bps without a platform fee account", async () => {
+    const response = await app.request(
+      "/v1/spl/transfer",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          from: owner,
+          to: destination,
+          mint: DEVNET_USDC_MINT,
+          amount: 500_000,
+          cluster: "devnet",
+          visibility: "public",
+          fromBalance: "base",
+          toBalance: "base",
+          platformFeeBps: 100,
+        }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(400);
+
+    const json = (await response.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("INVALID_PLATFORM_FEE");
+  });
+
+  it("rejects exact-in platform fees that consume the amount", async () => {
+    const response = await app.request(
+      "/v1/spl/transfer",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          from: owner,
+          to: destination,
+          mint: DEVNET_USDC_MINT,
+          amount: 1,
+          cluster: "devnet",
+          visibility: "public",
+          fromBalance: "base",
+          toBalance: "base",
+          exactOut: false,
+          platformFeeBps: 10_000,
+          platformFeeAccount: Keypair.generate().publicKey.toBase58(),
+        }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(400);
+
+    const json = (await response.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("INVALID_PLATFORM_FEE");
+  });
+
   it("rejects private base transfers when the source eATA is delegated to another validator", async () => {
     const transferEnv = {
       ...env,
@@ -4716,11 +4876,12 @@ describe("app", () => {
     ).toBe(true);
   });
 
-  it("builds a gasless public transfer with the sponsor as fee payer", async () => {
+  it("builds a gasless public transfer with the sponsor as fee payer and platform fee", async () => {
     const sponsor = Keypair.generate();
     const mint = DEVNET_USDC_MINT;
     const amount = 5_000_000;
     const ownerAta = deriveAssociatedTokenAddress(mint, owner);
+    const platformFeeAccount = Keypair.generate().publicKey.toBase58();
     const sponsorAta = deriveAssociatedTokenAddress(
       mint,
       sponsor.publicKey.toBase58(),
@@ -4762,6 +4923,8 @@ describe("app", () => {
           fromBalance: "base",
           toBalance: "base",
           gasless: true,
+          platformFeeBps: 100,
+          platformFeeAccount,
         }),
       },
       transferEnv,
@@ -4779,7 +4942,7 @@ describe("app", () => {
     };
     expect(json.fees).toEqual({
       lamports: "0",
-      tokens: "200000",
+      tokens: "250000",
     });
     expect(json.requiredSigners).toEqual(
       expect.arrayContaining([owner, sponsor.publicKey.toBase58()]),
@@ -4789,7 +4952,12 @@ describe("app", () => {
       Buffer.from(json.transactionBase64, "base64"),
     );
     expect(transaction.feePayer?.toBase58()).toBe(sponsor.publicKey.toBase58());
-    expect(transaction.instructions).toHaveLength(2);
+    expect(transaction.instructions).toHaveLength(3);
+    const sponsorSignature = transaction.signatures.find(
+      signature =>
+        signature.publicKey.toBase58() === sponsor.publicKey.toBase58(),
+    );
+    expect(sponsorSignature?.signature).not.toBeNull();
 
     const relayFeeIx = transaction.instructions[0]!;
     expect(relayFeeIx.programId.toBase58()).toBe(TOKEN_PROGRAM_ID.toBase58());
@@ -4801,7 +4969,17 @@ describe("app", () => {
     expect(relayFeeIx.data[0]).toBe(3);
     expect(relayFeeIx.data.readBigUInt64LE(1)).toBe(200_000n);
 
-    const publicTransferIx = transaction.instructions[1]!;
+    const platformFeeIx = transaction.instructions[1]!;
+    expect(platformFeeIx.programId.toBase58()).toBe(TOKEN_PROGRAM_ID.toBase58());
+    expect(platformFeeIx.keys.map(key => key.pubkey.toBase58())).toEqual([
+      ownerAta,
+      platformFeeAccount,
+      owner,
+    ]);
+    expect(platformFeeIx.data[0]).toBe(3);
+    expect(platformFeeIx.data.readBigUInt64LE(1)).toBe(50_000n);
+
+    const publicTransferIx = transaction.instructions[2]!;
     expect(publicTransferIx.programId.toBase58()).toBe(
       TOKEN_PROGRAM_ID.toBase58(),
     );

--- a/api/src/lib/solana.ts
+++ b/api/src/lib/solana.ts
@@ -1404,6 +1404,10 @@ function privateTransferFeeAmount(amount: bigint) {
   return amount * PRIVATE_TRANSFER_FEE_BASIS_POINTS / BASIS_POINTS_FACTOR;
 }
 
+function platformTransferFeeAmount(amount: bigint, platformFeeBps: number) {
+  return amount * BigInt(platformFeeBps) / BASIS_POINTS_FACTOR;
+}
+
 function isPrivateBaseToBaseTransfer(input: TransferRequest) {
   return input.visibility === "private"
     && input.fromBalance === "base"
@@ -1913,6 +1917,32 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
     const maxDelayMs = parseOptionalAmount(input.maxDelayMs, "maxDelayMs");
     const clientRefId = parseOptionalAmount(input.clientRefId, "clientRefId");
     const split = input.split;
+    const exactOut = input.exactOut ?? true;
+    const platformFeeBps = input.platformFeeBps ?? 0;
+    let platformFeeAccount: PublicKey | undefined;
+
+    if (!Number.isSafeInteger(platformFeeBps) || platformFeeBps < 0 || platformFeeBps > 10_000) {
+      throw new ApiError(400, "INVALID_PLATFORM_FEE", "platformFeeBps must be an integer between 0 and 10000");
+    }
+
+    if (platformFeeBps > 0) {
+      if (input.platformFeeAccount === undefined) {
+        throw new ApiError(400, "INVALID_PLATFORM_FEE", "platformFeeAccount is required when platformFeeBps is greater than 0");
+      }
+
+      if (input.fromBalance !== "base") {
+        throw new ApiError(400, "INVALID_PLATFORM_FEE", "platform fees are supported only when fromBalance is \"base\"");
+      }
+
+      platformFeeAccount = parsePublicKey(input.platformFeeAccount, "platformFeeAccount");
+    }
+
+    const platformFee = platformTransferFeeAmount(amount, platformFeeBps);
+    if (!exactOut && platformFee >= amount) {
+      throw new ApiError(400, "INVALID_PLATFORM_FEE", "platform fee must be less than amount when exactOut is false");
+    }
+
+    const transferAmount = exactOut ? amount : amount - platformFee;
 
     if (minDelayMs !== undefined && minDelayMs < 0n) {
       throw new ApiError(400, "INVALID_PRIVATE_TRANSFER", "minDelayMs must be non-negative");
@@ -1952,8 +1982,8 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
       throw new ApiError(400, "INVALID_PRIVATE_TRANSFER", "split must be an integer between 1 and 15");
     }
 
-    if (split !== undefined && BigInt(split) > amount) {
-      throw new ApiError(400, "INVALID_PRIVATE_TRANSFER", "split cannot exceed amount");
+    if (split !== undefined && BigInt(split) > transferAmount) {
+      throw new ApiError(400, "INVALID_PRIVATE_TRANSFER", "split cannot exceed transfer amount");
     }
 
     const useGasless = input.gasless === true && PublicKey.isOnCurve(from.toBuffer());
@@ -1977,10 +2007,10 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
     const sponsor = useGasless ? getGaslessSponsorKeypair(env) : undefined;
     const payer = sponsor?.publicKey ?? from;
     const feePayer = sponsor?.publicKey ?? from;
-    const privateTransferFee = isPrivateBaseToBaseTransfer(input) ? privateTransferFeeAmount(amount) : 0n;
+    const privateTransferFee = isPrivateBaseToBaseTransfer(input) ? privateTransferFeeAmount(transferAmount) : 0n;
     const fees = createTransferFees(
       privateTransferSetupLamports(input),
-      privateTransferFee + (sponsor ? GASLESS_RELAY_FEE_MICRO_USDC : 0n),
+      privateTransferFee + platformFee + (sponsor ? GASLESS_RELAY_FEE_MICRO_USDC : 0n),
     );
 
     const shouldResolveValidator = input.validator
@@ -2024,9 +2054,9 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
 
     const sendTo: SendTarget = input.fromBalance === "ephemeral" ? "ephemeral" : "base";
     const blockhash = await getBlockhash(config, sendTo, authToken);
-    const nativeSolWrapAmount = isPrivateBaseToBaseTransfer(input) && (input.exactOut ?? true)
-      ? amount + privateTransferFee
-      : amount;
+    const nativeSolWrapAmount = transferAmount + platformFee + (
+      isPrivateBaseToBaseTransfer(input) && exactOut ? privateTransferFee : 0n
+    );
     const nativeSolWrapInstructions = input.visibility === "private" && input.fromBalance === "base"
       ? await createNativeSolWrapInstructionsIfNeeded(
           config,
@@ -2037,8 +2067,19 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
           tokenProgram,
         )
       : [];
+    const platformFeeInstructions = platformFee > 0n && platformFeeAccount
+      ? [
+          createTokenTransferInstruction(
+            getAssociatedTokenAddressSync(mint, from, false, tokenProgram),
+            platformFeeAccount,
+            from,
+            platformFee,
+            tokenProgram,
+          ),
+        ]
+      : [];
 
-    const transferInstructions = await transferSpl(from, to, mint, amount, {
+    const transferInstructions = await transferSpl(from, to, mint, transferAmount, {
       visibility: input.visibility,
       fromBalance: input.fromBalance,
       toBalance: input.toBalance,
@@ -2055,12 +2096,12 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
             maxDelayMs,
             clientRefId,
             split,
-            exactOut: input.exactOut ?? true,
+            exactOut,
           }
         : undefined,
     });
     const normalizedTransferInstructions = transferInstructions.map(instruction =>
-      withPrivateTransferExactOut(instruction, input.exactOut ?? true));
+      withPrivateTransferExactOut(instruction, exactOut));
     // Gasless private base->base already adds a relay-fee token transfer. Dropping
     // the opportunistic queue-refill ix keeps the full transaction under Solana's
     // packet limit while preserving the actual private transfer instruction.
@@ -2075,6 +2116,7 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
     const instructions = [
       ...nativeSolWrapInstructions,
       ...gaslessFeeInstructions,
+      ...platformFeeInstructions,
       ...effectiveTransferInstructions,
       ...(input.memo !== undefined ? [createMemoInstruction(input.memo)] : []),
     ];

--- a/api/src/routes/spl/spl.schemas.ts
+++ b/api/src/routes/spl/spl.schemas.ts
@@ -332,6 +332,14 @@ export const transferRequestSchema = z.object({
     example: boolean,
     description: "Optional. If true, the fees are deducted from the sender, else from the recipient amount",
   }).optional(),
+  platformFeeBps: z.number().int().nonnegative().max(10_000).openapi({
+    example: 100,
+    description: "Optional platform fee in basis points, charged in the transferred token.",
+  }).optional(),
+  platformFeeAccount: publicKeySchema.openapi({
+    example: "6QxLzE2KfM1NAB7sTzUPk4cNsA6V9fB3eYq9s6d9r9hP",
+    description: "Required when platformFeeBps is greater than 0. Initialized token account that collects the platform fee.",
+  }).optional(),
   gasless: z.boolean().openapi({
     example: true,
     description: "Optional. When true, the API uses the configured sponsor as transaction fee payer and prepends a 0.2 USDC/USDT relay-fee token transfer to the sponsor ATA. Requires GASLESS_SPONSOR_SECRET_KEY, an approved stablecoin mint (mainnet USDC/USDT or devnet USDC), and at least 0.5 USDC/USDT.",


### PR DESCRIPTION
## Summary
- add optional `platformFeeBps` and `platformFeeAccount` fields to transfer requests
- include platform fee token transfers in the built transaction before serialization and sponsor signing
- keep `exactOut` semantics explicit: exact-out preserves recipient amount, exact-in deducts the platform fee from the recipient transfer amount
- document validation rules and add focused transfer/gasless coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional platform fees on SPL transfers, including a destination account for receiving those fees.
  * Improved transfer handling for exact-in and exact-out flows when fees and splits are applied.

* **Bug Fixes**
  * Tightened transfer validation so splits can’t exceed the remaining transfer amount.
  * Clarified and enforced fee rules, including required account details and limits on fee values.

* **Documentation**
  * Updated transfer API docs and examples to reflect the new fee fields and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->