### PR TITLE
feat: native SOL delivery with platform fee support

### DIFF
--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -242,6 +242,9 @@ describe("app", () => {
     vi.spyOn(Connection.prototype, "getMultipleAccountsInfo").mockImplementation(
       async addresses => addresses.map(() => null),
     );
+    // Private SOL transfers read the rent PDA (top-up) and recipient (dust floor) balances.
+    // Default to fully funded; tests exercising those paths override this spy.
+    vi.spyOn(Connection.prototype, "getBalance").mockResolvedValue(1_000_000_000);
   });
 
   afterEach(() => {
@@ -5298,6 +5301,257 @@ describe("app", () => {
     expect(json.error.message).toBe(
       "maxDelayMs must be less than or equal to 600000",
     );
+  });
+
+  it("rejects private SOL dust transfers to unfunded recipients", async () => {
+    vi.spyOn(Connection.prototype, "getBalance").mockResolvedValue(0);
+
+    const response = await app.request(
+      "/v1/spl/transfer",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          from: owner,
+          to: destination,
+          mint: "So11111111111111111111111111111111111111112",
+          amount: 1000,
+          visibility: "private",
+          fromBalance: "base",
+          toBalance: "base",
+        }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(400);
+
+    const json = (await response.json()) as {
+      error: {
+        code: string;
+        message: string;
+      };
+    };
+
+    expect(json.error.code).toBe("INVALID_PRIVATE_TRANSFER");
+    expect(json.error.message).toBe(
+      "private SOL transfers settle as native SOL and require at least 890880 lamports per split for an unfunded recipient",
+    );
+  });
+
+  it("charges SOL platform fees as native lamports from the sender wallet", async () => {
+    const mint = new PublicKey("So11111111111111111111111111111111111111112");
+    const sourceAta = new PublicKey(
+      deriveAssociatedTokenAddress(mint.toBase58(), owner),
+    );
+    const platformFeeWallet = Keypair.generate().publicKey;
+    const amount = 5_000_000;
+    const expectedFee = 50_000n; // 100 bps of amount
+
+    vi.spyOn(Connection.prototype, "getLatestBlockhash").mockResolvedValue({
+      blockhash: "11111111111111111111111111111111",
+      lastValidBlockHeight: 123,
+    });
+    vi.spyOn(Connection.prototype, "getAccountInfo").mockImplementation(
+      async (address) => {
+        if (address.equals(mint)) {
+          return createMintAccountInfo(TOKEN_PROGRAM_ID);
+        }
+
+        if (address.equals(sourceAta)) {
+          return createAccountInfo(1_000_000_000n);
+        }
+
+        return null;
+      },
+    );
+
+    const response = await app.request(
+      "/v1/spl/transfer",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          from: owner,
+          to: destination,
+          mint: mint.toBase58(),
+          amount,
+          visibility: "private",
+          fromBalance: "base",
+          toBalance: "base",
+          validator: resolvedValidator,
+          platformFeeBps: 100,
+          platformFeeAccount: platformFeeWallet.toBase58(),
+          legacy: true,
+        }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(200);
+
+    const json = (await response.json()) as {
+      transactionBase64: string;
+    };
+    const transaction = Transaction.from(
+      Buffer.from(json.transactionBase64, "base64"),
+    );
+
+    // The fee arrives as a native lamport transfer to the fee wallet, not a token transfer.
+    const feeIx = transaction.instructions.find((ix) => {
+      if (!ix.programId.equals(SystemProgram.programId)) {
+        return false;
+      }
+      try {
+        return SystemInstruction.decodeTransfer(ix).toPubkey.equals(
+          platformFeeWallet,
+        );
+      } catch {
+        return false;
+      }
+    });
+    expect(feeIx).toBeDefined();
+    const decodedFee = SystemInstruction.decodeTransfer(feeIx!);
+    expect(decodedFee.fromPubkey.toBase58()).toBe(owner);
+    expect(BigInt(decodedFee.lamports)).toBe(expectedFee);
+
+    const tokenTransferToFeeWallet = transaction.instructions.some(
+      (ix) =>
+        ix.programId.equals(TOKEN_PROGRAM_ID)
+        && ix.keys.some(key => key.pubkey.equals(platformFeeWallet)),
+    );
+    expect(tokenTransferToFeeWallet).toBe(false);
+  });
+
+  it("allows private SOL dust transfers when the recipient is already funded", async () => {
+    const mint = new PublicKey("So11111111111111111111111111111111111111112");
+    const sourceAta = new PublicKey(
+      deriveAssociatedTokenAddress(mint.toBase58(), owner),
+    );
+
+    vi.spyOn(Connection.prototype, "getBalance").mockResolvedValue(
+      1_000_000_000,
+    );
+    vi.spyOn(Connection.prototype, "getLatestBlockhash").mockResolvedValue({
+      blockhash: "11111111111111111111111111111111",
+      lastValidBlockHeight: 123,
+    });
+    vi.spyOn(Connection.prototype, "getAccountInfo").mockImplementation(
+      async (address) => {
+        if (address.equals(mint)) {
+          return createMintAccountInfo(TOKEN_PROGRAM_ID);
+        }
+
+        if (address.equals(sourceAta)) {
+          return createAccountInfo(1_000_000_000n);
+        }
+
+        return null;
+      },
+    );
+
+    const response = await app.request(
+      "/v1/spl/transfer",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          from: owner,
+          to: destination,
+          mint: mint.toBase58(),
+          amount: 1000,
+          visibility: "private",
+          fromBalance: "base",
+          toBalance: "base",
+          validator: resolvedValidator,
+          legacy: true,
+        }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("tops up the rent PDA for private SOL transfers when the rent PDA is short", async () => {
+    const mint = new PublicKey("So11111111111111111111111111111111111111112");
+    const sourceAta = new PublicKey(
+      deriveAssociatedTokenAddress(mint.toBase58(), owner),
+    );
+    const [rentPda] = deriveRentPda();
+    // Above the unfunded-recipient minimum, so no recipient balance lookup happens and
+    // getBalance only serves the rent PDA top-up check.
+    const amount = 5_000_000;
+
+    vi.spyOn(Connection.prototype, "getBalance").mockResolvedValue(500_000);
+    vi.spyOn(Connection.prototype, "getLatestBlockhash").mockResolvedValue({
+      blockhash: "11111111111111111111111111111111",
+      lastValidBlockHeight: 123,
+    });
+    vi.spyOn(Connection.prototype, "getAccountInfo").mockImplementation(
+      async (address) => {
+        if (address.equals(mint)) {
+          return createMintAccountInfo(TOKEN_PROGRAM_ID);
+        }
+
+        if (address.equals(sourceAta)) {
+          return createAccountInfo(1_000_000_000n);
+        }
+
+        return null;
+      },
+    );
+
+    const response = await app.request(
+      "/v1/spl/transfer",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          from: owner,
+          to: destination,
+          mint: mint.toBase58(),
+          amount,
+          visibility: "private",
+          fromBalance: "base",
+          toBalance: "base",
+          validator: resolvedValidator,
+          legacy: true,
+        }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(200);
+
+    const json = (await response.json()) as {
+      transactionBase64: string;
+    };
+    const transaction = Transaction.from(
+      Buffer.from(json.transactionBase64, "base64"),
+    );
+    const rentTopUpIx = transaction.instructions.find((ix) => {
+      if (!ix.programId.equals(SystemProgram.programId)) {
+        return false;
+      }
+      try {
+        return SystemInstruction.decodeTransfer(ix).toPubkey.equals(rentPda);
+      } catch {
+        return false;
+      }
+    });
+    expect(rentTopUpIx).toBeDefined();
+    const decodedTransfer = SystemInstruction.decodeTransfer(rentTopUpIx!);
+    expect(decodedTransfer.fromPubkey.toBase58()).toBe(owner);
+    expect(BigInt(decodedTransfer.lamports)).toBe(19_500_000n);
   });
 
   it("appends a memo instruction to transfers when memo is provided", async () => {

--- a/api/src/lib/solana.ts
+++ b/api/src/lib/solana.ts
@@ -123,6 +123,10 @@ const PRIVATE_TRANSFER_FEE_BASIS_POINTS = 10n;
 const BASIS_POINTS_FACTOR = 10_000n;
 const GASLESS_RELAY_FEE_MICRO_USDC = 200_000n; // 0.2 USDC/USDT
 const GASLESS_STABLECOIN_MIN_AMOUNT = 500_000n; // 0.5 USDC/USDT
+// Rent-exempt minimum for a zero-data system account. Private wrapped-SOL transfers settle as
+// native SOL for wallet recipients; a payout that would leave an unfunded wallet below this
+// floor falls back to wrapped-SOL delivery at settlement, so reject it at build time instead.
+const NATIVE_DELIVERY_MIN_UNFUNDED_RECIPIENT_LAMPORTS = 890_880n;
 
 const validatorCache = new Map<string, Promise<PublicKey | undefined>>();
 const transferQueueAuthErrorCounts = new Map<string, number>();
@@ -1986,6 +1990,49 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
       throw new ApiError(400, "INVALID_PRIVATE_TRANSFER", "split cannot exceed transfer amount");
     }
 
+    // Private SOL transfers settle as native lamports or bounce back to the sender through
+    // the refund path — recipients never receive wrapped SOL. Reject builds that are
+    // guaranteed to bounce at settlement.
+    if (
+      input.visibility === "private"
+      && input.toBalance === "base"
+      && input.mint === NATIVE_MINT.toBase58()
+    ) {
+      const walletDestination = tryParsePublicKey(input.to);
+      const chunkAmount = transferAmount / BigInt(split ?? 1);
+
+      if (chunkAmount < NATIVE_DELIVERY_MIN_UNFUNDED_RECIPIENT_LAMPORTS) {
+        if (walletDestination === undefined) {
+          // Stealth destinations resolve to fresh one-time keys at settlement, which cannot
+          // absorb sub-rent-exempt payouts.
+          throw new ApiError(
+            400,
+            "INVALID_PRIVATE_TRANSFER",
+            `private SOL transfers settle as native SOL and require at least ${NATIVE_DELIVERY_MIN_UNFUNDED_RECIPIENT_LAMPORTS} lamports per split for stealth destinations`,
+          );
+        }
+
+        let recipientLamports: bigint;
+        try {
+          recipientLamports = BigInt(await getBaseConnection(config).getBalance(to, "confirmed"));
+        } catch (error) {
+          throw new ApiError(502, "RPC_ERROR", "Failed to fetch recipient balance", {
+            recipient: to.toBase58(),
+            message: getSanitizedErrorMessage(error),
+          });
+        }
+
+        if (recipientLamports === 0n) {
+          throw new ApiError(
+            400,
+            "INVALID_PRIVATE_TRANSFER",
+            `private SOL transfers settle as native SOL and require at least ${NATIVE_DELIVERY_MIN_UNFUNDED_RECIPIENT_LAMPORTS} lamports per split for an unfunded recipient`,
+          );
+        }
+      }
+
+    }
+
     const useGasless = input.gasless === true && PublicKey.isOnCurve(from.toBuffer());
 
     if (useGasless && !isSupportedGaslessMint(config.cluster, mint)) {
@@ -2054,7 +2101,11 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
 
     const sendTo: SendTarget = input.fromBalance === "ephemeral" ? "ephemeral" : "base";
     const blockhash = await getBlockhash(config, sendTo, authToken);
-    const nativeSolWrapAmount = transferAmount + platformFee + (
+    // SOL-mint platform fees are charged as native lamports straight from the sender wallet
+    // (platformFeeAccount is then a wallet or any lamport-receivable account, consistent with
+    // native SOL delivery semantics), so the fee portion is excluded from the wrap amount.
+    const chargePlatformFeeInLamports = mint.equals(NATIVE_MINT) && tokenProgram.equals(TOKEN_PROGRAM_ID);
+    const nativeSolWrapAmount = transferAmount + (chargePlatformFeeInLamports ? 0n : platformFee) + (
       isPrivateBaseToBaseTransfer(input) && exactOut ? privateTransferFee : 0n
     );
     const nativeSolWrapInstructions = input.visibility === "private" && input.fromBalance === "base"
@@ -2069,14 +2120,33 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
       : [];
     const platformFeeInstructions = platformFee > 0n && platformFeeAccount
       ? [
-          createTokenTransferInstruction(
-            getAssociatedTokenAddressSync(mint, from, false, tokenProgram),
-            platformFeeAccount,
-            from,
-            platformFee,
-            tokenProgram,
-          ),
+          chargePlatformFeeInLamports
+            ? SystemProgram.transfer({
+                fromPubkey: from,
+                toPubkey: platformFeeAccount,
+                lamports: platformFee,
+              })
+            : createTokenTransferInstruction(
+                getAssociatedTokenAddressSync(mint, from, false, tokenProgram),
+                platformFeeAccount,
+                from,
+                platformFee,
+                tokenProgram,
+              ),
         ]
+      : [];
+    // Native SOL settlement runs through a rent-PDA-funded scratch account, so keep the rent
+    // PDA topped up from the sender, mirroring the SOL deposit flow (the helper is a no-op for
+    // non-native mints). Ephemeral-sourced transfers execute on the ER where the base-layer
+    // rent PDA is unreachable; those rely on deposit-time top-ups instead.
+    const nativeSolRentPdaTopUpInstructions = input.visibility === "private" && input.fromBalance === "base"
+      ? await createNativeSolRentPdaTopUpInstructionsIfNeeded(
+          config,
+          payer,
+          mint,
+          transferAmount,
+          tokenProgram,
+        )
       : [];
 
     const transferInstructions = await transferSpl(from, to, mint, transferAmount, {
@@ -2115,6 +2185,7 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
 
     const instructions = [
       ...nativeSolWrapInstructions,
+      ...nativeSolRentPdaTopUpInstructions,
       ...gaslessFeeInstructions,
       ...platformFeeInstructions,
       ...effectiveTransferInstructions,

--- a/api/src/routes/spl/spl.schemas.ts
+++ b/api/src/routes/spl/spl.schemas.ts
@@ -334,11 +334,11 @@ export const transferRequestSchema = z.object({
   }).optional(),
   platformFeeBps: z.number().int().nonnegative().max(10_000).openapi({
     example: 100,
-    description: "Optional platform fee in basis points, charged in the transferred token.",
+    description: "Optional platform fee in basis points, charged in the transferred token. For the wrapped SOL mint the fee is charged as native lamports from the sender wallet.",
   }).optional(),
   platformFeeAccount: publicKeySchema.openapi({
     example: "6QxLzE2KfM1NAB7sTzUPk4cNsA6V9fB3eYq9s6d9r9hP",
-    description: "Required when platformFeeBps is greater than 0. Initialized token account that collects the platform fee.",
+    description: "Required when platformFeeBps is greater than 0. Initialized token account that collects the platform fee. For the wrapped SOL mint, a wallet (or any lamport-receivable) address that collects the fee as native SOL.",
   }).optional(),
   gasless: z.boolean().openapi({
     example: true,

--- a/e-token/src/processor/close_shuttle_ata_intent.rs
+++ b/e-token/src/processor/close_shuttle_ata_intent.rs
@@ -7,13 +7,22 @@ use ephemeral_spl_api::{
         stash::StashPda,
     },
 };
-use pinocchio::{cpi::Signer, error::ProgramError, AccountView, ProgramResult};
-use pinocchio_system::instructions::Transfer;
+use pinocchio::{
+    cpi::{Seed, Signer},
+    error::ProgramError,
+    sysvars::{rent::Rent, Sysvar},
+    AccountView, ProgramResult,
+};
+use pinocchio_system::{instructions::Transfer, ID as SYSTEM_PROGRAM_ID};
 use pinocchio_token_2022::instructions::CloseAccount;
-use solana_address::Address;
+use solana_address::{address_eq, Address};
+use spl_token_interface::ID as SPL_TOKEN_PROGRAM_ID;
 
 use crate::processor::internal::{
-    get_associated_token_address, rent_pda::RENT_PDA, token_vault::withdraw_ephemeral_ata_tokens,
+    get_associated_token_address,
+    rent_pda::{RENT_PDA, RENT_PDA_BUMP, RENT_PDA_SEED},
+    token_vault::withdraw_ephemeral_ata_tokens,
+    unwrap_pda::{NATIVE_MINT, UNWRAP_PDA, UNWRAP_PDA_BUMP, UNWRAP_PDA_SEED},
     validate_token_account,
 };
 const DLP_EPHEMERAL_BALANCE_TAG: &[u8] = b"balance";
@@ -43,8 +52,15 @@ const CLOSE_STASH_DATA_LEN: usize = 33;
 /// escrow authority is the stash PDA and account 0 is the rent sink.
 ///
 pub fn process_close_shuttle_ata_intent(accounts: &[AccountView], instruction_data: &[u8]) -> ProgramResult {
-    let (head_accounts, source_program, escrow_authority, escrow_signer) = match accounts.len() {
-        12 => (&accounts[..9], &accounts[9], &accounts[10], &accounts[11]),
+    let (head_accounts, native_accounts, source_program, escrow_authority, escrow_signer) = match accounts.len() {
+        12 => (&accounts[..9], None, &accounts[9], &accounts[10], &accounts[11]),
+        18 => (
+            &accounts[..9],
+            Some(&accounts[9..15]),
+            &accounts[15],
+            &accounts[16],
+            &accounts[17],
+        ),
         _ => return Err(ProgramError::NotEnoughAccountKeys),
     };
     let [
@@ -168,17 +184,46 @@ pub fn process_close_shuttle_ata_intent(accounts: &[AccountView], instruction_da
         if shuttle_ephemeral_amount != 0 {
             require_eq_keys!(&mint, mint_info.address(), ProgramError::InvalidAccountData);
 
-            withdraw_ephemeral_ata_tokens(
-                shuttle_info,
-                false,
-                shuttle_ephemeral_ata_info,
-                vault_info,
-                mint_info,
-                vault_source_token_acc,
-                destination_token_info,
-                token_program_info,
-                shuttle_ephemeral_amount,
-            )?;
+            match native_accounts {
+                Some(native_accounts)
+                    if shuttle_native_delivery_eligible(
+                        native_accounts,
+                        mint_info,
+                        token_program_info,
+                        shuttle_ephemeral_amount,
+                    )? =>
+                {
+                    deliver_shuttle_native(
+                        native_accounts,
+                        shuttle_owner,
+                        shuttle_info,
+                        shuttle_ephemeral_ata_info,
+                        vault_info,
+                        mint_info,
+                        vault_source_token_acc,
+                        token_program_info,
+                        shuttle_ephemeral_amount,
+                    )?;
+                }
+                _ => {
+                    if native_accounts.is_some() {
+                        // Owner wallet or mint state no longer supports a native payout;
+                        // deliver the wrapped token to the owner ATA instead of failing.
+                        pinocchio_log::log!("deliver_native: falling back to token delivery");
+                    }
+                    withdraw_ephemeral_ata_tokens(
+                        shuttle_info,
+                        false,
+                        shuttle_ephemeral_ata_info,
+                        vault_info,
+                        mint_info,
+                        vault_source_token_acc,
+                        destination_token_info,
+                        token_program_info,
+                        shuttle_ephemeral_amount,
+                    )?;
+                }
+            }
         }
 
         let derived_shuttle = ShuttleMetadata::derive_pda(shuttle_owner, &mint, shuttle_id, shuttle_bump)?;
@@ -292,4 +337,159 @@ fn close_program_account_to_recipient(account: &AccountView, recipient: &Account
     recipient.set_lamports(updated_recipient_lamports);
     account.set_lamports(0);
     account.close()
+}
+
+/// A native payout is only attempted when the mint, token program, and owner-wallet state all
+/// support it; anything else degrades to the regular wrapped-token delivery so the withdrawal
+/// still completes.
+///
+/// Unlike queued-transfer settlement (which hard-fails into the refund path so third-party
+/// recipients never receive wrapped SOL), this close intent deliberately keeps the fallback:
+/// it pays the withdrawing owner their own funds, and a failed close intent has no retry, so
+/// degrading to the owner's wrapped-SOL ATA is strictly safer than stranding the balance.
+/// Identity checks on program-derived accounts stay hard errors inside
+/// `deliver_shuttle_native`.
+#[inline(always)]
+fn shuttle_native_delivery_eligible(
+    native_accounts: &[AccountView],
+    mint_info: &AccountView,
+    token_program_info: &AccountView,
+    amount: u64,
+) -> Result<bool, ProgramError> {
+    let owner_wallet_info = native_accounts.get(3).ok_or(ProgramError::NotEnoughAccountKeys)?;
+
+    if !address_eq(mint_info.address(), &NATIVE_MINT)
+        || !address_eq(token_program_info.address(), &SPL_TOKEN_PROGRAM_ID)
+    {
+        return Ok(false);
+    }
+
+    if !owner_wallet_info.owned_by(&SYSTEM_PROGRAM_ID) {
+        return Ok(false);
+    }
+
+    // An unfunded wallet must end at or above the rent-exempt floor or the system transfer
+    // would fail the whole close intent.
+    if owner_wallet_info.lamports() == 0 && amount < Rent::get()?.try_minimum_balance(0)? {
+        return Ok(false);
+    }
+
+    Ok(true)
+}
+
+/// Unwrap the shuttle's wrapped-SOL balance and pay the owner in native lamports.
+///
+/// The scratch WSOL account is created, filled with exactly `amount` (moved from the vault while
+/// decrementing the shuttle ephemeral ATA), and closed within this instruction, so the rent PDA is
+/// net-neutral and the owner receives exactly `amount` native lamports.
+#[allow(clippy::too_many_arguments)]
+#[inline(never)]
+fn deliver_shuttle_native(
+    native_accounts: &[AccountView],
+    owner: &Address,
+    shuttle_info: &AccountView,
+    shuttle_ephemeral_ata_info: &AccountView,
+    vault_info: &AccountView,
+    mint_info: &AccountView,
+    vault_source_token_acc: &AccountView,
+    token_program_info: &AccountView,
+    amount: u64,
+) -> ProgramResult {
+    let [
+        rent_pda_info, // force multi-line
+        scratch_wsol_ata_info,
+        unwrap_pda_info,
+        owner_wallet_info,
+        system_program_info,
+        associated_token_program_info,
+    ] = require_n_accounts!(native_accounts, 6);
+
+    // Native unwrap only applies to the classic SPL Token wrapped-SOL mint.
+    require_eq_keys!(mint_info.address(), &NATIVE_MINT, ProgramError::InvalidAccountData);
+    require!(
+        address_eq(token_program_info.address(), &SPL_TOKEN_PROGRAM_ID),
+        ProgramError::IncorrectProgramId
+    );
+
+    // Recipient must be the shuttle owner's plain system wallet.
+    require_eq_keys!(owner_wallet_info.address(), owner, ProgramError::InvalidAccountData);
+    require!(
+        owner_wallet_info.owned_by(&SYSTEM_PROGRAM_ID),
+        ProgramError::InvalidAccountOwner
+    );
+
+    // Rent PDA funds the scratch account and sinks the unwrapped lamports.
+    require!(
+        rent_pda_info.owned_by(&SYSTEM_PROGRAM_ID),
+        ProgramError::InvalidAccountOwner
+    );
+    require_eq_keys!(&RENT_PDA, rent_pda_info.address(), ProgramError::InvalidSeeds);
+    require!(rent_pda_info.data_len() == 0, ProgramError::InvalidAccountData);
+    require!(
+        associated_token_program_info.address() == &pinocchio_associated_token_account::ID
+            && system_program_info.address() == &SYSTEM_PROGRAM_ID,
+        ProgramError::InvalidAccountData
+    );
+
+    // Scratch account must be the unwrap PDA's ATA for this mint.
+    require_eq_keys!(unwrap_pda_info.address(), &UNWRAP_PDA, ProgramError::InvalidSeeds);
+    let expected_scratch =
+        get_associated_token_address(&UNWRAP_PDA, mint_info.address(), token_program_info.address());
+    require_eq_keys!(
+        &expected_scratch,
+        scratch_wsol_ata_info.address(),
+        ProgramError::InvalidSeeds
+    );
+
+    let rent_bump_seed = [RENT_PDA_BUMP];
+    let rent_signer_seed = [Seed::from(RENT_PDA_SEED), Seed::from(&rent_bump_seed)];
+    let rent_signer = Signer::from(&rent_signer_seed);
+
+    // 1. Create the scratch WSOL account (funded by the rent PDA).
+    (pinocchio_associated_token_account::instructions::CreateIdempotent {
+        funding_account: rent_pda_info,
+        account: scratch_wsol_ata_info,
+        wallet: unwrap_pda_info,
+        mint: mint_info,
+        system_program: system_program_info,
+        token_program: token_program_info,
+    })
+    .invoke_signed(&[rent_signer])?;
+
+    // 2. Move exactly `amount` wrapped SOL from the vault into the scratch account and decrement
+    //    the shuttle ephemeral ATA balance (vault-PDA signed inside the helper).
+    withdraw_ephemeral_ata_tokens(
+        shuttle_info,
+        false,
+        shuttle_ephemeral_ata_info,
+        vault_info,
+        mint_info,
+        vault_source_token_acc,
+        scratch_wsol_ata_info,
+        token_program_info,
+        amount,
+    )?;
+
+    // 3. Close the scratch account, unwrapping lamports (scratch rent + `amount`) to the rent PDA.
+    let unwrap_bump_seed = [UNWRAP_PDA_BUMP];
+    let unwrap_signer_seed = [Seed::from(UNWRAP_PDA_SEED), Seed::from(&unwrap_bump_seed)];
+    let unwrap_signer = Signer::from(&unwrap_signer_seed);
+    CloseAccount {
+        account: scratch_wsol_ata_info,
+        destination: rent_pda_info,
+        authority: unwrap_pda_info,
+        token_program: token_program_info.address(),
+    }
+    .invoke_signed(&[unwrap_signer])?;
+
+    // 4. Forward exactly `amount` native lamports from the rent PDA to the owner wallet.
+    let rent_signer = Signer::from(&rent_signer_seed);
+    Transfer {
+        from: rent_pda_info,
+        to: owner_wallet_info,
+        lamports: amount,
+    }
+    .invoke_signed(&[rent_signer])?;
+
+    Ok(())
 }

--- a/e-token/src/processor/execute_ready_queued_transfer.rs
+++ b/e-token/src/processor/execute_ready_queued_transfer.rs
@@ -8,13 +8,17 @@ use pinocchio::{
     error::ProgramError,
     AccountView, ProgramResult,
 };
-use pinocchio_system::ID as SYSTEM_PROGRAM_ID;
+use pinocchio_system::{instructions::Transfer, ID as SYSTEM_PROGRAM_ID};
+use pinocchio_token_2022::instructions::{CloseAccount, TransferChecked};
+use solana_address::address_eq;
+use spl_token_interface::ID as SPL_TOKEN_PROGRAM_ID;
 use wheels::layout::Decodable as _;
 
 use crate::processor::internal::{
-    read_mint_decimals,
+    get_associated_token_address, read_mint_decimals,
     rent_pda::{RENT_PDA, RENT_PDA_BUMP, RENT_PDA_SEED},
     token_vault::validate_vault_for_mint,
+    unwrap_pda::{NATIVE_MINT, UNWRAP_PDA, UNWRAP_PDA_BUMP, UNWRAP_PDA_SEED},
 };
 
 ///
@@ -25,20 +29,42 @@ use crate::processor::internal::{
 ///  0: []                  - PDA     : Global vault account.
 ///  1: []                  - SPL     : Mint account.
 ///  2: [writable]          - SPL     : Vault token account.
-///  3: []                  - Any     : Destination owner.
+///  3: []                  - Any     : Destination owner. (writable when delivering native SOL)
 ///  4: [writable]          - SPL     : Destination token account.
 ///  5: [writable]          - PDA     : Global rent PDA.
 ///  6: []                  - SPL     : Token program.
 ///  7: []                  - SPL     : Associated token program.
 ///  8: []                  - Builtin : System program.
-///  9: []                  - Program : Source program (must equal this program).
-/// 10: []                  - PDA     : Queue PDA authority.
-/// 11: [signer]            - PDA     : Escrow signer PDA.
+///
+/// For native-mint (wrapped SOL) settlements the scheduler inserts two extra accounts before
+/// DLP's appended trio; when present, the settlement unwraps and pays native lamports or
+/// fails into the standard refund path (recipients never receive wrapped SOL):
+///
+///  9: [writable]          - SPL     : Unwrap scratch WSOL token account (ATA of the unwrap PDA).
+/// 10: []                  - PDA     : Unwrap PDA (owner/authority of the scratch account).
+///
+/// Trailing accounts appended by DLP's CallHandlerV2:
+///
+///  *: []                  - Program : Source program (must equal this program).
+///  *: []                  - PDA     : Queue PDA authority.
+///  *: [signer]            - PDA     : Escrow signer PDA.
 ///
 /// Instruction Data: ExecuteQueuedTransferArgs
 ///
 #[inline(always)]
 pub fn process_execute_ready_queued_transfer(accounts: &[AccountView], instruction_data: &[u8]) -> ProgramResult {
+    let (head_accounts, native_accounts, source_program, escrow_authority, escrow_signer) = match accounts.len() {
+        12 => (&accounts[..9], None, &accounts[9], &accounts[10], &accounts[11]),
+        14 => (
+            &accounts[..9],
+            Some((&accounts[9], &accounts[10])),
+            &accounts[11],
+            &accounts[12],
+            &accounts[13],
+        ),
+        _ => return Err(ProgramError::NotEnoughAccountKeys),
+    };
+
     let [
         vault_info, // force multi-line
         mint_info,
@@ -49,10 +75,7 @@ pub fn process_execute_ready_queued_transfer(accounts: &[AccountView], instructi
         token_program_info,
         associated_token_program_info,
         system_program_info,
-        source_program,
-        escrow_authority,
-        escrow_signer,
-    ] = require_n_accounts!(accounts, 12);
+    ] = require_n_accounts!(head_accounts, 9);
 
     let args = ExecuteQueuedTransferArgs::decode(instruction_data)?;
 
@@ -64,6 +87,37 @@ pub fn process_execute_ready_queued_transfer(accounts: &[AccountView], instructi
 
     let expected_escrow = ephemeral_balance_pda_from_payer(escrow_authority.address(), args.escrow_index());
     require_eq_keys!(&expected_escrow, escrow_signer.address(), ProgramError::InvalidSeeds);
+
+    if let Some((scratch_wsol_ata_info, unwrap_pda_info)) = native_accounts {
+        // Native-mint settlements pay native lamports or fail; a failure surfaces through the
+        // action callback and triggers the standard refund path, so recipients never receive
+        // wrapped SOL. The remaining failure case is an unfunded destination paid less than
+        // the rent-exempt floor (runtime rent-exemption rule).
+        process_native_delivery(
+            NativeDeliveryAccounts {
+                vault_info,
+                mint_info,
+                vault_token_acc_info,
+                destination_owner_info,
+                rent_pda_info,
+                token_program_info,
+                associated_token_program_info,
+                system_program_info,
+                scratch_wsol_ata_info,
+                unwrap_pda_info,
+            },
+            args.amount(),
+        )?;
+
+        // Keep payment-confirmation logging identical to the legacy delivery path.
+        if let Some(client_ref_id) = args.client_ref_id() {
+            if client_ref_id != 0 {
+                pinocchio_log::log!("client_ref_id: {}", client_ref_id);
+            }
+        }
+
+        return Ok(());
+    }
 
     if args.should_create_destination_ata_idempotent() {
         require!(
@@ -100,7 +154,7 @@ pub fn process_execute_ready_queued_transfer(accounts: &[AccountView], instructi
     let signer_seeds = GlobalVault::signer_seeds(mint_info.address(), &vault_bump);
     let signer = Signer::from(&signer_seeds);
 
-    pinocchio_token_2022::instructions::TransferChecked {
+    TransferChecked {
         mint: mint_info,
         from: vault_token_acc_info,
         to: destination_token_acc_info,
@@ -116,6 +170,132 @@ pub fn process_execute_ready_queued_transfer(accounts: &[AccountView], instructi
             pinocchio_log::log!("client_ref_id: {}", client_ref_id);
         }
     }
+
+    Ok(())
+}
+
+struct NativeDeliveryAccounts<'a> {
+    vault_info: &'a AccountView,
+    mint_info: &'a AccountView,
+    vault_token_acc_info: &'a AccountView,
+    destination_owner_info: &'a AccountView,
+    rent_pda_info: &'a AccountView,
+    token_program_info: &'a AccountView,
+    associated_token_program_info: &'a AccountView,
+    system_program_info: &'a AccountView,
+    scratch_wsol_ata_info: &'a AccountView,
+    unwrap_pda_info: &'a AccountView,
+}
+
+/// Unwrap `amount` wrapped SOL from the vault and pay the recipient in native lamports.
+///
+/// The scratch WSOL account is created, filled with exactly `amount`, and closed within this
+/// single instruction, so the rent PDA is net-neutral (its scratch rent is returned on close)
+/// and the recipient receives exactly `amount` native lamports.
+#[inline(never)]
+fn process_native_delivery(accounts: NativeDeliveryAccounts<'_>, amount: u64) -> ProgramResult {
+    let NativeDeliveryAccounts {
+        vault_info,
+        mint_info,
+        vault_token_acc_info,
+        destination_owner_info,
+        rent_pda_info,
+        token_program_info,
+        associated_token_program_info,
+        system_program_info,
+        scratch_wsol_ata_info,
+        unwrap_pda_info,
+    } = accounts;
+
+    // Native unwrap only applies to the classic SPL Token wrapped-SOL mint.
+    require_eq_keys!(mint_info.address(), &NATIVE_MINT, ProgramError::InvalidAccountData);
+    require!(
+        address_eq(token_program_info.address(), &SPL_TOKEN_PROGRAM_ID),
+        ProgramError::IncorrectProgramId
+    );
+
+    // Lamport credits are permissionless on Solana, so the destination is deliberately
+    // unrestricted (base-layer semantics: the sender is responsible for the address). The one
+    // structural failure left is the runtime's rent-exemption rule for unfunded destinations,
+    // which bounces the settlement into the refund path.
+
+    // Validate the rent PDA (funds the scratch account and sinks the unwrapped lamports).
+    require!(
+        rent_pda_info.owned_by(&SYSTEM_PROGRAM_ID),
+        ProgramError::InvalidAccountOwner
+    );
+    require_eq_keys!(&RENT_PDA, rent_pda_info.address(), ProgramError::InvalidSeeds);
+    require!(rent_pda_info.data_len() == 0, ProgramError::InvalidAccountData);
+    require!(
+        associated_token_program_info.address() == &pinocchio_associated_token_account::ID
+            && system_program_info.address() == &SYSTEM_PROGRAM_ID,
+        ProgramError::InvalidAccountData
+    );
+
+    // Validate the scratch account is the unwrap PDA's ATA for this mint.
+    require_eq_keys!(unwrap_pda_info.address(), &UNWRAP_PDA, ProgramError::InvalidSeeds);
+    let expected_scratch =
+        get_associated_token_address(&UNWRAP_PDA, mint_info.address(), token_program_info.address());
+    require_eq_keys!(
+        &expected_scratch,
+        scratch_wsol_ata_info.address(),
+        ProgramError::InvalidSeeds
+    );
+
+    let vault_bump = validate_vault_for_mint(vault_info, mint_info, vault_token_acc_info)?;
+    let decimals = read_mint_decimals(mint_info, token_program_info)?;
+
+    let rent_bump_seed = [RENT_PDA_BUMP];
+    let rent_signer_seed = [Seed::from(RENT_PDA_SEED), Seed::from(&rent_bump_seed)];
+    let rent_signer = Signer::from(&rent_signer_seed);
+
+    // 1. Create the scratch WSOL account, funded by the rent PDA.
+    (pinocchio_associated_token_account::instructions::CreateIdempotent {
+        funding_account: rent_pda_info,
+        account: scratch_wsol_ata_info,
+        wallet: unwrap_pda_info,
+        mint: mint_info,
+        system_program: system_program_info,
+        token_program: token_program_info,
+    })
+    .invoke_signed(&[rent_signer])?;
+
+    // 2. Move exactly `amount` wrapped SOL from the vault into the scratch account.
+    let vault_bump = [vault_bump];
+    let vault_signer_seeds = GlobalVault::signer_seeds(mint_info.address(), &vault_bump);
+    let vault_signer = Signer::from(&vault_signer_seeds);
+    TransferChecked {
+        mint: mint_info,
+        from: vault_token_acc_info,
+        to: scratch_wsol_ata_info,
+        authority: vault_info,
+        token_program: token_program_info.address(),
+        amount,
+        decimals,
+    }
+    .invoke_signed(&[vault_signer])?;
+
+    // 3. Close the scratch account, unwrapping its lamports (scratch rent + `amount`) to the rent PDA.
+    let unwrap_bump_seed = [UNWRAP_PDA_BUMP];
+    let unwrap_signer_seed = [Seed::from(UNWRAP_PDA_SEED), Seed::from(&unwrap_bump_seed)];
+    let unwrap_signer = Signer::from(&unwrap_signer_seed);
+    CloseAccount {
+        account: scratch_wsol_ata_info,
+        destination: rent_pda_info,
+        authority: unwrap_pda_info,
+        token_program: token_program_info.address(),
+    }
+    .invoke_signed(&[unwrap_signer])?;
+
+    // 4. Forward exactly `amount` native lamports from the rent PDA to the recipient wallet,
+    //    leaving the returned scratch rent with the rent PDA (net-neutral).
+    let rent_signer = Signer::from(&rent_signer_seed);
+    Transfer {
+        from: rent_pda_info,
+        to: destination_owner_info,
+        lamports: amount,
+    }
+    .invoke_signed(&[rent_signer])?;
 
     Ok(())
 }

--- a/e-token/src/processor/internal/mod.rs
+++ b/e-token/src/processor/internal/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod shuttle_delegation;
 pub(crate) mod token;
 pub(crate) mod token_vault;
 pub(crate) mod transfer_queue_refill;
+pub(crate) mod unwrap_pda;
 
 pub(crate) use ephemeral_account::MAGIC_VAULT_ID;
 #[cfg(feature = "logging")]

--- a/e-token/src/processor/internal/queue_authorized_action.rs
+++ b/e-token/src/processor/internal/queue_authorized_action.rs
@@ -11,10 +11,15 @@ use pinocchio::{
     AccountView, ProgramResult,
 };
 use pinocchio_system::ID as SYSTEM_PROGRAM_ID;
-use solana_address::Address;
+use solana_address::{address_eq, Address};
+use spl_token_interface::ID as SPL_TOKEN_PROGRAM_ID;
 use wheels::layout::Encodable as _;
 
-use crate::processor::{internal, internal::rent_pda::RENT_PDA};
+use crate::processor::{
+    internal,
+    internal::rent_pda::RENT_PDA,
+    internal::unwrap_pda::{NATIVE_MINT, UNWRAP_PDA},
+};
 
 const MAGIC_INTENT_BUNDLE_DATA_LEN: usize = 512;
 pub(crate) const EXECUTE_READY_QUEUED_TRANSFER_ESCROW_INDEX: u8 = 0;
@@ -66,7 +71,7 @@ pub(crate) fn invoke_standalone_action(
 /// Action builder for `ExecuteReadyQueuedTransfer`
 pub(crate) struct QueuedTransferActionBuilder {
     queue_info: AccountView,
-    accounts: [ShortAccountMeta; 9],
+    accounts: Vec<ShortAccountMeta>,
     data: Vec<u8>,
 }
 
@@ -81,12 +86,16 @@ impl QueuedTransferActionBuilder {
         token_program: &Address,
         args: ExecuteQueuedTransferArgs,
     ) -> Self {
+        // Native-mint (wrapped SOL) settlements always deliver native lamports when the
+        // recipient state allows it, so the scratch/unwrap accounts are scheduled for the
+        // native mint unconditionally.
+        let deliver_native = address_eq(mint, &NATIVE_MINT) && address_eq(token_program, &SPL_TOKEN_PROGRAM_ID);
         let data =
             crate::instruction::ESplInternalInstruction::ExecuteReadyQueuedTransfer.with_data(&args.encode().unwrap());
 
         Self {
             queue_info: queue_info.clone(),
-            accounts: Self::action_accounts(destination_owner, vault, mint, token_program),
+            accounts: Self::action_accounts(destination_owner, vault, mint, token_program, deliver_native),
             data,
         }
     }
@@ -107,14 +116,16 @@ impl QueuedTransferActionBuilder {
         vault: &Address,
         mint: &Address,
         token_program: &Address,
-    ) -> [ShortAccountMeta; 9] {
+        deliver_native: bool,
+    ) -> Vec<ShortAccountMeta> {
         let vault_token_account = internal::get_associated_token_address(vault, mint, token_program);
         let destination_token_account = internal::get_associated_token_address(destination_owner, mint, token_program);
 
-        // Note that we initialize CallHandler with 9 accounts only, and then 3 more accounts [source_program,
-        // escrow_authority, escrow_signer] are appended by DLP's CallHandlerV2 instruction, which is
-        // why EXECUTE_READY_QUEUED_TRANSFER receives 12 accounts (not 9).
-        [
+        // Note that we initialize CallHandler with 9 (or 11, for native delivery) accounts, and then
+        // 3 more accounts [source_program, escrow_authority, escrow_signer] are appended by DLP's
+        // CallHandlerV2 instruction, which is why EXECUTE_READY_QUEUED_TRANSFER receives 12 (or 14)
+        // accounts.
+        let mut accounts = alloc::vec![
             ShortAccountMeta {
                 pubkey: vault.clone(),
                 is_writable: false,
@@ -128,8 +139,9 @@ impl QueuedTransferActionBuilder {
                 is_writable: true,
             },
             ShortAccountMeta {
+                // Writable for native delivery so the recipient wallet can be credited lamports.
                 pubkey: *destination_owner,
-                is_writable: false,
+                is_writable: deliver_native,
             },
             ShortAccountMeta {
                 pubkey: destination_token_account,
@@ -151,6 +163,21 @@ impl QueuedTransferActionBuilder {
                 pubkey: SYSTEM_PROGRAM_ID,
                 is_writable: false,
             },
-        ]
+        ];
+
+        if deliver_native {
+            // Scratch WSOL account (ATA of the unwrap PDA) plus the unwrap PDA authority.
+            let scratch_wsol_ata = internal::get_associated_token_address(&UNWRAP_PDA, mint, token_program);
+            accounts.push(ShortAccountMeta {
+                pubkey: scratch_wsol_ata,
+                is_writable: true,
+            });
+            accounts.push(ShortAccountMeta {
+                pubkey: UNWRAP_PDA,
+                is_writable: false,
+            });
+        }
+
+        accounts
     }
 }

--- a/e-token/src/processor/internal/unwrap_pda.rs
+++ b/e-token/src/processor/internal/unwrap_pda.rs
@@ -1,0 +1,17 @@
+use solana_address::Address;
+
+/// Wrapped SOL (native) mint address `So11111111111111111111111111111111111111112`.
+pub(crate) const NATIVE_MINT: Address = Address::new_from_array([
+    6, 155, 136, 87, 254, 171, 129, 132, 251, 104, 127, 99, 70, 24, 192, 53, 218, 196, 57, 220, 26, 235, 59, 85, 152,
+    160, 240, 0, 0, 0, 0, 1,
+]);
+
+/// PDA that owns the ephemeral scratch wrapped-SOL token account used to unwrap native
+/// deliveries. The account is created, funded, and closed within a single settlement
+/// instruction, so a single shared PDA is sufficient (transactions writing the same
+/// scratch account are serialized by the runtime).
+pub(crate) const UNWRAP_PDA_SEED: &[u8] = b"unwrap";
+const UNWRAP_PDA_AND_BUMP: ([u8; 32], u8) =
+    const_crypto::ed25519::derive_program_address(&[UNWRAP_PDA_SEED], crate::ID.as_array());
+pub(crate) const UNWRAP_PDA: Address = Address::new_from_array(UNWRAP_PDA_AND_BUMP.0);
+pub(crate) const UNWRAP_PDA_BUMP: u8 = UNWRAP_PDA_AND_BUMP.1;

--- a/e-token/src/processor/undelegate_and_close_shuttle_to_owner.rs
+++ b/e-token/src/processor/undelegate_and_close_shuttle_to_owner.rs
@@ -4,17 +4,27 @@ use ephemeral_spl_api::{
     state::{ephemeral_ata::EphemeralAta, load_initialized, shuttle_ephemeral_ata::ShuttleMetadata},
 };
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
-use solana_address::Address;
+use solana_address::{address_eq, Address};
+use spl_token_interface::ID as SPL_TOKEN_PROGRAM_ID;
+
+use pinocchio_system::ID as SYSTEM_PROGRAM_ID;
 
 use crate::{
     instruction::ESplInternalInstruction,
     processor::internal::{
-        get_associated_token_address, shuttle_delegation::DEFAULT_ESCROW_INDEX, validate_token_account,
+        get_associated_token_address,
+        rent_pda::RENT_PDA,
+        shuttle_delegation::DEFAULT_ESCROW_INDEX,
+        unwrap_pda::{NATIVE_MINT, UNWRAP_PDA},
+        validate_token_account,
     },
 };
 
 const INTENT_BUNDLE_DATA_BUF_SIZE: usize = 1536;
 const CLOSE_SHUTTLE_ATA_COMPUTE_UNITS: u32 = 100_000;
+/// Native delivery adds a scratch-ATA create, token close, and lamports transfer to the close
+/// intent, so it gets extra compute headroom; the legacy budget stays unchanged.
+const CLOSE_SHUTTLE_ATA_NATIVE_COMPUTE_UNITS: u32 = 140_000;
 const CLOSE_STASH_DATA_LEN: usize = 33;
 
 struct CloseStashForward {
@@ -100,6 +110,11 @@ pub fn process_undelegate_and_close_shuttle_to_owner(
         shuttle_ephemeral_ata.mint
     };
 
+    // Native-mint (wrapped SOL) close intents always schedule the unwrap accounts so any
+    // residual shuttle balance is paid out as native lamports when the owner state allows it.
+    let deliver_native =
+        address_eq(&mint, &NATIVE_MINT) && address_eq(token_program_info.address(), &SPL_TOKEN_PROGRAM_ID);
+
     let (derived_shuttle_ephemeral_ata, _) =
         Address::find_program_address(&[shuttle_info.address().as_ref(), mint.as_ref()], &crate::ID);
     require_eq_keys!(
@@ -142,6 +157,8 @@ pub fn process_undelegate_and_close_shuttle_to_owner(
         magic_program,
         escrow_index,
         close_stash.as_ref(),
+        &shuttle.owner,
+        deliver_native,
     )
 }
 
@@ -178,6 +195,8 @@ fn schedule_shuttle_close_after_undelegate(
     magic_program: &AccountView,
     escrow_index: u8,
     close_stash: Option<&CloseStashForward>,
+    owner: &Address,
+    deliver_native: bool,
 ) -> ProgramResult {
     let (vault_info, _) = Address::find_program_address(&[mint.as_ref()], &crate::ID);
     let vault_token_info = get_associated_token_address(&vault_info, mint, token_program_info.address());
@@ -186,7 +205,7 @@ fn schedule_shuttle_close_after_undelegate(
         close_handler_data.extend_from_slice(&close.user);
         close_handler_data.push(close.stash_bump);
     }
-    let close_handler_accounts = alloc::vec![
+    let mut close_handler_accounts = alloc::vec![
         ShortAccountMeta {
             pubkey: *rent_reimbursement.address(),
             is_writable: true,
@@ -224,11 +243,46 @@ fn schedule_shuttle_close_after_undelegate(
             is_writable: false,
         },
     ];
+
+    if deliver_native {
+        // Extra accounts consumed by the native-unwrap branch of the close intent: the global rent
+        // PDA (funds/sinks the scratch account and forwards lamports), the unwrap PDA and its
+        // scratch WSOL ATA, the owner's wallet (native recipient), and the system/ATA programs.
+        let scratch_wsol_ata = get_associated_token_address(&UNWRAP_PDA, mint, token_program_info.address());
+        close_handler_accounts.push(ShortAccountMeta {
+            pubkey: RENT_PDA,
+            is_writable: true,
+        });
+        close_handler_accounts.push(ShortAccountMeta {
+            pubkey: scratch_wsol_ata,
+            is_writable: true,
+        });
+        close_handler_accounts.push(ShortAccountMeta {
+            pubkey: UNWRAP_PDA,
+            is_writable: false,
+        });
+        close_handler_accounts.push(ShortAccountMeta {
+            pubkey: *owner,
+            is_writable: true,
+        });
+        close_handler_accounts.push(ShortAccountMeta {
+            pubkey: SYSTEM_PROGRAM_ID,
+            is_writable: false,
+        });
+        close_handler_accounts.push(ShortAccountMeta {
+            pubkey: pinocchio_associated_token_account::ID,
+            is_writable: false,
+        });
+    }
     let close_handler = [CallHandler {
         destination_program: crate::ID,
         escrow_authority: executor.clone(),
         args: ActionArgs::new(&close_handler_data).with_escrow_index(escrow_index),
-        compute_units: CLOSE_SHUTTLE_ATA_COMPUTE_UNITS,
+        compute_units: if deliver_native {
+            CLOSE_SHUTTLE_ATA_NATIVE_COMPUTE_UNITS
+        } else {
+            CLOSE_SHUTTLE_ATA_COMPUTE_UNITS
+        },
         accounts: &close_handler_accounts,
         callback: None,
     }];

--- a/e-token/tests/transfer_queue_automation.rs
+++ b/e-token/tests/transfer_queue_automation.rs
@@ -134,6 +134,15 @@ async fn latest_blockhash(context: &mut ProgramTestContext) -> solana_program::h
 }
 
 async fn setup_fixture() -> Fixture {
+    setup_fixture_impl(false).await
+}
+
+/// Fixture over the fixed-address wrapped-SOL mint, which triggers native-delivery scheduling.
+async fn setup_wsol_fixture() -> Fixture {
+    setup_fixture_impl(true).await
+}
+
+async fn setup_fixture_impl(native_mint: bool) -> Fixture {
     let magic_program =
         solana_pubkey::Pubkey::new_from_array(ephemeral_rollups_pinocchio::consts::MAGIC_PROGRAM_ID.to_bytes());
     let magic_context = convert_magic_pubkey(MAGIC_CONTEXT_PUBKEY);
@@ -156,13 +165,20 @@ async fn setup_fixture() -> Fixture {
 
     let payer_kp = utils::fixed_payer_keypair();
     let payer = payer_kp.pubkey();
-    let mint_kp = utils::test_keypair("tq_auto::setup_fixture::mint");
-    let mint = mint_kp.pubkey();
     let validator = automation_validator();
     let (rent_pda, _) = Pubkey::find_program_address(&[RENT_PDA_SEED], &PROGRAM);
 
-    let setup =
-        utils::setup_mint_and_token_accounts(&mut context, &payer_kp, &mint_kp, DECIMALS, STARTING_BALANCE, 2).await;
+    let (mint, setup) = if native_mint {
+        let setup =
+            utils::setup_native_mint_and_token_accounts(&mut context, &payer_kp, DECIMALS, STARTING_BALANCE, 2).await;
+        (utils::NATIVE_MINT, setup)
+    } else {
+        let mint_kp = utils::test_keypair("tq_auto::setup_fixture::mint");
+        let setup =
+            utils::setup_mint_and_token_accounts(&mut context, &payer_kp, &mint_kp, DECIMALS, STARTING_BALANCE, 2)
+                .await;
+        (mint_kp.pubkey(), setup)
+    };
 
     let (queue, _) = TransferQueue::find_pda(&mint, &validator);
     let magic_fee_vault = magic_fee_vault(&validator);
@@ -980,6 +996,53 @@ async fn process_transfer_queue_tick_uses_token_2022_accounts_from_queue_header(
         standalone_action.accounts[6].pubkey.to_bytes(),
         token_2022_program.to_bytes()
     );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn process_transfer_queue_tick_schedules_native_delivery_accounts_for_wsol() {
+    use ephemeral_spl_api::state::transfer_queue::QUEUED_TRANSFER_FLAG_CREATE_IDEMPOTENT_ATA;
+
+    let _test_guard = test_lock().lock().unwrap();
+    let mut fixture = setup_wsol_fixture().await;
+    // A plain enqueue on the wrapped-SOL queue; native delivery is keyed on the mint,
+    // not on any per-transfer flag.
+    enqueue_transfer(&mut fixture, 0, "tq_auto::enqueue_native").await;
+
+    let blockhash = latest_blockhash(&mut fixture.context).await;
+    let tx = Transaction::new_signed_with_payer(
+        &[process_queue_tick_ix(&fixture)],
+        Some(&fixture.payer),
+        &[&fixture.payer_kp],
+        blockhash,
+    );
+    common::metrics::process_transaction_record_cu(&fixture.context.banks_client, tx, "tq_auto::tick_native")
+        .await
+        .unwrap();
+
+    let captured_bundles = peek_captured_intent_bundles(fixture.magic_program);
+    assert_eq!(captured_bundles.len(), 1);
+    let action = &captured_bundles[0].args.standalone_actions[0];
+
+    // Native delivery appends the scratch WSOL ATA and the unwrap PDA (9 -> 11 accounts).
+    assert_eq!(action.accounts.len(), 11);
+    // The recipient (index 3) must be writable so it can be credited native lamports.
+    assert!(action.accounts[3].is_writable);
+
+    let unwrap_pda = Pubkey::find_program_address(&[b"unwrap"], &PROGRAM).0;
+    let scratch_wsol_ata = utils::derive_associated_token_address(unwrap_pda, fixture.mint);
+    assert_eq!(action.accounts[9].pubkey.to_bytes(), scratch_wsol_ata.to_bytes());
+    assert!(action.accounts[9].is_writable);
+    assert_eq!(action.accounts[10].pubkey.to_bytes(), unwrap_pda.to_bytes());
+
+    // Settlement args are unchanged from the legacy shape; no per-transfer native flag exists.
+    let args = ExecuteQueuedTransferArgs {
+        amount: QUEUED_AMOUNT,
+        client_ref_id: None,
+        escrow_index: EXECUTE_READY_QUEUED_TRANSFER_ESCROW_INDEX,
+        flags: QUEUED_TRANSFER_FLAG_CREATE_IDEMPOTENT_ATA,
+    };
+    let expected_action_data = TestInternalInstruction::ExecuteReadyQueuedTransfer.with_data(&args.encode().unwrap());
+    assert_eq!(action.args.data, expected_action_data);
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/e-token/tests/utils.rs
+++ b/e-token/tests/utils.rs
@@ -92,6 +92,10 @@ pub fn associated_token_program_id() -> Pubkey {
     ASSOCIATED_TOKEN_PROGRAM_ID
 }
 
+/// Wrapped SOL (native) mint address.
+#[allow(dead_code)]
+pub const NATIVE_MINT: Pubkey = pubkey!("So11111111111111111111111111111111111111112");
+
 /// Deterministic pubkey for integration tests (SHA-256 over `e-token::pubkey::{label}`).
 pub fn test_pubkey(label: &str) -> Pubkey {
     let input = format!("e-token::pubkey::{label}");
@@ -507,6 +511,82 @@ pub async fn setup_mint_and_token_accounts(
     // Submit transaction
     let tx = Transaction::new_signed_with_payer(&instructions, Some(&payer), &signers, context.last_blockhash);
 
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    TokenSetup { user_tokens }
+}
+
+/// Like `setup_mint_and_token_accounts`, but for the fixed-address wrapped-SOL mint, which has
+/// no keypair to sign account creation. Seeds a blank SPL-token-owned account at `NATIVE_MINT`
+/// and initializes it in place, then creates and funds the user token accounts.
+#[allow(dead_code)]
+pub async fn setup_native_mint_and_token_accounts(
+    context: &mut ProgramTestContext,
+    payer_signer: &Keypair,
+    decimals: u8,
+    starting_balance: u64,
+    user_accounts: usize,
+) -> TokenSetup {
+    assert!(user_accounts >= 1, "at least one user token account required");
+
+    let payer = payer_signer.pubkey();
+    let mint = NATIVE_MINT;
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+
+    context.set_account(
+        &mint,
+        &Account {
+            lamports: rent.minimum_balance(Mint::LEN).max(1),
+            data: vec![0u8; Mint::LEN],
+            owner: spl_token_interface::ID,
+            executable: false,
+            rent_epoch: 0,
+        }
+        .into(),
+    );
+
+    let mut instructions = vec![];
+    let mut signers: Vec<&Keypair> = vec![payer_signer];
+
+    let mut init_mint_ix = initialize_mint(&spl_token_interface::ID, &mint, &payer, Some(&payer), decimals).unwrap();
+    init_mint_ix.program_id = spl_token_interface::ID;
+    instructions.push(init_mint_ix);
+
+    let token_acc_space = SplAccount::LEN;
+    let token_acc_lamports = rent.minimum_balance(token_acc_space);
+
+    let mut user_tokens: Vec<Pubkey> = vec![];
+    let mut user_token_kps: Vec<Keypair> = vec![];
+
+    for i in 0..user_accounts {
+        let kp = test_keypair(&format!("setup_native_mint_and_token_accounts::user_token_{i}"));
+        let pk = kp.pubkey();
+        user_token_kps.push(kp);
+        user_tokens.push(pk);
+
+        // The token program rejects mint_to for the native mint, so fund the first account by
+        // over-provisioning lamports: initialize_account records lamports above the rent-exempt
+        // reserve as wrapped balance.
+        let extra_lamports = if i == 0 { starting_balance } else { 0 };
+        instructions.push(create_account(
+            &payer,
+            &pk,
+            token_acc_lamports + extra_lamports,
+            token_acc_space as u64,
+            &spl_token_interface::ID,
+        ));
+
+        let mut init_user_ix = initialize_account(&spl_token_interface::ID, &pk, &mint, &payer).unwrap();
+        init_user_ix.program_id = spl_token_interface::ID;
+        instructions.push(init_user_ix);
+    }
+
+    for kp in &user_token_kps {
+        signers.push(kp);
+    }
+
+    let tx = Transaction::new_signed_with_payer(&instructions, Some(&payer), &signers, context.last_blockhash);
     context.banks_client.process_transaction(tx).await.unwrap();
 
     TokenSetup { user_tokens }

--- a/e-token/tests/withdraw_through_delegated_shuttle_with_merge.rs
+++ b/e-token/tests/withdraw_through_delegated_shuttle_with_merge.rs
@@ -51,6 +51,12 @@ fn captured_intent_bundles() -> &'static Mutex<HashMap<Pubkey, Vec<CapturedInten
     CAPTURED.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// Serializes tests that capture intent bundles under the shared MAGIC_PROGRAM_ID key.
+fn scheduling_test_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
 fn clear_captured_intent_bundles(magic_program: Pubkey) {
     captured_intent_bundles().lock().unwrap().remove(&magic_program);
 }
@@ -319,6 +325,7 @@ async fn withdraw_through_delegated_shuttle_with_merge_stores_transfer_and_clean
 
 #[tokio::test]
 async fn undelegate_and_close_shuttle_ephemeral_ata_schedules_close_action() {
+    let _test_guard = scheduling_test_lock().lock().unwrap();
     let magic_program = Pubkey::new_from_array(ephemeral_rollups_pinocchio::consts::MAGIC_PROGRAM_ID.to_bytes());
     let magic_context = convert_magic_pubkey(MAGIC_CONTEXT_PUBKEY);
     clear_captured_intent_bundles(magic_program);
@@ -486,4 +493,184 @@ async fn undelegate_and_close_shuttle_ephemeral_ata_schedules_close_action() {
         captured_bundles[0].schedule_accounts[close_action.escrow_authority as usize],
         payer
     );
+}
+
+#[tokio::test]
+async fn undelegate_and_close_shuttle_with_native_flag_schedules_native_close_action() {
+    let _test_guard = scheduling_test_lock().lock().unwrap();
+    let magic_program = Pubkey::new_from_array(ephemeral_rollups_pinocchio::consts::MAGIC_PROGRAM_ID.to_bytes());
+    let magic_context = convert_magic_pubkey(MAGIC_CONTEXT_PUBKEY);
+    clear_captured_intent_bundles(magic_program);
+
+    let owner = utils::test_keypair("undelegate_and_close_shuttle_with_native_flag::owner");
+    // Native delivery is keyed on the wrapped-SOL mint; no per-transfer flag exists.
+    let mint = utils::NATIVE_MINT;
+    let shuttle_id = 6_u32;
+    let (rent_pda, _) = Pubkey::find_program_address(&[RENT_PDA_SEED], &PROGRAM);
+    let (unwrap_pda, _) = Pubkey::find_program_address(&[b"unwrap"], &PROGRAM);
+    let scratch_wsol_ata = utils::derive_associated_token_address(unwrap_pda, mint);
+    let (shuttle_metadata, _) = utils::derive_shuttle_ephemeral_ata(PROGRAM, owner.pubkey(), mint, shuttle_id);
+    let (shuttle_eata, _) = utils::derive_shuttle_eata(PROGRAM, shuttle_metadata, mint);
+    let shuttle_wallet_ata = utils::derive_associated_token_address(shuttle_metadata, mint);
+    let owner_destination_ata = utils::derive_associated_token_address(owner.pubkey(), mint);
+
+    let mut shuttle_data = vec![0u8; ShuttleMetadata::LEN];
+    let shuttle_state = load_mut::<ShuttleMetadata>(shuttle_data.as_mut_slice()).unwrap();
+    shuttle_state.owner = owner.pubkey();
+    shuttle_state.payer = rent_pda;
+    shuttle_state.id = shuttle_id;
+
+    let mut shuttle_eata_data = vec![0u8; EphemeralAta::LEN];
+    let shuttle_eata_state = load_mut::<EphemeralAta>(shuttle_eata_data.as_mut_slice()).unwrap();
+    shuttle_eata_state.owner = shuttle_metadata;
+    shuttle_eata_state.mint = mint;
+    shuttle_eata_state.amount = 0;
+
+    let mut context = utils::start_program_test_with(PROGRAM, |mut pt| {
+        pt.add_account(
+            owner.pubkey(),
+            Account {
+                lamports: Rent::default().minimum_balance(0).max(1),
+                data: vec![],
+                owner: solana_system_interface::program::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        );
+        pt.add_account(
+            rent_pda,
+            Account {
+                lamports: Rent::default().minimum_balance(0).max(1),
+                data: vec![],
+                owner: solana_system_interface::program::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        );
+        pt.add_account(
+            shuttle_metadata,
+            Account {
+                lamports: Rent::default().minimum_balance(ShuttleMetadata::LEN).max(1),
+                data: shuttle_data,
+                owner: PROGRAM,
+                executable: false,
+                rent_epoch: 0,
+            },
+        );
+        pt.add_account(
+            shuttle_eata,
+            Account {
+                lamports: Rent::default().minimum_balance(EphemeralAta::LEN).max(1),
+                data: shuttle_eata_data,
+                owner: PROGRAM,
+                executable: false,
+                rent_epoch: 0,
+            },
+        );
+        pt.add_account(
+            magic_context,
+            Account {
+                lamports: 1_000_000,
+                data: vec![0; 8],
+                owner: magic_program,
+                executable: false,
+                rent_epoch: 0,
+            },
+        );
+        add_magic_program_mock(&mut pt, magic_program);
+    })
+    .await;
+
+    let payer_kp = utils::fixed_payer_keypair();
+    let payer = payer_kp.pubkey();
+
+    utils::setup_native_mint_and_token_accounts(&mut context, &payer_kp, DECIMALS, STARTING_BALANCE, 1).await;
+
+    let ix_create_owner_destination =
+        associated_token_create_idempotent_ix(payer, owner_destination_ata, owner.pubkey(), mint);
+    let ix_create_shuttle_wallet =
+        associated_token_create_idempotent_ix(payer, shuttle_wallet_ata, shuttle_metadata, mint);
+    let tx_create_token_accounts = Transaction::new_signed_with_payer(
+        &[ix_create_owner_destination, ix_create_shuttle_wallet],
+        Some(&payer),
+        &[&payer_kp],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(tx_create_token_accounts)
+        .await
+        .unwrap();
+
+    // Plain legacy wire format: native scheduling is triggered by the mint alone.
+    let ix_undelegate = Instruction {
+        program_id: PROGRAM,
+        accounts: vec![
+            AccountMeta::new_readonly(payer, true),
+            AccountMeta::new_readonly(rent_pda, false),
+            AccountMeta::new_readonly(shuttle_metadata, false),
+            AccountMeta::new_readonly(shuttle_eata, false),
+            AccountMeta::new(shuttle_wallet_ata, false),
+            AccountMeta::new_readonly(owner_destination_ata, false),
+            AccountMeta::new_readonly(spl_token_interface::ID, false),
+            AccountMeta::new(magic_context, false),
+            AccountMeta::new_readonly(magic_program, false),
+        ],
+        data: instruction::ESplInstruction::UndelegateAndCloseShuttleToOwner.to_vec(),
+    };
+    let tx_undelegate = Transaction::new_signed_with_payer(
+        &[ix_undelegate],
+        Some(&payer),
+        &[&payer_kp],
+        context.banks_client.get_latest_blockhash().await.unwrap(),
+    );
+    common::metrics::process_transaction_record_cu(
+        &context.banks_client,
+        tx_undelegate,
+        "ud_wd_close::undelegate_native",
+    )
+    .await
+    .unwrap();
+
+    let captured_bundles = peek_captured_intent_bundles(magic_program);
+    assert_eq!(captured_bundles.len(), 1);
+    let commit_and_undelegate = captured_bundles[0]
+        .args
+        .commit_and_undelegate
+        .as_ref()
+        .expect("expected commit_and_undelegate bundle");
+    let UndelegateTypeArgs::WithBaseActions { base_actions } = &commit_and_undelegate.undelegate_type else {
+        panic!("expected undelegate base actions");
+    };
+    assert_eq!(base_actions.len(), 1);
+
+    let close_action = &base_actions[0];
+    // Close-intent data is the legacy shape; native delivery is signalled by the account set.
+    assert_eq!(
+        close_action.args.data,
+        vec![
+            TestInternalInstruction::SettleAndCloseShuttleIntent.discriminator(),
+            u8::MAX
+        ]
+    );
+    // Native delivery appends [rent PDA, scratch WSOL ATA, unwrap PDA, owner wallet,
+    // system program, ATA program] to the legacy 9 accounts.
+    assert_eq!(close_action.accounts.len(), 15);
+    assert_eq!(close_action.accounts[9].pubkey.to_bytes(), rent_pda.to_bytes());
+    assert!(close_action.accounts[9].is_writable);
+    assert_eq!(close_action.accounts[10].pubkey.to_bytes(), scratch_wsol_ata.to_bytes());
+    assert!(close_action.accounts[10].is_writable);
+    assert_eq!(close_action.accounts[11].pubkey.to_bytes(), unwrap_pda.to_bytes());
+    assert_eq!(close_action.accounts[12].pubkey.to_bytes(), owner.pubkey().to_bytes());
+    assert!(close_action.accounts[12].is_writable);
+    assert_eq!(
+        close_action.accounts[13].pubkey.to_bytes(),
+        solana_system_interface::program::ID.to_bytes()
+    );
+    assert_eq!(
+        close_action.accounts[14].pubkey.to_bytes(),
+        utils::associated_token_program_id().to_bytes()
+    );
+    // Native close intents get extra compute headroom; legacy stays at 100k.
+    assert_eq!(close_action.compute_units, 140_000);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native SOL support for private transfers and queued delivery paths.
  * Wrapped SOL transfers can now settle directly as lamports when conditions allow.

* **Bug Fixes**
  * Prevented unsupported private dust transfers to unfunded recipients.
  * Improved handling of platform fees for wrapped SOL, including direct lamport collection.
  * Added rent-account top-up handling to avoid failed native SOL settlements.

* **Tests**
  * Expanded coverage for private SOL transfers, native delivery, and queue scheduling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->