### PR TITLE
docs: add clusters for tee

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -482,7 +482,7 @@ http://127.0.0.1:6274
   - use `mainnet-private` to use `BASE_RPC_URL` and `EPHEMERAL_TEE_RPC_URL`
   - use `devnet-private` to use `BASE_DEVNET_RPC_URL` and `EPHEMERAL_DEVNET_TEE_RPC_URL`
   - use any other valid http(s) URL to override only the base RPC and keep the configured ephemeral RPC
-- auth (`/v1/spl/challenge`, `/v1/spl/login`) and bearer-token-gated reads only work on the `-private` clusters: the auth service runs on the TEE validators, not on the public ephemeral RPCs. On `mainnet`/`devnet` the API currently falls back to a `MOCK:`-prefixed challenge and `mock-auth-token` (no signature verification) — treat those values as a misconfigured cluster, and keep the whole auth + private-read flow on the same `-private` cluster because tokens are scoped per validator
+- auth (`/v1/spl/challenge`, `/v1/spl/login`) and bearer-token-gated reads require a `-private` cluster; keep the whole flow on the same cluster because tokens are scoped per validator
 - amount encoding depends on the route:
   - deposit, withdraw, and transfer: integer JSON values with minimum `1`, for example `1` or `1000000`
 - do not send UI-decimal token strings like `"1.5"`
@@ -802,9 +802,7 @@ Note:
 
 ### `GET /v1/spl/challenge`
 
-Returns a challenge string for the wallet to sign as the first step of the Private Ephemeral Rollup login flow.
-
-Requires `cluster=mainnet-private` or `cluster=devnet-private`: the auth service runs on the TEE validators only. With `cluster` omitted or set to `mainnet`/`devnet`, the ephemeral RPC has no `/auth/challenge` endpoint and the API returns a placeholder challenge prefixed with `MOCK:` that no validator will accept.
+Returns a challenge string for the wallet to sign as the first step of the Private Ephemeral Rollup login flow. Requires `cluster=mainnet-private` or `cluster=devnet-private`; the auth service runs on the TEE validators only.
 
 Example:
 
@@ -822,9 +820,7 @@ Response:
 
 ### `POST /v1/spl/login`
 
-Verifies the wallet's signature over the challenge and returns a bearer token for auth-gated routes such as `/v1/spl/private-balance` and ephemeral-side transfers.
-
-Use the same `-private` cluster as the challenge request; tokens are scoped to the validator that issued them. As with the challenge route, `mainnet`/`devnet` have no auth service and the API falls back to `{"token": "mock-auth-token"}` without verifying the signature — a client that receives `mock-auth-token` should treat it as a cluster misconfiguration, not a successful login.
+Verifies the wallet's signature over the challenge and returns a bearer token for auth-gated routes such as `/v1/spl/private-balance` and ephemeral-side transfers. Use the same `-private` cluster as the challenge request; tokens are scoped to the validator that issued them.
 
 Example:
 

--- a/api/README.md
+++ b/api/README.md
@@ -24,6 +24,8 @@ The API exposes:
 - `GET /v1/spl/stealth-pool`
 - `GET /v1/spl/balance`
 - `GET /v1/spl/private-balance`
+- `GET /v1/spl/challenge`
+- `POST /v1/spl/login`
 - `GET /v1/swap/quote`
 - `POST /v1/swap/swap`
 - `POST /v1/transaction/send`
@@ -480,6 +482,7 @@ http://127.0.0.1:6274
   - use `mainnet-private` to use `BASE_RPC_URL` and `EPHEMERAL_TEE_RPC_URL`
   - use `devnet-private` to use `BASE_DEVNET_RPC_URL` and `EPHEMERAL_DEVNET_TEE_RPC_URL`
   - use any other valid http(s) URL to override only the base RPC and keep the configured ephemeral RPC
+- auth (`/v1/spl/challenge`, `/v1/spl/login`) and bearer-token-gated reads only work on the `-private` clusters: the auth service runs on the TEE validators, not on the public ephemeral RPCs. On `mainnet`/`devnet` the API currently falls back to a `MOCK:`-prefixed challenge and `mock-auth-token` (no signature verification) — treat those values as a misconfigured cluster, and keep the whole auth + private-read flow on the same `-private` cluster because tokens are scoped per validator
 - amount encoding depends on the route:
   - deposit, withdraw, and transfer: integer JSON values with minimum `1`, for example `1` or `1000000`
 - do not send UI-decimal token strings like `"1.5"`
@@ -796,6 +799,55 @@ Note:
 
 - returns `0` when the eATA delegation record is missing or delegated to another validator
 - the response still reports the projected owner ATA address, not the delegation PDA
+
+### `GET /v1/spl/challenge`
+
+Returns a challenge string for the wallet to sign as the first step of the Private Ephemeral Rollup login flow.
+
+Requires `cluster=mainnet-private` or `cluster=devnet-private`: the auth service runs on the TEE validators only. With `cluster` omitted or set to `mainnet`/`devnet`, the ephemeral RPC has no `/auth/challenge` endpoint and the API returns a placeholder challenge prefixed with `MOCK:` that no validator will accept.
+
+Example:
+
+```bash
+curl "http://127.0.0.1:8787/v1/spl/challenge?pubkey=3rXKwQ1kpjBd5tdcco32qsvqUh1BnZjcYnS5kYrP7AYE&cluster=mainnet-private"
+```
+
+Response:
+
+```json
+{
+  "challenge": "Login to Query Filtering Service\nTimestamp: 1783914173\nUser: 3rXKwQ1kpjBd5tdcco32qsvqUh1BnZjcYnS5kYrP7AYE"
+}
+```
+
+### `POST /v1/spl/login`
+
+Verifies the wallet's signature over the challenge and returns a bearer token for auth-gated routes such as `/v1/spl/private-balance` and ephemeral-side transfers.
+
+Use the same `-private` cluster as the challenge request; tokens are scoped to the validator that issued them. As with the challenge route, `mainnet`/`devnet` have no auth service and the API falls back to `{"token": "mock-auth-token"}` without verifying the signature — a client that receives `mock-auth-token` should treat it as a cluster misconfiguration, not a successful login.
+
+Example:
+
+```bash
+curl -X POST http://127.0.0.1:8787/v1/spl/login \
+  -H 'content-type: application/json' \
+  -d '{
+    "cluster": "mainnet-private",
+    "pubkey": "3rXKwQ1kpjBd5tdcco32qsvqUh1BnZjcYnS5kYrP7AYE",
+    "challenge": "Login to Query Filtering Service\nTimestamp: 1783914173\nUser: 3rXKwQ1kpjBd5tdcco32qsvqUh1BnZjcYnS5kYrP7AYE",
+    "signature": "<base58 signature of the challenge>"
+  }'
+```
+
+Response:
+
+```json
+{
+  "token": "<bearer token>"
+}
+```
+
+Pass the token as `Authorization: Bearer <token>` on subsequent requests, keeping `cluster` set to the same `-private` value.
 
 ## Error Handling
 

--- a/api/src/routes/spl/spl.routes.ts
+++ b/api/src/routes/spl/spl.routes.ts
@@ -318,7 +318,7 @@ export const challengeRoute = createRoute({
   path: "/v1/spl/challenge",
   method: "get",
   tags,
-  description: "Generate a challenge string for the wallet to sign.",
+  description: "Generate a challenge string for the wallet to sign. The auth service only runs on the TEE validators, so pass `cluster=mainnet-private` or `cluster=devnet-private`. On `mainnet`/`devnet` (or when `cluster` is omitted) the ephemeral RPC has no auth endpoints and the API returns a placeholder challenge prefixed with `MOCK:` that no validator will accept.",
   request: {
     query: challengeRequestSchema,
   },
@@ -333,7 +333,7 @@ export const loginRoute = createRoute({
   path: "/v1/spl/login",
   method: "post",
   tags,
-  description: "Login the wallet to the Private Ephemeral Rollup.",
+  description: "Login the wallet to the Private Ephemeral Rollup. Verifies the wallet's signature over the challenge from `/v1/spl/challenge` and returns a bearer token scoped to that validator. Use the same `-private` cluster as the challenge request; on `mainnet`/`devnet` (or when `cluster` is omitted) there is no auth service and the API returns `mock-auth-token` without verifying the signature — treat a `MOCK:` challenge or `mock-auth-token` as a misconfigured cluster, not a successful login.",
   request: {
     body: jsonContentRequired(loginRequestSchema, "Login request"),
   },

--- a/api/src/routes/spl/spl.routes.ts
+++ b/api/src/routes/spl/spl.routes.ts
@@ -318,7 +318,7 @@ export const challengeRoute = createRoute({
   path: "/v1/spl/challenge",
   method: "get",
   tags,
-  description: "Generate a challenge string for the wallet to sign. The auth service only runs on the TEE validators, so pass `cluster=mainnet-private` or `cluster=devnet-private`. On `mainnet`/`devnet` (or when `cluster` is omitted) the ephemeral RPC has no auth endpoints and the API returns a placeholder challenge prefixed with `MOCK:` that no validator will accept.",
+  description: "Generate a challenge string for the wallet to sign. Requires `cluster=mainnet-private` or `cluster=devnet-private`; the auth service runs on the TEE validators only.",
   request: {
     query: challengeRequestSchema,
   },
@@ -333,7 +333,7 @@ export const loginRoute = createRoute({
   path: "/v1/spl/login",
   method: "post",
   tags,
-  description: "Login the wallet to the Private Ephemeral Rollup. Verifies the wallet's signature over the challenge from `/v1/spl/challenge` and returns a bearer token scoped to that validator. Use the same `-private` cluster as the challenge request; on `mainnet`/`devnet` (or when `cluster` is omitted) there is no auth service and the API returns `mock-auth-token` without verifying the signature — treat a `MOCK:` challenge or `mock-auth-token` as a misconfigured cluster, not a successful login.",
+  description: "Login the wallet to the Private Ephemeral Rollup. Exchanges the signed challenge from `/v1/spl/challenge` for a bearer token. Use the same `-private` cluster as the challenge request.",
   request: {
     body: jsonContentRequired(loginRequestSchema, "Login request"),
   },

--- a/api/src/schema.ts
+++ b/api/src/schema.ts
@@ -102,7 +102,7 @@ export const clusterSchema = z
   .openapi({
     example: "mainnet",
     description:
-      "Optional. Use `mainnet` for BASE_RPC_URL and EPHEMERAL_RPC_URL, `devnet` for BASE_DEVNET_RPC_URL and EPHEMERAL_DEVNET_RPC_URL, `mainnet-private` for BASE_RPC_URL and EPHEMERAL_TEE_RPC_URL, `devnet-private` for BASE_DEVNET_RPC_URL and EPHEMERAL_DEVNET_TEE_RPC_URL, or provide a custom http(s) RPC URL to override the base RPC while keeping the configured ephemeral RPC.",
+      "Optional, defaults to `mainnet`. `mainnet` and `devnet` route to the public ephemeral RPC for that network; `mainnet-private` and `devnet-private` route to the TEE-backed Private Ephemeral Rollup. The auth endpoints (`/v1/spl/challenge`, `/v1/spl/login`) and bearer-token-gated reads are only served by the TEE validators, so those calls must use a `-private` cluster. A custom http(s) RPC URL overrides only the base RPC while keeping the configured ephemeral RPC.",
   });
 
 export const visibilitySchema = z

--- a/api/src/schema.ts
+++ b/api/src/schema.ts
@@ -102,7 +102,7 @@ export const clusterSchema = z
   .openapi({
     example: "mainnet",
     description:
-      "Optional, defaults to `mainnet`. `mainnet` and `devnet` route to the public ephemeral RPC for that network; `mainnet-private` and `devnet-private` route to the TEE-backed Private Ephemeral Rollup. The auth endpoints (`/v1/spl/challenge`, `/v1/spl/login`) and bearer-token-gated reads are only served by the TEE validators, so those calls must use a `-private` cluster. A custom http(s) RPC URL overrides only the base RPC while keeping the configured ephemeral RPC.",
+      "Optional, defaults to `mainnet`. `mainnet` and `devnet` route to the public ephemeral RPC for that network; `mainnet-private` and `devnet-private` route to the TEE-backed Private Ephemeral Rollup and are required for auth and bearer-token-gated reads. A custom http(s) RPC URL overrides only the base RPC while keeping the configured ephemeral RPC.",
   });
 
 export const visibilitySchema = z


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented new SPL authentication endpoints for generating challenges and logging in.
  * Added guidance on private-cluster requirements for authentication and bearer-token requests.
  * Clarified mock responses on non-private clusters and same-cluster authentication flows.
  * Expanded endpoint examples, response formats, and cluster routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->