### PR TITLE
Deliver WSOL settlements as native SOL

### DIFF
--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -242,6 +242,7 @@ describe("app", () => {
     vi.spyOn(Connection.prototype, "getMultipleAccountsInfo").mockImplementation(
       async addresses => addresses.map(() => null),
     );
+    vi.spyOn(Connection.prototype, "getBalance").mockResolvedValue(20_000_000);
   });
 
   afterEach(() => {
@@ -2967,6 +2968,36 @@ describe("app", () => {
       = transaction.instructions[transaction.instructions.length - 1]!;
     expect(withdrawIx.data[0]).toBe(26);
     expect(withdrawIx.data.length).toBe(45);
+
+    const legacyResponse = await app.request(
+      "/v1/spl/withdraw",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          owner,
+          mint: "So11111111111111111111111111111111111111112",
+          amount: 1,
+          idempotent: false,
+        }),
+      },
+      withdrawEnv,
+    );
+    expect(legacyResponse.status).toBe(200);
+
+    const legacyJson = (await legacyResponse.json()) as {
+      transactionBase64: string;
+    };
+    const legacyTransaction = Transaction.from(
+      Buffer.from(legacyJson.transactionBase64, "base64"),
+    );
+    const closeIx
+      = legacyTransaction.instructions[legacyTransaction.instructions.length - 1]!;
+    expect(closeIx.programId.equals(TOKEN_PROGRAM_ID)).toBe(true);
+    expect([...closeIx.data]).toEqual([9]);
+    expect(closeIx.keys[1]?.pubkey.toBase58()).toBe(owner);
   });
 
   it("uses the mint token program when building a withdraw", async () => {
@@ -4561,6 +4592,7 @@ describe("app", () => {
   it("wraps enough native SOL for exact-out private transfer fees", async () => {
     const mint = new PublicKey("So11111111111111111111111111111111111111112");
     const sourceAta = new PublicKey(deriveAssociatedTokenAddress(mint.toBase58(), owner));
+    const [rentPda] = deriveRentPda();
     const amount = 100_000_000;
     const wrappedBalance = 25_000_000n;
     const expectedFee = BigInt(amount) * 10n / 10_000n;
@@ -4569,6 +4601,7 @@ describe("app", () => {
       blockhash: "11111111111111111111111111111111",
       lastValidBlockHeight: 123,
     });
+    vi.spyOn(Connection.prototype, "getBalance").mockResolvedValue(500_000);
     vi.spyOn(Connection.prototype, "getAccountInfo").mockImplementation(
       async (address) => {
         if (address.equals(mint)) {
@@ -4628,6 +4661,11 @@ describe("app", () => {
     expect(BigInt(decodedTransfer.lamports)).toBe(
       BigInt(amount) + expectedFee - wrappedBalance,
     );
+    const rentTopUpIx = transaction.instructions.find(
+      ix => ix.programId.equals(SystemProgram.programId)
+        && ix.keys[1]?.pubkey.equals(rentPda),
+    )!;
+    expect(BigInt(SystemInstruction.decodeTransfer(rentTopUpIx).lamports)).toBe(19_500_000n);
   });
 
   it("builds a gasless private transfer with the sponsor as fee payer", async () => {

--- a/api/src/lib/solana.ts
+++ b/api/src/lib/solana.ts
@@ -562,6 +562,23 @@ function createSyncNativeInstruction(
   });
 }
 
+function createCloseTokenAccountInstruction(
+  account: PublicKey,
+  destination: PublicKey,
+  authority: PublicKey,
+  programId: PublicKey = TOKEN_PROGRAM_ID,
+) {
+  return new TransactionInstruction({
+    programId,
+    keys: [
+      { pubkey: account, isSigner: false, isWritable: true },
+      { pubkey: destination, isSigner: false, isWritable: true },
+      { pubkey: authority, isSigner: true, isWritable: false },
+    ],
+    data: Buffer.from([9]),
+  });
+}
+
 async function createNativeSolWrapInstructionsIfNeeded(
   config: RpcConfig,
   sourceOwner: PublicKey,
@@ -1681,6 +1698,21 @@ export async function buildWithdrawTransaction(env: AppEnv, input: WithdrawReque
       idempotent: input.idempotent,
     });
 
+    if (
+      input.idempotent === false
+      && mint.equals(NATIVE_MINT)
+      && tokenProgram.equals(TOKEN_PROGRAM_ID)
+    ) {
+      instructions.push(
+        createCloseTokenAccountInstruction(
+          getAssociatedTokenAddressSync(mint, owner, false, tokenProgram),
+          owner,
+          owner,
+          tokenProgram,
+        ),
+      );
+    }
+
     return serializeTransaction(
       "withdraw",
       "base",
@@ -2067,6 +2099,15 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
           tokenProgram,
         )
       : [];
+    const nativeSolRentPdaTopUpInstructions = input.visibility === "private" && input.fromBalance === "base"
+      ? await createNativeSolRentPdaTopUpInstructionsIfNeeded(
+          config,
+          payer,
+          mint,
+          transferAmount,
+          tokenProgram,
+        )
+      : [];
     const platformFeeInstructions = platformFee > 0n && platformFeeAccount
       ? [
           createTokenTransferInstruction(
@@ -2115,6 +2156,7 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
 
     const instructions = [
       ...nativeSolWrapInstructions,
+      ...nativeSolRentPdaTopUpInstructions,
       ...gaslessFeeInstructions,
       ...platformFeeInstructions,
       ...effectiveTransferInstructions,

--- a/e-token/src/processor/close_shuttle_ata_intent.rs
+++ b/e-token/src/processor/close_shuttle_ata_intent.rs
@@ -7,13 +7,22 @@ use ephemeral_spl_api::{
         stash::StashPda,
     },
 };
-use pinocchio::{cpi::Signer, error::ProgramError, AccountView, ProgramResult};
-use pinocchio_system::instructions::Transfer;
+use pinocchio::{
+    cpi::{Seed, Signer},
+    error::ProgramError,
+    sysvars::{rent::Rent, Sysvar},
+    AccountView, ProgramResult,
+};
+use pinocchio_system::{instructions::Transfer, ID as SYSTEM_PROGRAM_ID};
 use pinocchio_token_2022::instructions::{CloseAccount, TransferChecked};
-use solana_address::Address;
+use solana_address::{address_eq, Address};
+use spl_token_interface::ID as SPL_TOKEN_PROGRAM_ID;
 
 use crate::processor::internal::{
-    get_associated_token_address, read_mint_decimals, rent_pda::RENT_PDA, token_vault::withdraw_ephemeral_ata_tokens,
+    get_associated_token_address, read_mint_decimals,
+    rent_pda::{RENT_PDA, RENT_PDA_BUMP, RENT_PDA_SEED},
+    token_vault::withdraw_ephemeral_ata_tokens,
+    unwrap_pda::NATIVE_MINT,
     validate_token_account,
 };
 const DLP_EPHEMERAL_BALANCE_TAG: &[u8] = b"balance";
@@ -34,17 +43,28 @@ const CLOSE_STASH_DATA_LEN: usize = 33;
 ///  6: []                  - PDA     : Global vault account.
 ///  7: [writable]          - SPL     : Vault source token account.
 ///  8: []                  - SPL     : Token program account.
-///  9: []                  - Program : Source program (must equal this program).
-/// 10: []                  - Any     : Escrow authority.
-/// 11: [signer]            - PDA     : Escrow signer PDA.
+///  9: [writable]          - Any     : Owner wallet (native SOL only).
+///
+/// The following accounts are appended by DLP after the action accounts:
+///
+///  *: []                  - Program : Source program (must equal this program).
+///  *: []                  - Any     : Escrow authority.
+///  *: [signer]            - PDA     : Escrow signer PDA.
 ///
 /// Instruction Data: escrow_index (u8), optionally followed by
 /// `[user(32) | stash_bump(1)]` for the stash close path. In that path the
 /// escrow authority is the stash PDA and account 0 is the rent sink.
 ///
 pub fn process_close_shuttle_ata_intent(accounts: &[AccountView], instruction_data: &[u8]) -> ProgramResult {
-    let (head_accounts, source_program, escrow_authority, escrow_signer) = match accounts.len() {
-        12 => (&accounts[..9], &accounts[9], &accounts[10], &accounts[11]),
+    let (head_accounts, native_accounts, source_program, escrow_authority, escrow_signer) = match accounts.len() {
+        12 => (&accounts[..9], None, &accounts[9], &accounts[10], &accounts[11]),
+        13 => (
+            &accounts[..9],
+            Some(&accounts[9..10]),
+            &accounts[10],
+            &accounts[11],
+            &accounts[12],
+        ),
         _ => return Err(ProgramError::NotEnoughAccountKeys),
     };
 
@@ -68,6 +88,7 @@ pub fn process_close_shuttle_ata_intent(accounts: &[AccountView], instruction_da
     settle_and_close_shuttle_accounts(
         head_accounts,
         close_stash_seeds.map(|(user, stash_bump)| (escrow_authority, user, stash_bump)),
+        native_accounts,
     )
 }
 
@@ -86,6 +107,7 @@ fn parse_close_shuttle_intent_data(instruction_data: &[u8]) -> Result<(u8, Optio
 pub(crate) fn settle_and_close_shuttle_accounts(
     head_accounts: &[AccountView],
     close_stash: Option<(&AccountView, [u8; 32], u8)>,
+    native_accounts: Option<&[AccountView]>,
 ) -> ProgramResult {
     let [
         rent_reimbursement_info, // force multi-line
@@ -121,6 +143,7 @@ pub(crate) fn settle_and_close_shuttle_accounts(
         shuttle_bump = Some(shuttle.bump);
     }
 
+    let mut shuttle_wallet_amount = 0;
     if shuttle_wallet_present {
         require!(
             shuttle_wallet_ata_info.owned_by(token_program_info.address()),
@@ -129,25 +152,95 @@ pub(crate) fn settle_and_close_shuttle_accounts(
         let shuttle_bump = require_some!(shuttle_bump, ProgramError::InvalidAccountData);
 
         let shuttle_owner = require_some!(shuttle_owner_opt.as_ref(), ProgramError::InvalidAccountData);
-        let (mint, shuttle_wallet_amount) = {
+        let mint = {
             let token_account = validate_token_account(
                 shuttle_wallet_ata_info,
                 mint_info.address(),
                 Some(shuttle_info.address()),
                 Some(token_program_info.address()),
             )?;
-            (token_account.mint(), token_account.amount())
+            shuttle_wallet_amount = token_account.amount();
+            *token_account.mint()
         };
 
-        let shuttle_id_seed = shuttle_id.to_le_bytes();
-        let derived_shuttle = ShuttleMetadata::derive_pda(shuttle_owner, mint, shuttle_id, shuttle_bump)?;
+        let derived_shuttle = ShuttleMetadata::derive_pda(shuttle_owner, &mint, shuttle_id, shuttle_bump)?;
+        require_eq_keys!(&derived_shuttle, shuttle_info.address(), ProgramError::InvalidSeeds);
+    }
+
+    let mut shuttle_ephemeral_amount = 0;
+    if shuttle_ephemeral_present {
+        require!(
+            shuttle_ephemeral_ata_info.owned_by(&crate::ID),
+            ProgramError::InvalidAccountOwner
+        );
+        let shuttle_bump = require_some!(shuttle_bump, ProgramError::InvalidAccountData);
+
+        let shuttle_owner = require_some!(shuttle_owner_opt.as_ref(), ProgramError::InvalidAccountData);
+        let (mint, amount, eata_bump) = {
+            let shuttle_ephemeral_ata_data = shuttle_ephemeral_ata_info.try_borrow()?;
+            let (ephemeral_owner, mint, amount, eata_bump) = read_ephemeral_ata_compat(&shuttle_ephemeral_ata_data)?;
+            require_eq_keys!(
+                &ephemeral_owner,
+                shuttle_info.address(),
+                ProgramError::InvalidAccountData
+            );
+            (mint, amount, eata_bump)
+        };
+        require_eq_keys!(&mint, mint_info.address(), ProgramError::InvalidAccountData);
+
+        let derived_shuttle = ShuttleMetadata::derive_pda(shuttle_owner, &mint, shuttle_id, shuttle_bump)?;
         require_eq_keys!(&derived_shuttle, shuttle_info.address(), ProgramError::InvalidSeeds);
 
+        let derived_shuttle_ephemeral_ata = EphemeralAta::derive_pda(shuttle_info.address(), &mint, eata_bump)?;
+        require_eq_keys!(
+            &derived_shuttle_ephemeral_ata,
+            shuttle_ephemeral_ata_info.address(),
+            ProgramError::InvalidSeeds
+        );
+
+        shuttle_ephemeral_amount = amount;
+    }
+
+    let native_amount = shuttle_wallet_amount
+        .checked_add(shuttle_ephemeral_amount)
+        .ok_or(ProgramError::InvalidArgument)?;
+    let deliver_native = native_delivery_eligible(
+        native_accounts,
+        rent_reimbursement_info,
+        shuttle_owner_opt.as_ref(),
+        mint_info,
+        token_program_info,
+        shuttle_wallet_present,
+        native_amount,
+    )?;
+
+    if shuttle_ephemeral_amount != 0 {
+        withdraw_ephemeral_ata_tokens(
+            shuttle_info,
+            false,
+            shuttle_ephemeral_ata_info,
+            vault_info,
+            mint_info,
+            vault_source_token_acc,
+            if deliver_native {
+                shuttle_wallet_ata_info
+            } else {
+                destination_token_info
+            },
+            token_program_info,
+            shuttle_ephemeral_amount,
+        )?;
+    }
+
+    if shuttle_wallet_present {
+        let shuttle_bump = require_some!(shuttle_bump, ProgramError::InvalidAccountData);
+        let shuttle_owner = require_some!(shuttle_owner_opt.as_ref(), ProgramError::InvalidAccountData);
+        let shuttle_id_seed = shuttle_id.to_le_bytes();
         let bump = [shuttle_bump];
-        let signer_seeds = ShuttleMetadata::signer_seeds(shuttle_owner, mint, &shuttle_id_seed, &bump);
+        let signer_seeds = ShuttleMetadata::signer_seeds(shuttle_owner, mint_info.address(), &shuttle_id_seed, &bump);
         let signer = Signer::from(&signer_seeds);
 
-        if shuttle_wallet_amount != 0 {
+        if shuttle_wallet_amount != 0 && !deliver_native {
             let decimals = read_mint_decimals(mint_info, token_program_info)?;
             TransferChecked {
                 mint: mint_info,
@@ -170,52 +263,12 @@ pub(crate) fn settle_and_close_shuttle_accounts(
         .invoke_signed(&[signer])?;
     }
 
-    if shuttle_ephemeral_present {
-        require!(
-            shuttle_ephemeral_ata_info.owned_by(&crate::ID),
-            ProgramError::InvalidAccountOwner
-        );
-        let shuttle_bump = require_some!(shuttle_bump, ProgramError::InvalidAccountData);
-
-        let shuttle_owner = require_some!(shuttle_owner_opt.as_ref(), ProgramError::InvalidAccountData);
-        let (mint, shuttle_ephemeral_amount, shuttle_eata_bump) = {
-            let shuttle_ephemeral_ata_data = shuttle_ephemeral_ata_info.try_borrow()?;
-            let (ephemeral_owner, mint, amount, shuttle_eata_bump) =
-                read_ephemeral_ata_compat(&shuttle_ephemeral_ata_data)?;
-            require_eq_keys!(
-                &ephemeral_owner,
-                shuttle_info.address(),
-                ProgramError::InvalidAccountData
-            );
-            (mint, amount, shuttle_eata_bump)
-        };
-
-        if shuttle_ephemeral_amount != 0 {
-            require_eq_keys!(&mint, mint_info.address(), ProgramError::InvalidAccountData);
-
-            withdraw_ephemeral_ata_tokens(
-                shuttle_info,
-                false,
-                shuttle_ephemeral_ata_info,
-                vault_info,
-                mint_info,
-                vault_source_token_acc,
-                destination_token_info,
-                token_program_info,
-                shuttle_ephemeral_amount,
-            )?;
-        }
-
-        let derived_shuttle = ShuttleMetadata::derive_pda(shuttle_owner, &mint, shuttle_id, shuttle_bump)?;
-
-        require_eq_keys!(&derived_shuttle, shuttle_info.address(), ProgramError::InvalidSeeds);
-
-        let derived_shuttle_ephemeral_ata = EphemeralAta::derive_pda(shuttle_info.address(), &mint, shuttle_eata_bump)?;
-        require_eq_keys!(
-            &derived_shuttle_ephemeral_ata,
-            shuttle_ephemeral_ata_info.address(),
-            ProgramError::InvalidSeeds
-        );
+    if deliver_native {
+        transfer_native_to_owner(
+            native_accounts.ok_or(ProgramError::NotEnoughAccountKeys)?,
+            rent_reimbursement_info,
+            native_amount,
+        )?;
     }
 
     if let Some((stash_pda_info, user, stash_bump)) = close_stash {
@@ -241,6 +294,70 @@ pub(crate) fn settle_and_close_shuttle_accounts(
     }
 
     Ok(())
+}
+
+#[inline(always)]
+fn native_delivery_eligible(
+    native_accounts: Option<&[AccountView]>,
+    rent_reimbursement_info: &AccountView,
+    shuttle_owner: Option<&Address>,
+    mint_info: &AccountView,
+    token_program_info: &AccountView,
+    shuttle_wallet_present: bool,
+    amount: u64,
+) -> Result<bool, ProgramError> {
+    let Some(native_accounts) = native_accounts else {
+        return Ok(false);
+    };
+    let [owner_wallet_info] = require_n_accounts!(native_accounts, 1);
+    let Some(shuttle_owner) = shuttle_owner else {
+        return Ok(false);
+    };
+
+    require_eq_keys!(
+        owner_wallet_info.address(),
+        shuttle_owner,
+        ProgramError::InvalidAccountData
+    );
+
+    if !shuttle_wallet_present
+        || amount == 0
+        || !address_eq(mint_info.address(), &NATIVE_MINT)
+        || !address_eq(token_program_info.address(), &SPL_TOKEN_PROGRAM_ID)
+        || rent_reimbursement_info.address() != &RENT_PDA
+        || !rent_reimbursement_info.owned_by(&SYSTEM_PROGRAM_ID)
+        || rent_reimbursement_info.data_len() != 0
+        || !owner_wallet_info.owned_by(&SYSTEM_PROGRAM_ID)
+        || owner_wallet_info.address() == rent_reimbursement_info.address()
+    {
+        return Ok(false);
+    }
+
+    if owner_wallet_info.lamports() == 0 && amount < Rent::get()?.try_minimum_balance(0)? {
+        return Ok(false);
+    }
+
+    Ok(true)
+}
+
+#[inline(always)]
+fn transfer_native_to_owner(
+    native_accounts: &[AccountView],
+    rent_pda_info: &AccountView,
+    amount: u64,
+) -> ProgramResult {
+    let [owner_wallet_info] = require_n_accounts!(native_accounts, 1);
+    require_eq_keys!(rent_pda_info.address(), &RENT_PDA, ProgramError::InvalidSeeds);
+
+    let rent_bump_seed = [RENT_PDA_BUMP];
+    let rent_signer_seed = [Seed::from(RENT_PDA_SEED), Seed::from(&rent_bump_seed)];
+    let rent_signer = Signer::from(&rent_signer_seed);
+    Transfer {
+        from: rent_pda_info,
+        to: owner_wallet_info,
+        lamports: amount,
+    }
+    .invoke_signed(&[rent_signer])
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/e-token/src/processor/close_shuttle_ata_intent.rs
+++ b/e-token/src/processor/close_shuttle_ata_intent.rs
@@ -44,6 +44,7 @@ const CLOSE_STASH_DATA_LEN: usize = 33;
 ///  7: [writable]          - SPL     : Vault source token account.
 ///  8: []                  - SPL     : Token program account.
 ///  9: [writable]          - Any     : Owner wallet (native SOL only).
+/// 10: []                  - Program : System program (native SOL only).
 ///
 /// The following accounts are appended by DLP after the action accounts:
 ///
@@ -58,12 +59,12 @@ const CLOSE_STASH_DATA_LEN: usize = 33;
 pub fn process_close_shuttle_ata_intent(accounts: &[AccountView], instruction_data: &[u8]) -> ProgramResult {
     let (head_accounts, native_accounts, source_program, escrow_authority, escrow_signer) = match accounts.len() {
         12 => (&accounts[..9], None, &accounts[9], &accounts[10], &accounts[11]),
-        13 => (
+        14 => (
             &accounts[..9],
-            Some(&accounts[9..10]),
-            &accounts[10],
+            Some(&accounts[9..11]),
             &accounts[11],
             &accounts[12],
+            &accounts[13],
         ),
         _ => return Err(ProgramError::NotEnoughAccountKeys),
     };
@@ -309,11 +310,16 @@ fn native_delivery_eligible(
     let Some(native_accounts) = native_accounts else {
         return Ok(false);
     };
-    let [owner_wallet_info] = require_n_accounts!(native_accounts, 1);
+    let [owner_wallet_info, system_program_info] = require_n_accounts!(native_accounts, 2);
     let Some(shuttle_owner) = shuttle_owner else {
         return Ok(false);
     };
 
+    require_eq_keys!(
+        system_program_info.address(),
+        &SYSTEM_PROGRAM_ID,
+        ProgramError::IncorrectProgramId
+    );
     require_eq_keys!(
         owner_wallet_info.address(),
         shuttle_owner,
@@ -346,7 +352,12 @@ fn transfer_native_to_owner(
     rent_pda_info: &AccountView,
     amount: u64,
 ) -> ProgramResult {
-    let [owner_wallet_info] = require_n_accounts!(native_accounts, 1);
+    let [owner_wallet_info, system_program_info] = require_n_accounts!(native_accounts, 2);
+    require_eq_keys!(
+        system_program_info.address(),
+        &SYSTEM_PROGRAM_ID,
+        ProgramError::IncorrectProgramId
+    );
     require_eq_keys!(rent_pda_info.address(), &RENT_PDA, ProgramError::InvalidSeeds);
 
     let rent_bump_seed = [RENT_PDA_BUMP];

--- a/e-token/src/processor/execute_ready_queued_transfer.rs
+++ b/e-token/src/processor/execute_ready_queued_transfer.rs
@@ -6,6 +6,7 @@ use ephemeral_spl_api::{
 use pinocchio::{
     cpi::{Seed, Signer},
     error::ProgramError,
+    sysvars::{rent::Rent, Sysvar},
     AccountView, ProgramResult,
 };
 use pinocchio_system::{instructions::Transfer, ID as SYSTEM_PROGRAM_ID};
@@ -80,7 +81,9 @@ pub fn process_execute_ready_queued_transfer(accounts: &[AccountView], instructi
     let expected_escrow = ephemeral_balance_pda_from_payer(escrow_authority.address(), args.escrow_index());
     require_eq_keys!(&expected_escrow, escrow_signer.address(), ProgramError::InvalidSeeds);
 
-    if let Some((scratch_wsol_ata_info, unwrap_pda_info)) = native_accounts {
+    // Preserve token delivery for recipients that cannot safely receive native lamports.
+    if native_accounts.is_some() && native_delivery_eligible(destination_owner_info, args.amount())? {
+        let (scratch_wsol_ata_info, unwrap_pda_info) = native_accounts.ok_or(ProgramError::NotEnoughAccountKeys)?;
         process_native_delivery(
             NativeDeliveryAccounts {
                 vault_info,
@@ -159,6 +162,19 @@ pub fn process_execute_ready_queued_transfer(accounts: &[AccountView], instructi
     }
 
     Ok(())
+}
+
+#[inline(always)]
+fn native_delivery_eligible(destination_owner_info: &AccountView, amount: u64) -> Result<bool, ProgramError> {
+    if !destination_owner_info.owned_by(&SYSTEM_PROGRAM_ID) {
+        return Ok(false);
+    }
+
+    if destination_owner_info.lamports() == 0 && amount < Rent::get()?.try_minimum_balance(0)? {
+        return Ok(false);
+    }
+
+    Ok(true)
 }
 
 struct NativeDeliveryAccounts<'a> {

--- a/e-token/src/processor/execute_ready_queued_transfer.rs
+++ b/e-token/src/processor/execute_ready_queued_transfer.rs
@@ -8,13 +8,17 @@ use pinocchio::{
     error::ProgramError,
     AccountView, ProgramResult,
 };
-use pinocchio_system::ID as SYSTEM_PROGRAM_ID;
+use pinocchio_system::{instructions::Transfer, ID as SYSTEM_PROGRAM_ID};
+use pinocchio_token_2022::instructions::{CloseAccount, TransferChecked};
+use solana_address::address_eq;
+use spl_token_interface::ID as SPL_TOKEN_PROGRAM_ID;
 use wheels::layout::Decodable as _;
 
 use crate::processor::internal::{
-    read_mint_decimals,
+    get_associated_token_address, read_mint_decimals,
     rent_pda::{RENT_PDA, RENT_PDA_BUMP, RENT_PDA_SEED},
     token_vault::validate_vault_for_mint,
+    unwrap_pda::{NATIVE_MINT, UNWRAP_PDA, UNWRAP_PDA_BUMP, UNWRAP_PDA_SEED},
 };
 
 ///
@@ -25,20 +29,34 @@ use crate::processor::internal::{
 ///  0: []                  - PDA     : Global vault account.
 ///  1: []                  - SPL     : Mint account.
 ///  2: [writable]          - SPL     : Vault token account.
-///  3: []                  - Any     : Destination owner.
+///  3: []                  - Any     : Destination owner. (writable for native SOL)
 ///  4: [writable]          - SPL     : Destination token account.
 ///  5: [writable]          - PDA     : Global rent PDA.
 ///  6: []                  - SPL     : Token program.
 ///  7: []                  - SPL     : Associated token program.
 ///  8: []                  - Builtin : System program.
-///  9: []                  - Program : Source program (must equal this program).
-/// 10: []                  - PDA     : Queue PDA authority.
-/// 11: [signer]            - PDA     : Escrow signer PDA.
+///
+/// Native SOL settlements insert two accounts before DLP's appended accounts:
+///
+///  9: [writable]          - SPL     : Scratch WSOL ATA owned by the unwrap PDA.
+/// 10: []                  - PDA     : Unwrap authority.
 ///
 /// Instruction Data: ExecuteQueuedTransferArgs
 ///
 #[inline(always)]
 pub fn process_execute_ready_queued_transfer(accounts: &[AccountView], instruction_data: &[u8]) -> ProgramResult {
+    let (head_accounts, native_accounts, source_program, escrow_authority, escrow_signer) = match accounts.len() {
+        12 => (&accounts[..9], None, &accounts[9], &accounts[10], &accounts[11]),
+        14 => (
+            &accounts[..9],
+            Some((&accounts[9], &accounts[10])),
+            &accounts[11],
+            &accounts[12],
+            &accounts[13],
+        ),
+        _ => return Err(ProgramError::NotEnoughAccountKeys),
+    };
+
     let [
         vault_info, // force multi-line
         mint_info,
@@ -49,10 +67,7 @@ pub fn process_execute_ready_queued_transfer(accounts: &[AccountView], instructi
         token_program_info,
         associated_token_program_info,
         system_program_info,
-        source_program,
-        escrow_authority,
-        escrow_signer,
-    ] = require_n_accounts!(accounts, 12);
+    ] = require_n_accounts!(head_accounts, 9);
 
     let args = ExecuteQueuedTransferArgs::decode(instruction_data)?;
 
@@ -64,6 +79,32 @@ pub fn process_execute_ready_queued_transfer(accounts: &[AccountView], instructi
 
     let expected_escrow = ephemeral_balance_pda_from_payer(escrow_authority.address(), args.escrow_index());
     require_eq_keys!(&expected_escrow, escrow_signer.address(), ProgramError::InvalidSeeds);
+
+    if let Some((scratch_wsol_ata_info, unwrap_pda_info)) = native_accounts {
+        process_native_delivery(
+            NativeDeliveryAccounts {
+                vault_info,
+                mint_info,
+                vault_token_acc_info,
+                destination_owner_info,
+                rent_pda_info,
+                token_program_info,
+                associated_token_program_info,
+                system_program_info,
+                scratch_wsol_ata_info,
+                unwrap_pda_info,
+            },
+            args.amount(),
+        )?;
+
+        if let Some(client_ref_id) = args.client_ref_id() {
+            if client_ref_id != 0 {
+                pinocchio_log::log!("client_ref_id: {}", client_ref_id);
+            }
+        }
+
+        return Ok(());
+    }
 
     if args.should_create_destination_ata_idempotent() {
         require!(
@@ -100,7 +141,7 @@ pub fn process_execute_ready_queued_transfer(accounts: &[AccountView], instructi
     let signer_seeds = GlobalVault::signer_seeds(mint_info.address(), &vault_bump);
     let signer = Signer::from(&signer_seeds);
 
-    pinocchio_token_2022::instructions::TransferChecked {
+    TransferChecked {
         mint: mint_info,
         from: vault_token_acc_info,
         to: destination_token_acc_info,
@@ -118,4 +159,107 @@ pub fn process_execute_ready_queued_transfer(accounts: &[AccountView], instructi
     }
 
     Ok(())
+}
+
+struct NativeDeliveryAccounts<'a> {
+    vault_info: &'a AccountView,
+    mint_info: &'a AccountView,
+    vault_token_acc_info: &'a AccountView,
+    destination_owner_info: &'a AccountView,
+    rent_pda_info: &'a AccountView,
+    token_program_info: &'a AccountView,
+    associated_token_program_info: &'a AccountView,
+    system_program_info: &'a AccountView,
+    scratch_wsol_ata_info: &'a AccountView,
+    unwrap_pda_info: &'a AccountView,
+}
+
+#[inline(never)]
+fn process_native_delivery(accounts: NativeDeliveryAccounts<'_>, amount: u64) -> ProgramResult {
+    let NativeDeliveryAccounts {
+        vault_info,
+        mint_info,
+        vault_token_acc_info,
+        destination_owner_info,
+        rent_pda_info,
+        token_program_info,
+        associated_token_program_info,
+        system_program_info,
+        scratch_wsol_ata_info,
+        unwrap_pda_info,
+    } = accounts;
+
+    require_eq_keys!(mint_info.address(), &NATIVE_MINT, ProgramError::InvalidAccountData);
+    require!(
+        address_eq(token_program_info.address(), &SPL_TOKEN_PROGRAM_ID),
+        ProgramError::IncorrectProgramId
+    );
+    require!(
+        rent_pda_info.owned_by(&SYSTEM_PROGRAM_ID),
+        ProgramError::InvalidAccountOwner
+    );
+    require_eq_keys!(&RENT_PDA, rent_pda_info.address(), ProgramError::InvalidSeeds);
+    require!(rent_pda_info.data_len() == 0, ProgramError::InvalidAccountData);
+    require!(
+        associated_token_program_info.address() == &pinocchio_associated_token_account::ID
+            && system_program_info.address() == &SYSTEM_PROGRAM_ID,
+        ProgramError::InvalidAccountData
+    );
+
+    require_eq_keys!(unwrap_pda_info.address(), &UNWRAP_PDA, ProgramError::InvalidSeeds);
+    let expected_scratch = get_associated_token_address(&UNWRAP_PDA, mint_info.address(), token_program_info.address());
+    require_eq_keys!(
+        &expected_scratch,
+        scratch_wsol_ata_info.address(),
+        ProgramError::InvalidSeeds
+    );
+
+    let vault_bump = validate_vault_for_mint(vault_info, mint_info, vault_token_acc_info)?;
+    let decimals = read_mint_decimals(mint_info, token_program_info)?;
+
+    let rent_bump_seed = [RENT_PDA_BUMP];
+    let rent_signer_seed = [Seed::from(RENT_PDA_SEED), Seed::from(&rent_bump_seed)];
+    let rent_signer = Signer::from(&rent_signer_seed);
+    (pinocchio_associated_token_account::instructions::CreateIdempotent {
+        funding_account: rent_pda_info,
+        account: scratch_wsol_ata_info,
+        wallet: unwrap_pda_info,
+        mint: mint_info,
+        system_program: system_program_info,
+        token_program: token_program_info,
+    })
+    .invoke_signed(&[rent_signer])?;
+
+    let vault_bump = [vault_bump];
+    let vault_signer_seeds = GlobalVault::signer_seeds(mint_info.address(), &vault_bump);
+    let vault_signer = Signer::from(&vault_signer_seeds);
+    TransferChecked {
+        mint: mint_info,
+        from: vault_token_acc_info,
+        to: scratch_wsol_ata_info,
+        authority: vault_info,
+        token_program: token_program_info.address(),
+        amount,
+        decimals,
+    }
+    .invoke_signed(&[vault_signer])?;
+
+    let unwrap_bump_seed = [UNWRAP_PDA_BUMP];
+    let unwrap_signer_seed = [Seed::from(UNWRAP_PDA_SEED), Seed::from(&unwrap_bump_seed)];
+    let unwrap_signer = Signer::from(&unwrap_signer_seed);
+    CloseAccount {
+        account: scratch_wsol_ata_info,
+        destination: rent_pda_info,
+        authority: unwrap_pda_info,
+        token_program: token_program_info.address(),
+    }
+    .invoke_signed(&[unwrap_signer])?;
+
+    let rent_signer = Signer::from(&rent_signer_seed);
+    Transfer {
+        from: rent_pda_info,
+        to: destination_owner_info,
+        lamports: amount,
+    }
+    .invoke_signed(&[rent_signer])
 }

--- a/e-token/src/processor/internal/mod.rs
+++ b/e-token/src/processor/internal/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod shuttle_delegation;
 pub(crate) mod token;
 pub(crate) mod token_vault;
 pub(crate) mod transfer_queue_refill;
+pub(crate) mod unwrap_pda;
 
 pub(crate) use ephemeral_account::MAGIC_VAULT_ID;
 #[cfg(feature = "logging")]

--- a/e-token/src/processor/internal/queue_authorized_action.rs
+++ b/e-token/src/processor/internal/queue_authorized_action.rs
@@ -11,10 +11,17 @@ use pinocchio::{
     AccountView, ProgramResult,
 };
 use pinocchio_system::ID as SYSTEM_PROGRAM_ID;
-use solana_address::Address;
+use solana_address::{address_eq, Address};
+use spl_token_interface::ID as SPL_TOKEN_PROGRAM_ID;
 use wheels::layout::Encodable as _;
 
-use crate::processor::{internal, internal::rent_pda::RENT_PDA};
+use crate::processor::{
+    internal,
+    internal::{
+        rent_pda::RENT_PDA,
+        unwrap_pda::{NATIVE_MINT, UNWRAP_PDA},
+    },
+};
 
 const MAGIC_INTENT_BUNDLE_DATA_LEN: usize = 512;
 pub(crate) const EXECUTE_READY_QUEUED_TRANSFER_ESCROW_INDEX: u8 = 0;
@@ -66,7 +73,7 @@ pub(crate) fn invoke_standalone_action(
 /// Action builder for `ExecuteReadyQueuedTransfer`
 pub(crate) struct QueuedTransferActionBuilder {
     queue_info: AccountView,
-    accounts: [ShortAccountMeta; 9],
+    accounts: Vec<ShortAccountMeta>,
     data: Vec<u8>,
 }
 
@@ -107,20 +114,19 @@ impl QueuedTransferActionBuilder {
         vault: &Address,
         mint: &Address,
         token_program: &Address,
-    ) -> [ShortAccountMeta; 9] {
+    ) -> Vec<ShortAccountMeta> {
+        let deliver_native = address_eq(mint, &NATIVE_MINT) && address_eq(token_program, &SPL_TOKEN_PROGRAM_ID);
         let vault_token_account = internal::get_associated_token_address(vault, mint, token_program);
         let destination_token_account = internal::get_associated_token_address(destination_owner, mint, token_program);
 
-        // Note that we initialize CallHandler with 9 accounts only, and then 3 more accounts [source_program,
-        // escrow_authority, escrow_signer] are appended by DLP's CallHandlerV2 instruction, which is
-        // why EXECUTE_READY_QUEUED_TRANSFER receives 12 accounts (not 9).
-        [
+        // DLP appends [source_program, escrow_authority, escrow_signer].
+        let mut accounts = alloc::vec![
             ShortAccountMeta {
-                pubkey: vault.clone(),
+                pubkey: *vault,
                 is_writable: false,
             },
             ShortAccountMeta {
-                pubkey: mint.clone(),
+                pubkey: *mint,
                 is_writable: false,
             },
             ShortAccountMeta {
@@ -129,7 +135,7 @@ impl QueuedTransferActionBuilder {
             },
             ShortAccountMeta {
                 pubkey: *destination_owner,
-                is_writable: false,
+                is_writable: deliver_native,
             },
             ShortAccountMeta {
                 pubkey: destination_token_account,
@@ -151,6 +157,49 @@ impl QueuedTransferActionBuilder {
                 pubkey: SYSTEM_PROGRAM_ID,
                 is_writable: false,
             },
-        ]
+        ];
+
+        if deliver_native {
+            accounts.push(ShortAccountMeta {
+                pubkey: internal::get_associated_token_address(&UNWRAP_PDA, mint, token_program),
+                is_writable: true,
+            });
+            accounts.push(ShortAccountMeta {
+                pubkey: UNWRAP_PDA,
+                is_writable: false,
+            });
+        }
+
+        accounts
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_delivery_only_extends_the_wsol_action_accounts() {
+        let destination = Address::new_from_array([1; 32]);
+        let vault = Address::new_from_array([2; 32]);
+
+        let native_accounts =
+            QueuedTransferActionBuilder::action_accounts(&destination, &vault, &NATIVE_MINT, &SPL_TOKEN_PROGRAM_ID);
+        assert_eq!(native_accounts.len(), 11);
+        assert!(native_accounts[3].is_writable);
+        assert_eq!(
+            native_accounts[9].pubkey,
+            internal::get_associated_token_address(&UNWRAP_PDA, &NATIVE_MINT, &SPL_TOKEN_PROGRAM_ID)
+        );
+        assert_eq!(native_accounts[10].pubkey, UNWRAP_PDA);
+
+        let spl_accounts = QueuedTransferActionBuilder::action_accounts(
+            &destination,
+            &vault,
+            &Address::new_from_array([3; 32]),
+            &SPL_TOKEN_PROGRAM_ID,
+        );
+        assert_eq!(spl_accounts.len(), 9);
+        assert!(!spl_accounts[3].is_writable);
     }
 }

--- a/e-token/src/processor/internal/unwrap_pda.rs
+++ b/e-token/src/processor/internal/unwrap_pda.rs
@@ -1,0 +1,13 @@
+use solana_address::Address;
+
+/// Wrapped SOL (native) mint address `So11111111111111111111111111111111111111112`.
+pub(crate) const NATIVE_MINT: Address = Address::new_from_array([
+    6, 155, 136, 87, 254, 171, 129, 132, 251, 104, 127, 99, 70, 24, 192, 53, 218, 196, 57, 220, 26, 235, 59, 85, 152,
+    160, 240, 0, 0, 0, 0, 1,
+]);
+
+pub(crate) const UNWRAP_PDA_SEED: &[u8] = b"unwrap";
+const UNWRAP_PDA_AND_BUMP: ([u8; 32], u8) =
+    const_crypto::ed25519::derive_program_address(&[UNWRAP_PDA_SEED], crate::ID.as_array());
+pub(crate) const UNWRAP_PDA: Address = Address::new_from_array(UNWRAP_PDA_AND_BUMP.0);
+pub(crate) const UNWRAP_PDA_BUMP: u8 = UNWRAP_PDA_AND_BUMP.1;

--- a/e-token/src/processor/recover_and_close_shuttle_to_owner.rs
+++ b/e-token/src/processor/recover_and_close_shuttle_to_owner.rs
@@ -81,5 +81,5 @@ pub fn process_recover_and_close_shuttle_to_owner(accounts: &[AccountView], inst
         Some(token_program_info.address()),
     )?;
 
-    settle_and_close_shuttle_accounts(accounts, None)
+    settle_and_close_shuttle_accounts(accounts, None, None)
 }

--- a/e-token/src/processor/undelegate_and_close_shuttle_to_owner.rs
+++ b/e-token/src/processor/undelegate_and_close_shuttle_to_owner.rs
@@ -4,17 +4,20 @@ use ephemeral_spl_api::{
     state::{ephemeral_ata::EphemeralAta, load_initialized, shuttle_ephemeral_ata::ShuttleMetadata},
 };
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
-use solana_address::Address;
+use solana_address::{address_eq, Address};
+use spl_token_interface::ID as SPL_TOKEN_PROGRAM_ID;
 
 use crate::{
     instruction::ESplInternalInstruction,
     processor::internal::{
-        get_associated_token_address, shuttle_delegation::DEFAULT_ESCROW_INDEX, validate_token_account,
+        get_associated_token_address, shuttle_delegation::DEFAULT_ESCROW_INDEX, unwrap_pda::NATIVE_MINT,
+        validate_token_account,
     },
 };
 
 const INTENT_BUNDLE_DATA_BUF_SIZE: usize = 1536;
 const CLOSE_SHUTTLE_ATA_COMPUTE_UNITS: u32 = 100_000;
+const CLOSE_SHUTTLE_ATA_NATIVE_COMPUTE_UNITS: u32 = 140_000;
 const CLOSE_STASH_DATA_LEN: usize = 33;
 
 struct CloseStashForward {
@@ -99,6 +102,8 @@ pub fn process_undelegate_and_close_shuttle_to_owner(
         );
         shuttle_ephemeral_ata.mint
     };
+    let deliver_native =
+        address_eq(&mint, &NATIVE_MINT) && address_eq(token_program_info.address(), &SPL_TOKEN_PROGRAM_ID);
 
     let (derived_shuttle_ephemeral_ata, _) =
         Address::find_program_address(&[shuttle_info.address().as_ref(), mint.as_ref()], &crate::ID);
@@ -142,6 +147,8 @@ pub fn process_undelegate_and_close_shuttle_to_owner(
         magic_program,
         escrow_index,
         close_stash.as_ref(),
+        &shuttle.owner,
+        deliver_native,
     )
 }
 
@@ -178,6 +185,8 @@ fn schedule_shuttle_close_after_undelegate(
     magic_program: &AccountView,
     escrow_index: u8,
     close_stash: Option<&CloseStashForward>,
+    owner: &Address,
+    deliver_native: bool,
 ) -> ProgramResult {
     let (vault_info, _) = Address::find_program_address(&[mint.as_ref()], &crate::ID);
     let vault_token_info = get_associated_token_address(&vault_info, mint, token_program_info.address());
@@ -186,7 +195,7 @@ fn schedule_shuttle_close_after_undelegate(
         close_handler_data.extend_from_slice(&close.user);
         close_handler_data.push(close.stash_bump);
     }
-    let close_handler_accounts = alloc::vec![
+    let mut close_handler_accounts = alloc::vec![
         ShortAccountMeta {
             pubkey: *rent_reimbursement.address(),
             is_writable: true,
@@ -224,11 +233,21 @@ fn schedule_shuttle_close_after_undelegate(
             is_writable: false,
         },
     ];
+    if deliver_native {
+        close_handler_accounts.push(ShortAccountMeta {
+            pubkey: *owner,
+            is_writable: true,
+        });
+    }
     let close_handler = [CallHandler {
         destination_program: crate::ID,
         escrow_authority: executor.clone(),
         args: ActionArgs::new(&close_handler_data).with_escrow_index(escrow_index),
-        compute_units: CLOSE_SHUTTLE_ATA_COMPUTE_UNITS,
+        compute_units: if deliver_native {
+            CLOSE_SHUTTLE_ATA_NATIVE_COMPUTE_UNITS
+        } else {
+            CLOSE_SHUTTLE_ATA_COMPUTE_UNITS
+        },
         accounts: &close_handler_accounts,
         callback: None,
     }];

--- a/e-token/src/processor/undelegate_and_close_shuttle_to_owner.rs
+++ b/e-token/src/processor/undelegate_and_close_shuttle_to_owner.rs
@@ -4,6 +4,7 @@ use ephemeral_spl_api::{
     state::{ephemeral_ata::EphemeralAta, load_initialized, shuttle_ephemeral_ata::ShuttleMetadata},
 };
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+use pinocchio_system::ID as SYSTEM_PROGRAM_ID;
 use solana_address::{address_eq, Address};
 use spl_token_interface::ID as SPL_TOKEN_PROGRAM_ID;
 
@@ -234,10 +235,7 @@ fn schedule_shuttle_close_after_undelegate(
         },
     ];
     if deliver_native {
-        close_handler_accounts.push(ShortAccountMeta {
-            pubkey: *owner,
-            is_writable: true,
-        });
+        close_handler_accounts.extend(native_close_action_accounts(owner));
     }
     let close_handler = [CallHandler {
         destination_program: crate::ID,
@@ -258,4 +256,34 @@ fn schedule_shuttle_close_after_undelegate(
         .commit_and_undelegate(&committed_accounts)
         .add_post_undelegate_actions(&close_handler)
         .build_and_invoke(&mut intent_bundle_data)
+}
+
+#[inline(always)]
+fn native_close_action_accounts(owner: &Address) -> [ShortAccountMeta; 2] {
+    [
+        ShortAccountMeta {
+            pubkey: *owner,
+            is_writable: true,
+        },
+        ShortAccountMeta {
+            pubkey: SYSTEM_PROGRAM_ID,
+            is_writable: false,
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_close_action_includes_owner_and_system_program() {
+        let owner = Address::new_from_array([1; 32]);
+        let accounts = native_close_action_accounts(&owner);
+
+        assert_eq!(accounts[0].pubkey, owner);
+        assert!(accounts[0].is_writable);
+        assert_eq!(accounts[1].pubkey, SYSTEM_PROGRAM_ID);
+        assert!(!accounts[1].is_writable);
+    }
 }


### PR DESCRIPTION
## Summary

- deliver queued WSOL payments as native lamports through a transient program-owned WSOL account
- deliver normal WSOL unshielding as native lamports by reusing and closing the shuttle token account
- unwrap direct non-idempotent API withdrawals and fund the queue rent PDA for private SOL payments
- preserve existing public request and instruction-data formats

## Problem

Private SOL payments and unshielding completed into wrapped SOL token accounts, requiring recipients to unwrap funds manually. The queued settlement path also had no program-controlled account through which it could safely close WSOL and forward the exact payment amount as lamports.

## Solution

WSOL queue actions now include a deterministic unwrap PDA and scratch ATA. Settlement creates the scratch account, transfers the exact queued amount, closes it back into the rent PDA, and forwards only that amount to the destination.

The unshield path reuses the existing shuttle WSOL account, combines its wallet and ephemeral balances, closes it into the rent PDA, and forwards the exact token total to the owner. Unsupported owner or reimbursement states retain the existing token-delivery fallback so funds are not stranded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added native SOL delivery and settlement for queued transfers, including a native-eligible settlement path.
  - Added automatic WSOL handling (temporary account creation, unwrapping, and cleanup) for native flows.
  - Enhanced shuttle account closing/settlement to optionally route proceeds to the owner via native SOL.
- **Bug Fixes**
  - Improved withdrawal cleanup by closing the SPL token account when using the legacy withdrawal path.
  - Corrected native SOL rent top-ups for private transfers.
- **Tests**
  - Expanded transaction-building test coverage with stronger assertions for native/SPL scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->