### PR TITLE
feat: add group permission acl

### DIFF
--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -3504,6 +3504,88 @@ describe("app", () => {
     });
   });
 
+  it("adds group receipt permission accounts to private queue transfers", async () => {
+    const mint = new PublicKey("So11111111111111111111111111111111111111112");
+    const validator = new PublicKey(resolvedValidator);
+    const [transferQueue] = deriveTransferQueue(mint, validator);
+
+    vi.spyOn(Connection.prototype, "getLatestBlockhash").mockImplementation(
+      async function getLatestBlockhash(
+        this: Connection & { _rpcEndpoint: string },
+      ) {
+        expect((this as Connection & { _rpcEndpoint: string })._rpcEndpoint).toBe(
+          env.EPHEMERAL_RPC_URL,
+        );
+        return {
+          blockhash: "11111111111111111111111111111111",
+          lastValidBlockHeight: 456,
+        };
+      },
+    );
+    vi.spyOn(Connection.prototype, "getAccountInfo").mockImplementation(
+      async address =>
+        address.equals(mint)
+          ? createMintAccountInfo(TOKEN_PROGRAM_ID)
+          : null,
+    );
+
+    const response = await app.request(
+      "/v1/spl/transfer",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          from: owner,
+          to: destination,
+          mint: mint.toBase58(),
+          amount: 1,
+          visibility: "private",
+          fromBalance: "ephemeral",
+          toBalance: "base",
+          validator: resolvedValidator,
+          minDelayMs: "0",
+          maxDelayMs: "0",
+          split: 1,
+        }),
+      },
+      env,
+    );
+
+    expect(response.status, await response.clone().text()).toBe(200);
+
+    const json = (await response.json()) as {
+      sendTo: string;
+      transactionBase64: string;
+    };
+    expect(json.sendTo).toBe("ephemeral");
+
+    const transaction = Transaction.from(
+      Buffer.from(json.transactionBase64, "base64"),
+    );
+    const queueTransferIx = transaction.instructions.find(
+      ix => ix.programId.equals(EPHEMERAL_SPL_TOKEN_PROGRAM_ID) && ix.data[0] === 16,
+    )!;
+    const groupReceipt = queueTransferIx.keys[9]!.pubkey;
+
+    expect(queueTransferIx.keys).toHaveLength(14);
+    expect(queueTransferIx.keys[0]!.pubkey.toBase58()).toBe(transferQueue.toBase58());
+    expect(queueTransferIx.keys[6]!.pubkey.toBase58()).toBe(owner);
+    expect(queueTransferIx.keys[12]).toMatchObject({
+      isSigner: false,
+      isWritable: true,
+    });
+    expect(queueTransferIx.keys[12]!.pubkey.toBase58()).toBe(
+      permissionPdaFromAccount(groupReceipt).toBase58(),
+    );
+    expect(queueTransferIx.keys[13]).toMatchObject({
+      pubkey: PERMISSION_PROGRAM_ID,
+      isSigner: false,
+      isWritable: false,
+    });
+  });
+
   it("builds a private transfer with top-level split and delay options", async () => {
     const transferEnv = {
       ...env,

--- a/api/src/lib/solana.ts
+++ b/api/src/lib/solana.ts
@@ -106,6 +106,9 @@ const TRANSFER_QUEUE_AUTH_ERROR_FORCE_INTERVAL = 100;
 const SOLANA_WIRE_TRANSACTION_SIZE_LIMIT = 1232;
 const UPDATE_STEALTH_POOL_DISCRIMINATOR = 21;
 const ENSURE_STEALTH_POOL_DELEGATED_DISCRIMINATOR = 22;
+const DEPOSIT_AND_QUEUE_TRANSFER_DISCRIMINATOR = 16;
+const DEPOSIT_AND_QUEUE_TRANSFER_LEGACY_ACCOUNT_COUNT = 12;
+const DEPOSIT_AND_QUEUE_TRANSFER_GROUP_RECEIPT_INDEX = 9;
 const STEALTH_POOL_SEED = Buffer.from("stealth_pool");
 const STEALTH_POOL_LONG_HANDLE_HASH_DOMAIN = Buffer.from("stealth_pool_handle");
 const STEALTH_POOL_SPLIT_ACROSS_KEYS_FLAG = 1 << 0;
@@ -1141,6 +1144,39 @@ function withPrivateTransferExactOut(
   });
 }
 
+function withGroupReceiptPermissionAccounts(instruction: TransactionInstruction) {
+  if (
+    !instruction.programId.equals(EPHEMERAL_SPL_TOKEN_PROGRAM_ID)
+    || instruction.data[0] !== DEPOSIT_AND_QUEUE_TRANSFER_DISCRIMINATOR
+    || instruction.keys.length !== DEPOSIT_AND_QUEUE_TRANSFER_LEGACY_ACCOUNT_COUNT
+  ) {
+    return instruction;
+  }
+
+  const groupReceipt = instruction.keys[DEPOSIT_AND_QUEUE_TRANSFER_GROUP_RECEIPT_INDEX]?.pubkey;
+  if (!groupReceipt) {
+    return instruction;
+  }
+
+  return new TransactionInstruction({
+    programId: instruction.programId,
+    keys: [
+      ...instruction.keys,
+      {
+        pubkey: permissionPdaFromAccount(groupReceipt),
+        isSigner: false,
+        isWritable: true,
+      },
+      {
+        pubkey: PERMISSION_PROGRAM_ID,
+        isSigner: false,
+        isWritable: false,
+      },
+    ],
+    data: Buffer.from(instruction.data),
+  });
+}
+
 function createRandomShuttleId() {
   return crypto.getRandomValues(new Uint32Array(1))[0] & 0x7fffffff;
 }
@@ -2142,7 +2178,7 @@ export async function buildTransferTransaction(env: AppEnv, input: TransferReque
         : undefined,
     });
     const normalizedTransferInstructions = transferInstructions.map(instruction =>
-      withPrivateTransferExactOut(instruction, exactOut));
+      withGroupReceiptPermissionAccounts(withPrivateTransferExactOut(instruction, exactOut)));
     // Gasless private base->base already adds a relay-fee token transfer. Dropping
     // the opportunistic queue-refill ix keeps the full transaction under Solana's
     // packet limit while preserving the actual private transfer instruction.

--- a/e-token-api/src/state/group_receipt.rs
+++ b/e-token-api/src/state/group_receipt.rs
@@ -82,6 +82,11 @@ impl<'a> GroupReceipt<'a> {
     pub fn splits(&self) -> u32 {
         self.header.splits()
     }
+
+    #[inline(always)]
+    pub fn bump(&self) -> u8 {
+        self.header.bump()
+    }
 }
 
 /// Header for group receipts

--- a/e-token/src/processor/deposit_and_queue_transfer.rs
+++ b/e-token/src/processor/deposit_and_queue_transfer.rs
@@ -5,8 +5,9 @@ use ephemeral_rollups_pinocchio::consts::MAGIC_PROGRAM_ID;
 use ephemeral_spl_api::state::transfer_queue::capacity_from_data_len;
 use ephemeral_spl_api::{
     debug_log,
+    error::EphemeralSplError,
     instructions::DepositAndQueueTransferArgs,
-    require, require_eq_keys, require_n_accounts,
+    require, require_eq_keys, require_n_accounts_with_optionals,
     state::{
         stealth_pool::StealthPool,
         transfer_queue::{
@@ -29,7 +30,7 @@ use crate::processor::internal::{
     group_receipt::derive_group_receipt_id,
     group_receipt_create, read_mint_decimals, token_program_kind,
     token_vault::{transfer_to_queue_vault_for_mint, transfer_to_vault_for_mint, validate_queue_vault_for_mint},
-    GroupReceiptAccounts,
+    GroupReceiptAccounts, GroupReceiptPermissionAccounts,
 };
 
 const MILLIS_PER_SECOND: u64 = 1_000;
@@ -52,24 +53,47 @@ const MILLIS_PER_SECOND: u64 = 1_000;
 ///  10: [writable]         - SPL     : Magic vault
 ///  11: []                 - Magic   : Magic program
 ///
+/// Accounts (14-account shape — adds a private ACL permission on the group receipt):
+///
+///  0-11: same as above.
+///  12: [writable]         - PDA     : Group receipt permission (derived from ["permission:", group_receipt]).
+///  13: []                 - Program : Permission program (ACL).
+///
 /// Instruction Data: DepositAndQueueTransferArgs
 ///
 #[inline(always)]
 pub fn process_deposit_and_queue_transfer(accounts: &[AccountView], instruction_data: &[u8]) -> ProgramResult {
-    let [
-        queue_info, // force multi-line
-        vault_info,
-        mint_info,
-        user_source_token_acc,
-        vault_token_acc,
-        destination_info,
-        user_authority,
-        token_program_info,
-        reimbursement_token_info,
-        group_receipt_info,
-        magic_vault,
-        magic_program,
-    ] = require_n_accounts!(accounts, 12);
+    // TODO (snawaz): fold the 12-account shape into the 14-account one once all clients
+    // pass the group receipt permission accounts.
+    let (
+        [
+            queue_info, // force multi-line
+            vault_info,
+            mint_info,
+            user_source_token_acc,
+            vault_token_acc,
+            destination_info,
+            user_authority,
+            token_program_info,
+            reimbursement_token_info,
+            group_receipt_info,
+            magic_vault,
+            magic_program,
+        ],
+        optional_accounts,
+    ) = require_n_accounts_with_optionals!(accounts, 12);
+
+    // Only the 12- and 14-account shapes are valid: a partial permission pair
+    // must fail loudly rather than silently create an unprotected receipt.
+    let receipt_permission = match optional_accounts {
+        [] => None,
+        [permission_info, permission_program] => Some(GroupReceiptPermissionAccounts {
+            permission_info,
+            permission_program,
+        }),
+        [_] => return Err(ProgramError::NotEnoughAccountKeys),
+        _ => return Err(EphemeralSplError::TooManyAccountKeys.into()),
+    };
 
     let args = DepositAndQueueTransferArgs::decode(instruction_data)?;
 
@@ -237,7 +261,8 @@ pub fn process_deposit_and_queue_transfer(accounts: &[AccountView], instruction_
             group_receipt_info,
             source: user_authority,
             magic_vault,
-            _magic_program: magic_program,
+            magic_program,
+            permission: receipt_permission,
         },
         group_receipt_bump,
         group_id,

--- a/e-token/src/processor/execute_transfer_callback.rs
+++ b/e-token/src/processor/execute_transfer_callback.rs
@@ -15,7 +15,7 @@ use crate::processor::internal::{
     group_receipt::{derive_group_receipt_id, TransferCallbackArgs, TransferCallbackArgsView},
     group_receipt_close,
     refund::{schedule_refund_on_failure, RefundOnFailureAccounts, MAX_REFUND_RETRIES},
-    GroupReceiptAccounts, CALLBACK_SIGNER,
+    GroupReceiptAccounts, GroupReceiptPermissionAccounts, CALLBACK_SIGNER,
 };
 
 ///
@@ -37,6 +37,12 @@ use crate::processor::internal::{
 /// 11: []                   - Program : Magic program.
 /// 12: [writable]           - PDA     : Magic context account.
 ///
+/// Accounts (15-account shape — adds close of the group receipt's ACL permission):
+///
+///  0-12: same as above.
+/// 13: [writable]           - PDA     : Group receipt permission (derived from ["permission:", group_receipt]).
+/// 14: []                   - Program : Permission program (ACL).
+///
 /// Accounts (11-account shape, legacy — no refund on failure):
 ///
 ///  0-9: same as above.
@@ -46,15 +52,41 @@ use crate::processor::internal::{
 ///
 pub fn process_execute_transfer_callback(accounts: &[AccountView], instruction_data: &[u8]) -> ProgramResult {
     // TODO(edwin/snawaz): remove 11-account compat path after next deployment
-    let (callback_signer, group_receipt, queue_info, mint, source, magic_vault, magic_program, maybe_refund) =
-        if accounts.len() >= 13 {
-            let [cb, gr, qi, _vault, mint, _vault_ta, src, _src_ta, _tp, mv, mfv, mp, mc] =
-                require_n_accounts!(accounts, 13);
-            (cb, gr, qi, mint, src, mv, mp, Some((mfv, mc)))
-        } else {
-            let [cb, gr, qi, _vault, mint, _vault_ta, src, _src_ta, _tp, mv, mp] = require_n_accounts!(accounts, 11);
-            (cb, gr, qi, mint, src, mv, mp, None)
-        };
+    let (
+        callback_signer,
+        group_receipt,
+        queue_info,
+        mint,
+        source,
+        magic_vault,
+        magic_program,
+        maybe_refund,
+        permission,
+    ) = if accounts.len() >= 15 {
+        let [cb, gr, qi, _vault, mint, _vault_ta, src, _src_ta, _tp, mv, mfv, mp, mc, perm, perm_prog] =
+            require_n_accounts!(accounts, 15);
+        (
+            cb,
+            gr,
+            qi,
+            mint,
+            src,
+            mv,
+            mp,
+            Some((mfv, mc)),
+            Some(GroupReceiptPermissionAccounts {
+                permission_info: perm,
+                permission_program: perm_prog,
+            }),
+        )
+    } else if accounts.len() >= 13 {
+        let [cb, gr, qi, _vault, mint, _vault_ta, src, _src_ta, _tp, mv, mfv, mp, mc] =
+            require_n_accounts!(accounts, 13);
+        (cb, gr, qi, mint, src, mv, mp, Some((mfv, mc)), None)
+    } else {
+        let [cb, gr, qi, _vault, mint, _vault_ta, src, _src_ta, _tp, mv, mp] = require_n_accounts!(accounts, 11);
+        (cb, gr, qi, mint, src, mv, mp, None, None)
+    };
 
     // Verify validator & queue info
     let (header, _) = queue_views_checked(unsafe { queue_info.borrow_unchecked() })?;
@@ -70,6 +102,7 @@ pub fn process_execute_transfer_callback(accounts: &[AccountView], instruction_d
         source,
         magic_vault,
         magic_program,
+        permission,
         &args,
         &response,
     )?;
@@ -135,12 +168,13 @@ fn validate_common(
 /// 1. Receipt doesn't exist - create
 /// 2. Update receipt
 /// 3. Closes if this is the last transfer
-fn handle_group_receipt(
-    queue_info: &AccountView,
-    group_receipt_info: &AccountView,
-    source: &AccountView,
-    magic_vault: &AccountView,
-    magic_program: &AccountView,
+fn handle_group_receipt<'a>(
+    queue_info: &'a AccountView,
+    group_receipt_info: &'a AccountView,
+    source: &'a AccountView,
+    magic_vault: &'a AccountView,
+    magic_program: &'a AccountView,
+    permission: Option<GroupReceiptPermissionAccounts<'a>>,
     args: &TransferCallbackArgsView<'_>,
     response: &MagicResponseView,
 ) -> ProgramResult {
@@ -192,7 +226,8 @@ fn handle_group_receipt(
                 queue_info,
                 source,
                 magic_vault,
-                _magic_program: magic_program,
+                magic_program,
+                permission,
             },
             group_receipt,
         )

--- a/e-token/src/processor/internal/group_receipt_accounts.rs
+++ b/e-token/src/processor/internal/group_receipt_accounts.rs
@@ -1,7 +1,8 @@
 use ephemeral_rollups_pinocchio::acl::{
     consts::PERMISSION_PROGRAM_ID,
+    instruction::{CloseEphemeralPermission, CreateEphemeralPermission},
     pda::permission_pda_from_permissioned_account,
-    types::{Member, MemberFlags},
+    types::{EphemeralMembersArgs, Member, MemberFlags},
 };
 use ephemeral_spl_api::{
     require_eq_keys, require_ok,
@@ -12,9 +13,8 @@ use ephemeral_spl_api::{
     },
 };
 use pinocchio::{
-    cpi::{invoke_signed_with_bounds, Seed, Signer},
+    cpi::{Seed, Signer},
     error::ProgramError,
-    instruction::{InstructionAccount, InstructionView},
     AccountView, ProgramResult,
 };
 use solana_address::Address;
@@ -24,11 +24,7 @@ use super::{
     group_receipt::GROUP_RECEIPT_SEED,
 };
 
-/// ACL discriminator for `CreateEphemeralPermission` (not in ephemeral-rollups-pinocchio 0.10.x).
-const CREATE_EPHEMERAL_PERMISSION_DISCRIMINATOR: u64 = 6;
-
-/// ACL discriminator for `CloseEphemeralPermission` (not in ephemeral-rollups-pinocchio 0.10.x).
-const CLOSE_EPHEMERAL_PERMISSION_DISCRIMINATOR: u64 = 8;
+const CREATE_GROUP_RECEIPT_PERMISSION_IX_DATA_LEN: usize = 8 + 1 + 33;
 
 /// Accounts for the ephemeral ACL permission that keeps a `GroupReceipt` readable
 /// only by its source while settlement signatures accumulate in it.
@@ -189,35 +185,22 @@ fn create_group_receipt_permission(
         return Ok(());
     }
 
-    // [disc u64][is_private u8][member: flags u8 + pubkey 32]
-    let mut data = [0u8; 42];
-    data[..8].copy_from_slice(&CREATE_EPHEMERAL_PERMISSION_DISCRIMINATOR.to_le_bytes());
-    data[8] = 1; // is_private
     let member = source_member(accounts.source.address());
-    data[9] = member.flags.as_u8();
-    data[10..42].copy_from_slice(member.pubkey.as_ref());
+    let members = [member];
 
-    invoke_signed_with_bounds::<5>(
-        &InstructionView {
-            program_id: &PERMISSION_PROGRAM_ID,
-            accounts: &[
-                InstructionAccount::writable_signer(accounts.queue_info.address()),
-                InstructionAccount::readonly_signer(accounts.group_receipt_info.address()),
-                InstructionAccount::writable(permission.permission_info.address()),
-                InstructionAccount::writable(accounts.magic_vault.address()),
-                InstructionAccount::readonly(accounts.magic_program.address()),
-            ],
-            data: &data,
+    CreateEphemeralPermission {
+        permissioned_account: accounts.group_receipt_info,
+        permission: permission.permission_info,
+        payer: accounts.queue_info,
+        vault: accounts.magic_vault,
+        magic_program: accounts.magic_program,
+        permission_program: permission.permission_program,
+        args: EphemeralMembersArgs {
+            is_private: true,
+            members: &members,
         },
-        &[
-            accounts.queue_info,
-            accounts.group_receipt_info,
-            permission.permission_info,
-            accounts.magic_vault,
-            accounts.magic_program,
-        ],
-        signers,
-    )
+    }
+    .invoke_signed::<CREATE_GROUP_RECEIPT_PERMISSION_IX_DATA_LEN>(signers)
 }
 
 /// Closes the group receipt's ephemeral ACL permission, refunding rent to the
@@ -240,29 +223,17 @@ fn close_group_receipt_permission(
         return Ok(());
     }
 
-    invoke_signed_with_bounds::<6>(
-        &InstructionView {
-            program_id: &PERMISSION_PROGRAM_ID,
-            accounts: &[
-                InstructionAccount::writable_signer(accounts.queue_info.address()),
-                InstructionAccount::readonly(accounts.queue_info.address()),
-                InstructionAccount::readonly_signer(accounts.group_receipt_info.address()),
-                InstructionAccount::writable(permission.permission_info.address()),
-                InstructionAccount::writable(accounts.magic_vault.address()),
-                InstructionAccount::readonly(accounts.magic_program.address()),
-            ],
-            data: &CLOSE_EPHEMERAL_PERMISSION_DISCRIMINATOR.to_le_bytes(),
-        },
-        &[
-            accounts.queue_info,
-            accounts.queue_info,
-            accounts.group_receipt_info,
-            permission.permission_info,
-            accounts.magic_vault,
-            accounts.magic_program,
-        ],
-        signers,
-    )
+    CloseEphemeralPermission {
+        permissioned_account: accounts.group_receipt_info,
+        permission: permission.permission_info,
+        payer: accounts.queue_info,
+        authority: accounts.queue_info,
+        vault: accounts.magic_vault,
+        magic_program: accounts.magic_program,
+        permission_program: permission.permission_program,
+        authority_is_signer: false,
+    }
+    .invoke_signed(signers)
 }
 
 /// Read-only membership for the source: transaction logs, balances, message,

--- a/e-token/src/processor/internal/group_receipt_accounts.rs
+++ b/e-token/src/processor/internal/group_receipt_accounts.rs
@@ -218,6 +218,13 @@ fn close_group_receipt_permission(
         ProgramError::IncorrectProgramId
     );
 
+    let expected_permission = permission_pda_from_permissioned_account(accounts.group_receipt_info.address());
+    require_eq_keys!(
+        &expected_permission,
+        permission.permission_info.address(),
+        ProgramError::InvalidSeeds
+    );
+
     // Ephemeral accounts hold zero lamports on the ER; existence is data_len.
     if permission.permission_info.data_len() == 0 {
         return Ok(());

--- a/e-token/src/processor/internal/group_receipt_accounts.rs
+++ b/e-token/src/processor/internal/group_receipt_accounts.rs
@@ -1,5 +1,10 @@
+use ephemeral_rollups_pinocchio::acl::{
+    consts::PERMISSION_PROGRAM_ID,
+    pda::permission_pda_from_permissioned_account,
+    types::{Member, MemberFlags},
+};
 use ephemeral_spl_api::{
-    require_ok,
+    require_eq_keys, require_ok,
     state::{
         group_receipt,
         group_receipt::GroupReceipt,
@@ -7,15 +12,30 @@ use ephemeral_spl_api::{
     },
 };
 use pinocchio::{
-    cpi::{Seed, Signer},
+    cpi::{invoke_signed_with_bounds, Seed, Signer},
     error::ProgramError,
+    instruction::{InstructionAccount, InstructionView},
     AccountView, ProgramResult,
 };
+use solana_address::Address;
 
 use super::{
     ephemeral_account::{close_ephemeral_account, create_ephemeral_account},
     group_receipt::GROUP_RECEIPT_SEED,
 };
+
+/// ACL discriminator for `CreateEphemeralPermission` (not in ephemeral-rollups-pinocchio 0.10.x).
+const CREATE_EPHEMERAL_PERMISSION_DISCRIMINATOR: u64 = 6;
+
+/// ACL discriminator for `CloseEphemeralPermission` (not in ephemeral-rollups-pinocchio 0.10.x).
+const CLOSE_EPHEMERAL_PERMISSION_DISCRIMINATOR: u64 = 8;
+
+/// Accounts for the ephemeral ACL permission that keeps a `GroupReceipt` readable
+/// only by its source while settlement signatures accumulate in it.
+pub(crate) struct GroupReceiptPermissionAccounts<'a> {
+    pub(crate) permission_info: &'a AccountView,
+    pub(crate) permission_program: &'a AccountView,
+}
 
 /// Required accounts for control over receipt
 pub(crate) struct GroupReceiptAccounts<'a> {
@@ -23,11 +43,18 @@ pub(crate) struct GroupReceiptAccounts<'a> {
     pub(crate) queue_info: &'a AccountView,
     pub(crate) source: &'a AccountView,
     pub(crate) magic_vault: &'a AccountView,
-    pub(crate) _magic_program: &'a AccountView,
+    pub(crate) magic_program: &'a AccountView,
+    /// Present on the extended account shapes; `None` preserves the legacy
+    /// behavior of a receipt without an ACL permission.
+    pub(crate) permission: Option<GroupReceiptPermissionAccounts<'a>>,
 }
 
 /// Creates `GroupReceipt` and initializes it.
 /// Use this when the receipt account does not yet exist.
+///
+/// When permission accounts are provided, also creates a private ephemeral ACL
+/// permission on the receipt (member: source) so the settlement signatures it
+/// accumulates are not readable by third parties through the private RPC.
 pub(crate) fn group_receipt_create<'a>(
     accounts: &GroupReceiptAccounts<'a>,
     group_receipt_bump: u8,
@@ -72,14 +99,28 @@ pub(crate) fn group_receipt_create<'a>(
         group_receipt_bump,
     ));
 
+    if let Some(permission) = &accounts.permission {
+        let queue_signer = Signer::from(&queue_signer_seeds);
+        let receipt_signer = Signer::from(&receipt_signer_seeds);
+        require_ok!(create_group_receipt_permission(
+            accounts,
+            permission,
+            &[queue_signer, receipt_signer],
+        ));
+    }
+
     GroupReceipt::new(accounts.group_receipt_info)
 }
 
 /// Closes the group receipt account, refunding rent to the queue PDA.
 /// Consumes the receipt since the account is no longer valid after closing.
+///
+/// When permission accounts are provided, first closes the receipt's ephemeral
+/// ACL permission (rent refunds to the queue). Skipped for receipts created by
+/// the legacy account shape, which have no permission.
 pub(crate) fn group_receipt_close(
     accounts: &GroupReceiptAccounts<'_>,
-    _group_receipt: GroupReceipt<'_>,
+    group_receipt: GroupReceipt<'_>,
 ) -> ProgramResult {
     let (header, _) = queue_views_checked(unsafe { accounts.queue_info.borrow_unchecked() })?;
     let queue_bump_seed = [header.bump];
@@ -89,6 +130,26 @@ pub(crate) fn group_receipt_close(
         Seed::from(header.validator.as_ref()),
         Seed::from(&queue_bump_seed),
     ];
+
+    if let Some(permission) = &accounts.permission {
+        let group_id_bytes = group_receipt.id().to_le_bytes();
+        let receipt_bump_seed = [group_receipt.bump()];
+        let receipt_signer_seeds = [
+            Seed::from(GROUP_RECEIPT_SEED),
+            Seed::from(accounts.queue_info.address().as_ref()),
+            Seed::from(accounts.source.address().as_ref()),
+            Seed::from(group_id_bytes.as_ref()),
+            Seed::from(&receipt_bump_seed),
+        ];
+        let queue_signer = Signer::from(&queue_signer_seeds);
+        let receipt_signer = Signer::from(&receipt_signer_seeds);
+        require_ok!(close_group_receipt_permission(
+            accounts,
+            permission,
+            &[queue_signer, receipt_signer],
+        ));
+    }
+
     let queue_signer = Signer::from(&queue_signer_seeds);
     close_ephemeral_account(
         accounts.queue_info,
@@ -96,6 +157,124 @@ pub(crate) fn group_receipt_close(
         accounts.magic_vault,
         &[queue_signer],
     )
+}
+
+/// Creates a private ephemeral ACL permission on the group receipt, restricting
+/// reads to the source. Rent is sponsored by the queue PDA (debited to the magic
+/// vault, refunded on close).
+///
+/// Idempotent: a pre-existing permission is left untouched. This is safe because
+/// the permission PDA derives from the receipt address, which bakes in the same
+/// source; a stale permission from a missed close still grants only the source.
+fn create_group_receipt_permission(
+    accounts: &GroupReceiptAccounts<'_>,
+    permission: &GroupReceiptPermissionAccounts<'_>,
+    signers: &[Signer<'_, '_>],
+) -> ProgramResult {
+    require_eq_keys!(
+        &PERMISSION_PROGRAM_ID,
+        permission.permission_program.address(),
+        ProgramError::IncorrectProgramId
+    );
+
+    let expected_permission = permission_pda_from_permissioned_account(accounts.group_receipt_info.address());
+    require_eq_keys!(
+        &expected_permission,
+        permission.permission_info.address(),
+        ProgramError::InvalidSeeds
+    );
+
+    // Ephemeral accounts hold zero lamports on the ER; existence is data_len.
+    if permission.permission_info.data_len() != 0 {
+        return Ok(());
+    }
+
+    // [disc u64][is_private u8][member: flags u8 + pubkey 32]
+    let mut data = [0u8; 42];
+    data[..8].copy_from_slice(&CREATE_EPHEMERAL_PERMISSION_DISCRIMINATOR.to_le_bytes());
+    data[8] = 1; // is_private
+    let member = source_member(accounts.source.address());
+    data[9] = member.flags.as_u8();
+    data[10..42].copy_from_slice(member.pubkey.as_ref());
+
+    invoke_signed_with_bounds::<5>(
+        &InstructionView {
+            program_id: &PERMISSION_PROGRAM_ID,
+            accounts: &[
+                InstructionAccount::writable_signer(accounts.queue_info.address()),
+                InstructionAccount::readonly_signer(accounts.group_receipt_info.address()),
+                InstructionAccount::writable(permission.permission_info.address()),
+                InstructionAccount::writable(accounts.magic_vault.address()),
+                InstructionAccount::readonly(accounts.magic_program.address()),
+            ],
+            data: &data,
+        },
+        &[
+            accounts.queue_info,
+            accounts.group_receipt_info,
+            permission.permission_info,
+            accounts.magic_vault,
+            accounts.magic_program,
+        ],
+        signers,
+    )
+}
+
+/// Closes the group receipt's ephemeral ACL permission, refunding rent to the
+/// queue PDA. The receipt PDA authorizes the close by signing as the
+/// permissioned account. No-op when the permission does not exist (receipts
+/// created by the legacy account shape).
+fn close_group_receipt_permission(
+    accounts: &GroupReceiptAccounts<'_>,
+    permission: &GroupReceiptPermissionAccounts<'_>,
+    signers: &[Signer<'_, '_>],
+) -> ProgramResult {
+    require_eq_keys!(
+        &PERMISSION_PROGRAM_ID,
+        permission.permission_program.address(),
+        ProgramError::IncorrectProgramId
+    );
+
+    // Ephemeral accounts hold zero lamports on the ER; existence is data_len.
+    if permission.permission_info.data_len() == 0 {
+        return Ok(());
+    }
+
+    invoke_signed_with_bounds::<6>(
+        &InstructionView {
+            program_id: &PERMISSION_PROGRAM_ID,
+            accounts: &[
+                InstructionAccount::writable_signer(accounts.queue_info.address()),
+                InstructionAccount::readonly(accounts.queue_info.address()),
+                InstructionAccount::readonly_signer(accounts.group_receipt_info.address()),
+                InstructionAccount::writable(permission.permission_info.address()),
+                InstructionAccount::writable(accounts.magic_vault.address()),
+                InstructionAccount::readonly(accounts.magic_program.address()),
+            ],
+            data: &CLOSE_EPHEMERAL_PERMISSION_DISCRIMINATOR.to_le_bytes(),
+        },
+        &[
+            accounts.queue_info,
+            accounts.queue_info,
+            accounts.group_receipt_info,
+            permission.permission_info,
+            accounts.magic_vault,
+            accounts.magic_program,
+        ],
+        signers,
+    )
+}
+
+/// Read-only membership for the source: transaction logs, balances, message,
+/// and account signatures — but not `AUTHORITY`, so the permission lifecycle
+/// stays program-managed for the receipt's whole lifetime.
+fn source_member(source: &Address) -> Member {
+    let mut flags = MemberFlags::new();
+    flags.set(MemberFlags::TX_LOGS);
+    flags.set(MemberFlags::TX_BALANCES);
+    flags.set(MemberFlags::TX_MESSAGE);
+    flags.set(MemberFlags::ACCOUNT_SIGNATURES);
+    Member { flags, pubkey: *source }
 }
 
 #[cfg(feature = "logging")]

--- a/e-token/src/processor/internal/mod.rs
+++ b/e-token/src/processor/internal/mod.rs
@@ -18,7 +18,9 @@ pub(crate) mod unwrap_pda;
 pub(crate) use ephemeral_account::MAGIC_VAULT_ID;
 #[cfg(feature = "logging")]
 pub(crate) use group_receipt_accounts::group_receipt_log;
-pub(crate) use group_receipt_accounts::{group_receipt_close, group_receipt_create, GroupReceiptAccounts};
+pub(crate) use group_receipt_accounts::{
+    group_receipt_close, group_receipt_create, GroupReceiptAccounts, GroupReceiptPermissionAccounts,
+};
 pub(crate) use pda::CALLBACK_SIGNER;
 use pinocchio::error::ProgramError;
 use solana_address::Address;

--- a/e-token/src/processor/internal/private_transfer.rs
+++ b/e-token/src/processor/internal/private_transfer.rs
@@ -8,7 +8,10 @@ use dlp_api::{
     },
     compact::{self, ClearTextWithInsertable},
 };
-use ephemeral_rollups_pinocchio::consts::MAGIC_PROGRAM_ID;
+use ephemeral_rollups_pinocchio::{
+    acl::{consts::PERMISSION_PROGRAM_ID, pda::permission_pda_from_permissioned_account},
+    consts::MAGIC_PROGRAM_ID,
+};
 use ephemeral_spl_api::{
     consts, debug_log,
     instruction::ESplInstruction,
@@ -213,6 +216,9 @@ fn private_transfer_action_encrypted(
     let group_id = u32::from(group_id_raw[0]) | (u32::from(group_id_raw[1]) << 8) | (u32::from(group_id_raw[2]) << 16);
     let group_receipt_info =
         derive_group_receipt_id(queue_info.address(), common_accounts.owner_info.address(), group_id).0;
+    // Cleartext is fine: the permission PDA derives from the receipt address,
+    // which is already cleartext below, and reveals nothing further.
+    let group_receipt_permission = permission_pda_from_permissioned_account(&group_receipt_info);
     Ok(PostDelegationActions {
         inserted_signers: 0,
         inserted_non_signers: 0,
@@ -230,6 +236,8 @@ fn private_transfer_action_encrypted(
             MaybeEncryptedPubkey::ClearText(group_receipt_info.to_bytes()),
             MaybeEncryptedPubkey::ClearText(MAGIC_VAULT_ID.to_bytes()),
             MaybeEncryptedPubkey::ClearText(MAGIC_PROGRAM_ID.to_bytes()),
+            MaybeEncryptedPubkey::ClearText(group_receipt_permission.to_bytes()),
+            MaybeEncryptedPubkey::ClearText(PERMISSION_PROGRAM_ID.to_bytes()),
         ],
         instructions: alloc::vec![MaybeEncryptedInstruction {
             program_id: 1,
@@ -246,6 +254,8 @@ fn private_transfer_action_encrypted(
                 MaybeEncryptedAccountMeta::ClearText(compact::AccountMeta::new(10, false)),
                 MaybeEncryptedAccountMeta::ClearText(compact::AccountMeta::new(11, false)),
                 MaybeEncryptedAccountMeta::ClearText(compact::AccountMeta::new_readonly(12, false)),
+                MaybeEncryptedAccountMeta::ClearText(compact::AccountMeta::new(13, false)),
+                MaybeEncryptedAccountMeta::ClearText(compact::AccountMeta::new_readonly(14, false)),
             ],
             data: MaybeEncryptedIxData {
                 prefix: ESplInstruction::DepositAndQueueTransfer

--- a/e-token/src/processor/internal/queue_authorized_action.rs
+++ b/e-token/src/processor/internal/queue_authorized_action.rs
@@ -23,7 +23,7 @@ use crate::processor::{
     },
 };
 
-const MAGIC_INTENT_BUNDLE_DATA_LEN: usize = 512;
+const MAGIC_INTENT_BUNDLE_DATA_LEN: usize = 640;
 pub(crate) const EXECUTE_READY_QUEUED_TRANSFER_ESCROW_INDEX: u8 = 0;
 
 pub(crate) struct IntentBundleAccounts<'a> {

--- a/e-token/src/processor/transfer_queue_tick.rs
+++ b/e-token/src/processor/transfer_queue_tick.rs
@@ -2,6 +2,7 @@
 use alloc::string::ToString;
 
 use ephemeral_rollups_pinocchio::{
+    acl::{consts::PERMISSION_PROGRAM_ID, pda::permission_pda_from_permissioned_account},
     consts::{MAGIC_CONTEXT_ID, MAGIC_PROGRAM_ID},
     intent_bundle::{ActionArgs, ActionCallback, CallHandler, ShortAccountMeta},
 };
@@ -320,11 +321,12 @@ fn create_action_callback_accounts(
     vault: &Address,
     mint: &Address,
     token_program: &Address,
-) -> [ShortAccountMeta; 13] {
+) -> [ShortAccountMeta; 15] {
     let vault_token_account = get_associated_token_address(vault, mint, token_program);
     let source_token_account = get_associated_token_address(&queued_transfer.source, mint, token_program);
     let (group_receipt_account, _) =
         derive_group_receipt_id(queue_address, &queued_transfer.source, queued_transfer.group_id());
+    let group_receipt_permission = permission_pda_from_permissioned_account(&group_receipt_account);
     [
         ShortAccountMeta {
             pubkey: CALLBACK_SIGNER,
@@ -378,11 +380,19 @@ fn create_action_callback_accounts(
             pubkey: MAGIC_CONTEXT_ID,
             is_writable: true,
         },
+        ShortAccountMeta {
+            pubkey: group_receipt_permission,
+            is_writable: true,
+        },
+        ShortAccountMeta {
+            pubkey: PERMISSION_PROGRAM_ID,
+            is_writable: false,
+        },
     ]
 }
 
 fn create_action_callback<'a>(accounts: &'a [ShortAccountMeta], payload: &'a [u8]) -> ActionCallback<'a> {
-    const CALLBACK_COMPUTE_UNITS: u32 = 100_000;
+    const CALLBACK_COMPUTE_UNITS: u32 = 120_000;
 
     ActionCallback {
         destination_program: crate::ID,

--- a/e-token/tests/common/acl_mock.rs
+++ b/e-token/tests/common/acl_mock.rs
@@ -1,0 +1,150 @@
+//! Native mock for the ACL permission program.
+//!
+//! The `acl.so` fixture predates ephemeral permissions, and the real ephemeral
+//! flow allocates the permission account through the magic program builtin,
+//! which `magic_mock` stubs as a no-op anyway. This mock validates account
+//! metas, captures invocations for assertions, and succeeds — mirroring the
+//! `magic_mock` capture style.
+
+#![allow(dead_code)]
+
+use std::sync::{Mutex, OnceLock};
+
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError};
+use solana_program_test::ProgramTest;
+use solana_pubkey::Pubkey;
+
+const CREATE_PERMISSION_DISCRIMINATOR: u64 = 0;
+const CREATE_EPHEMERAL_PERMISSION_DISCRIMINATOR: u64 = 6;
+const CLOSE_EPHEMERAL_PERMISSION_DISCRIMINATOR: u64 = 8;
+
+const MEMBER_SIZE: usize = 33; // flags(1) + pubkey(32)
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CapturedMember {
+    pub flags: u8,
+    pub pubkey: Pubkey,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CapturedCreateEphemeralPermission {
+    pub payer: Pubkey,
+    pub permissioned_account: Pubkey,
+    pub permission: Pubkey,
+    pub is_private: bool,
+    pub members: Vec<CapturedMember>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CapturedCloseEphemeralPermission {
+    pub payer: Pubkey,
+    pub permissioned_account: Pubkey,
+    pub permission: Pubkey,
+}
+
+fn captured_ephemeral_permission_creates() -> &'static Mutex<Vec<CapturedCreateEphemeralPermission>> {
+    static S: OnceLock<Mutex<Vec<CapturedCreateEphemeralPermission>>> = OnceLock::new();
+    S.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+fn captured_ephemeral_permission_closes() -> &'static Mutex<Vec<CapturedCloseEphemeralPermission>> {
+    static S: OnceLock<Mutex<Vec<CapturedCloseEphemeralPermission>>> = OnceLock::new();
+    S.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+pub fn take_captured_ephemeral_permission_creates() -> Vec<CapturedCreateEphemeralPermission> {
+    std::mem::take(&mut *captured_ephemeral_permission_creates().lock().unwrap())
+}
+
+pub fn take_captured_ephemeral_permission_closes() -> Vec<CapturedCloseEphemeralPermission> {
+    std::mem::take(&mut *captured_ephemeral_permission_closes().lock().unwrap())
+}
+
+pub fn clear_all_captured() {
+    take_captured_ephemeral_permission_creates();
+    take_captured_ephemeral_permission_closes();
+}
+
+pub fn process(_program_id: &Pubkey, accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
+    let discriminator_bytes: [u8; 8] = instruction_data
+        .get(..8)
+        .and_then(|b| b.try_into().ok())
+        .ok_or(ProgramError::InvalidInstructionData)?;
+
+    match u64::from_le_bytes(discriminator_bytes) {
+        // Fixture setup (queue / stealth pool init) creates base permissions;
+        // nothing on-chain reads them back, so success is enough here.
+        CREATE_PERMISSION_DISCRIMINATOR => Ok(()),
+        CREATE_EPHEMERAL_PERMISSION_DISCRIMINATOR => {
+            let [payer, permissioned_account, permission, _vault, _magic_program, ..] = accounts else {
+                return Err(ProgramError::NotEnoughAccountKeys);
+            };
+            if !payer.is_signer || !payer.is_writable {
+                return Err(ProgramError::MissingRequiredSignature);
+            }
+            if !permissioned_account.is_signer {
+                return Err(ProgramError::MissingRequiredSignature);
+            }
+            if !permission.is_writable {
+                return Err(ProgramError::InvalidAccountData);
+            }
+
+            let args = &instruction_data[8..];
+            let (&is_private, members_data) = args.split_first().ok_or(ProgramError::InvalidInstructionData)?;
+            if members_data.len() % MEMBER_SIZE != 0 {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+            let members = members_data
+                .chunks_exact(MEMBER_SIZE)
+                .map(|chunk| CapturedMember {
+                    flags: chunk[0],
+                    pubkey: Pubkey::new_from_array(chunk[1..].try_into().unwrap()),
+                })
+                .collect();
+
+            captured_ephemeral_permission_creates()
+                .lock()
+                .unwrap()
+                .push(CapturedCreateEphemeralPermission {
+                    payer: *payer.key,
+                    permissioned_account: *permissioned_account.key,
+                    permission: *permission.key,
+                    is_private: is_private != 0,
+                    members,
+                });
+            Ok(())
+        }
+        CLOSE_EPHEMERAL_PERMISSION_DISCRIMINATOR => {
+            let [payer, _authority, permissioned_account, permission, _vault, _magic_program, ..] = accounts else {
+                return Err(ProgramError::NotEnoughAccountKeys);
+            };
+            if !payer.is_signer || !payer.is_writable {
+                return Err(ProgramError::MissingRequiredSignature);
+            }
+            if !permissioned_account.is_signer {
+                return Err(ProgramError::MissingRequiredSignature);
+            }
+            if !permission.is_writable {
+                return Err(ProgramError::InvalidAccountData);
+            }
+
+            captured_ephemeral_permission_closes()
+                .lock()
+                .unwrap()
+                .push(CapturedCloseEphemeralPermission {
+                    payer: *payer.key,
+                    permissioned_account: *permissioned_account.key,
+                    permission: *permission.key,
+                });
+            Ok(())
+        }
+        _ => Err(ProgramError::InvalidInstructionData),
+    }
+}
+
+pub fn add_mock(pt: &mut ProgramTest) {
+    use solana_program_test::processor;
+    pt.prefer_bpf(false);
+    pt.add_program("acl_mock", crate::utils::permission_program_id(), processor!(process));
+    pt.prefer_bpf(true);
+}

--- a/e-token/tests/common/mod.rs
+++ b/e-token/tests/common/mod.rs
@@ -1,3 +1,4 @@
+pub mod acl_mock;
 pub mod callback_mock;
 pub mod magic_mock;
 pub mod metrics;

--- a/e-token/tests/deposit_and_queue_transfer.rs
+++ b/e-token/tests/deposit_and_queue_transfer.rs
@@ -72,7 +72,9 @@ async fn setup_fixture_with_acl_mock(items: Option<u32>) -> Fixture {
 
 async fn setup_fixture_inner(items: Option<u32>, acl_mock: bool) -> Fixture {
     common::magic_mock::take_captured_ephemeral_creates(MAGIC_PROGRAM);
-    common::acl_mock::clear_all_captured();
+    if acl_mock {
+        common::acl_mock::clear_all_captured();
+    }
 
     let mut context = utils::start_program_test_with_acl_and(PROGRAM, !acl_mock, |pt| {
         pt.prefer_bpf(false);

--- a/e-token/tests/deposit_and_queue_transfer.rs
+++ b/e-token/tests/deposit_and_queue_transfer.rs
@@ -233,15 +233,6 @@ fn build_deposit_and_queue_ix_for_destination(
     }
 }
 
-/// Derives the ACL permission PDA guarding the given group receipt.
-fn derive_group_receipt_permission(group_receipt: Pubkey) -> Pubkey {
-    Pubkey::find_program_address(
-        &[b"permission:", group_receipt.as_ref()],
-        &utils::permission_program_id(),
-    )
-    .0
-}
-
 /// Extends a 12-account deposit instruction to the 14-account shape that also
 /// creates the group receipt's ACL permission.
 fn with_receipt_permission(mut ix: Instruction, permission: Pubkey) -> Instruction {
@@ -1140,23 +1131,6 @@ async fn deposit_and_queue_transfer_can_split_stealth_pool_across_keys() {
 
 // ── group receipt permission ──────────────────────────────────────────────────
 
-/// Injects a non-empty ACL-owned permission account, as left behind by a
-/// missed close (ephemeral accounts are existence-checked by data length).
-fn pre_create_receipt_permission(context: &mut ProgramTestContext, permission: Pubkey) {
-    let data = vec![1u8; 71];
-    context.set_account(
-        &permission,
-        &solana_account::Account {
-            lamports: solana_program::rent::Rent::default().minimum_balance(data.len()),
-            data,
-            owner: utils::permission_program_id(),
-            executable: false,
-            rent_epoch: 0,
-        }
-        .into(),
-    );
-}
-
 /// 14-account shape: the deposit creates a private ephemeral ACL permission on
 /// the group receipt, sponsored by the queue, with the source as sole member.
 #[tokio::test]
@@ -1166,7 +1140,7 @@ async fn deposit_and_queue_transfer_creates_receipt_permission() {
     let group_id: u32 = 1;
     let split: u32 = 2;
     let group_receipt = pre_create_group_receipt(&mut fixture.context, fixture.queue, fixture.payer, group_id, split);
-    let permission = derive_group_receipt_permission(group_receipt);
+    let permission = utils::derive_group_receipt_permission(group_receipt);
 
     let ix = with_receipt_permission(
         build_deposit_and_queue_ix(&fixture, 10, 0, 0, split, group_id, group_receipt),
@@ -1204,8 +1178,8 @@ async fn deposit_and_queue_transfer_skips_existing_receipt_permission() {
     let group_id: u32 = 1;
     let split: u32 = 2;
     let group_receipt = pre_create_group_receipt(&mut fixture.context, fixture.queue, fixture.payer, group_id, split);
-    let permission = derive_group_receipt_permission(group_receipt);
-    pre_create_receipt_permission(&mut fixture.context, permission);
+    let permission = utils::derive_group_receipt_permission(group_receipt);
+    utils::pre_create_receipt_permission(&mut fixture.context, permission);
 
     let ix = with_receipt_permission(
         build_deposit_and_queue_ix(&fixture, 10, 0, 0, split, group_id, group_receipt),
@@ -1229,7 +1203,7 @@ async fn deposit_and_queue_transfer_rejects_wrong_receipt_permission() {
     let split: u32 = 2;
     let group_receipt = pre_create_group_receipt(&mut fixture.context, fixture.queue, fixture.payer, group_id, split);
     // Valid ACL PDA, but for the wrong permissioned account.
-    let wrong_permission = derive_group_receipt_permission(fixture.queue);
+    let wrong_permission = utils::derive_group_receipt_permission(fixture.queue);
 
     let ix = with_receipt_permission(
         build_deposit_and_queue_ix(&fixture, 10, 0, 0, split, group_id, group_receipt),
@@ -1257,7 +1231,7 @@ async fn deposit_and_queue_transfer_rejects_partial_permission_pair() {
     let group_id: u32 = 1;
     let split: u32 = 2;
     let group_receipt = pre_create_group_receipt(&mut fixture.context, fixture.queue, fixture.payer, group_id, split);
-    let permission = derive_group_receipt_permission(group_receipt);
+    let permission = utils::derive_group_receipt_permission(group_receipt);
 
     let mut ix = build_deposit_and_queue_ix(&fixture, 10, 0, 0, split, group_id, group_receipt);
     ix.accounts.push(AccountMeta::new(permission, false)); // 12: permission PDA without the program

--- a/e-token/tests/deposit_and_queue_transfer.rs
+++ b/e-token/tests/deposit_and_queue_transfer.rs
@@ -60,12 +60,27 @@ fn read_item_unaligned(data: &[u8], index: usize) -> QueuedTransfer {
 }
 
 async fn setup_fixture(items: Option<u32>) -> Fixture {
-    common::magic_mock::take_captured_ephemeral_creates(MAGIC_PROGRAM);
+    setup_fixture_inner(items, false).await
+}
 
-    let mut context = utils::start_program_test_with(PROGRAM, |pt| {
+/// Variant that replaces the `acl.so` fixture with the capture-style ACL mock,
+/// needed by tests exercising the group receipt permission (the fixture binary
+/// predates ephemeral permissions).
+async fn setup_fixture_with_acl_mock(items: Option<u32>) -> Fixture {
+    setup_fixture_inner(items, true).await
+}
+
+async fn setup_fixture_inner(items: Option<u32>, acl_mock: bool) -> Fixture {
+    common::magic_mock::take_captured_ephemeral_creates(MAGIC_PROGRAM);
+    common::acl_mock::clear_all_captured();
+
+    let mut context = utils::start_program_test_with_acl_and(PROGRAM, !acl_mock, |pt| {
         pt.prefer_bpf(false);
         pt.add_program("magic_mock", MAGIC_PROGRAM, processor!(common::magic_mock::process));
         pt.prefer_bpf(true);
+        if acl_mock {
+            common::acl_mock::add_mock(pt);
+        }
     })
     .await;
 
@@ -214,6 +229,24 @@ fn build_deposit_and_queue_ix_for_destination(
         ],
         data,
     }
+}
+
+/// Derives the ACL permission PDA guarding the given group receipt.
+fn derive_group_receipt_permission(group_receipt: Pubkey) -> Pubkey {
+    Pubkey::find_program_address(
+        &[b"permission:", group_receipt.as_ref()],
+        &utils::permission_program_id(),
+    )
+    .0
+}
+
+/// Extends a 12-account deposit instruction to the 14-account shape that also
+/// creates the group receipt's ACL permission.
+fn with_receipt_permission(mut ix: Instruction, permission: Pubkey) -> Instruction {
+    ix.accounts.push(AccountMeta::new(permission, false)); // 12: group_receipt_permission
+    ix.accounts
+        .push(AccountMeta::new_readonly(utils::permission_program_id(), false)); // 13: permission_program
+    ix
 }
 
 fn build_update_stealth_pool_ix(
@@ -1101,4 +1134,138 @@ async fn deposit_and_queue_transfer_can_split_stealth_pool_across_keys() {
     actual.sort_unstable();
     expected.sort_unstable();
     assert_eq!(actual, expected);
+}
+
+// ── group receipt permission ──────────────────────────────────────────────────
+
+/// Injects a non-empty ACL-owned permission account, as left behind by a
+/// missed close (ephemeral accounts are existence-checked by data length).
+fn pre_create_receipt_permission(context: &mut ProgramTestContext, permission: Pubkey) {
+    let data = vec![1u8; 71];
+    context.set_account(
+        &permission,
+        &solana_account::Account {
+            lamports: solana_program::rent::Rent::default().minimum_balance(data.len()),
+            data,
+            owner: utils::permission_program_id(),
+            executable: false,
+            rent_epoch: 0,
+        }
+        .into(),
+    );
+}
+
+/// 14-account shape: the deposit creates a private ephemeral ACL permission on
+/// the group receipt, sponsored by the queue, with the source as sole member.
+#[tokio::test]
+#[serial]
+async fn deposit_and_queue_transfer_creates_receipt_permission() {
+    let mut fixture = setup_fixture_with_acl_mock(None).await;
+    let group_id: u32 = 1;
+    let split: u32 = 2;
+    let group_receipt = pre_create_group_receipt(&mut fixture.context, fixture.queue, fixture.payer, group_id, split);
+    let permission = derive_group_receipt_permission(group_receipt);
+
+    let ix = with_receipt_permission(
+        build_deposit_and_queue_ix(&fixture, 10, 0, 0, split, group_id, group_receipt),
+        permission,
+    );
+    let blockhash = fixture.context.banks_client.get_latest_blockhash().await.unwrap();
+    let tx = Transaction::new_signed_with_payer(&[ix], Some(&fixture.payer), &[&fixture.payer_kp], blockhash);
+    fixture.context.banks_client.process_transaction(tx).await.unwrap();
+
+    let creates = common::acl_mock::take_captured_ephemeral_permission_creates();
+    assert_eq!(creates.len(), 1, "expected exactly one CreateEphemeralPermission CPI");
+    let create = &creates[0];
+    assert_eq!(create.payer, fixture.queue, "queue must sponsor the permission");
+    assert_eq!(create.permissioned_account, group_receipt);
+    assert_eq!(create.permission, permission);
+    assert!(create.is_private);
+    assert_eq!(
+        create.members,
+        vec![common::acl_mock::CapturedMember {
+            // TX_LOGS | TX_BALANCES | TX_MESSAGE | ACCOUNT_SIGNATURES, no AUTHORITY
+            flags: 0b1_1110,
+            pubkey: fixture.payer,
+        }],
+        "source must be the sole read-only member"
+    );
+}
+
+/// A pre-existing permission (stale from a missed close) is reused, not
+/// recreated: its PDA derives from the receipt address, which bakes in the
+/// same source.
+#[tokio::test]
+#[serial]
+async fn deposit_and_queue_transfer_skips_existing_receipt_permission() {
+    let mut fixture = setup_fixture_with_acl_mock(None).await;
+    let group_id: u32 = 1;
+    let split: u32 = 2;
+    let group_receipt = pre_create_group_receipt(&mut fixture.context, fixture.queue, fixture.payer, group_id, split);
+    let permission = derive_group_receipt_permission(group_receipt);
+    pre_create_receipt_permission(&mut fixture.context, permission);
+
+    let ix = with_receipt_permission(
+        build_deposit_and_queue_ix(&fixture, 10, 0, 0, split, group_id, group_receipt),
+        permission,
+    );
+    let blockhash = fixture.context.banks_client.get_latest_blockhash().await.unwrap();
+    let tx = Transaction::new_signed_with_payer(&[ix], Some(&fixture.payer), &[&fixture.payer_kp], blockhash);
+    fixture.context.banks_client.process_transaction(tx).await.unwrap();
+
+    let creates = common::acl_mock::take_captured_ephemeral_permission_creates();
+    assert!(creates.is_empty(), "expected no CreateEphemeralPermission CPI");
+}
+
+/// A permission account that does not match ["permission:", group_receipt] is
+/// rejected before any CPI.
+#[tokio::test]
+#[serial]
+async fn deposit_and_queue_transfer_rejects_wrong_receipt_permission() {
+    let mut fixture = setup_fixture_with_acl_mock(None).await;
+    let group_id: u32 = 1;
+    let split: u32 = 2;
+    let group_receipt = pre_create_group_receipt(&mut fixture.context, fixture.queue, fixture.payer, group_id, split);
+    // Valid ACL PDA, but for the wrong permissioned account.
+    let wrong_permission = derive_group_receipt_permission(fixture.queue);
+
+    let ix = with_receipt_permission(
+        build_deposit_and_queue_ix(&fixture, 10, 0, 0, split, group_id, group_receipt),
+        wrong_permission,
+    );
+    let blockhash = fixture.context.banks_client.get_latest_blockhash().await.unwrap();
+    let tx = Transaction::new_signed_with_payer(&[ix], Some(&fixture.payer), &[&fixture.payer_kp], blockhash);
+    let err = fixture.context.banks_client.process_transaction(tx).await.unwrap_err();
+
+    assert_eq!(
+        err.unwrap(),
+        TransactionError::InstructionError(0, InstructionError::InvalidSeeds)
+    );
+
+    let creates = common::acl_mock::take_captured_ephemeral_permission_creates();
+    assert!(creates.is_empty(), "expected no CreateEphemeralPermission CPI");
+}
+
+/// A partial permission pair (13 accounts) must fail loudly instead of
+/// silently creating an unprotected receipt.
+#[tokio::test]
+#[serial]
+async fn deposit_and_queue_transfer_rejects_partial_permission_pair() {
+    let mut fixture = setup_fixture_with_acl_mock(None).await;
+    let group_id: u32 = 1;
+    let split: u32 = 2;
+    let group_receipt = pre_create_group_receipt(&mut fixture.context, fixture.queue, fixture.payer, group_id, split);
+    let permission = derive_group_receipt_permission(group_receipt);
+
+    let mut ix = build_deposit_and_queue_ix(&fixture, 10, 0, 0, split, group_id, group_receipt);
+    ix.accounts.push(AccountMeta::new(permission, false)); // 12: permission PDA without the program
+
+    let blockhash = fixture.context.banks_client.get_latest_blockhash().await.unwrap();
+    let tx = Transaction::new_signed_with_payer(&[ix], Some(&fixture.payer), &[&fixture.payer_kp], blockhash);
+    let err = fixture.context.banks_client.process_transaction(tx).await.unwrap_err();
+
+    assert_eq!(
+        err.unwrap(),
+        TransactionError::InstructionError(0, InstructionError::NotEnoughAccountKeys)
+    );
 }

--- a/e-token/tests/execute_transfer_callback.rs
+++ b/e-token/tests/execute_transfer_callback.rs
@@ -21,7 +21,7 @@ use utils::TestInternalInstruction as internal;
 use wheels::{layout::Encodable as _, variable_offset_layout};
 
 use crate::common::{
-    callback_mock,
+    acl_mock, callback_mock,
     callback_mock::take_execute_callbacks,
     magic_mock,
     magic_mock::{take_captured_ephemeral_closes, take_captured_ephemeral_creates},
@@ -124,6 +124,7 @@ async fn setup_context(
     pt.add_program("ephemeral_token_program", PROGRAM, None);
     magic_mock::add_mock(&mut pt);
     callback_mock::add_mock(&mut pt);
+    acl_mock::add_mock(&mut pt);
 
     let queue_data = queue_account_data(mint, validator.pubkey(), queue_bump);
     pt.add_account(
@@ -175,6 +176,8 @@ async fn setup_context(
     let ctx = pt.start_with_context().await;
 
     magic_mock::clear_all_captured(MAGIC_PROGRAM_ID);
+    acl_mock::clear_all_captured();
+    let _ = take_execute_callbacks();
 
     (ctx, validator, mint, queue, receipt, vault, vault_token, source)
 }
@@ -211,6 +214,11 @@ fn callback_executor_ix(
         group_id,
     );
 
+    callback_executor_ix_from(validator, callback_ix)
+}
+
+/// Wraps an inner callback instruction in the callback-executor instruction.
+fn callback_executor_ix_from(validator: Pubkey, callback_ix: Instruction) -> Instruction {
     // Mandatory accounts for magic-program
     let mut account_metas = vec![
         AccountMeta::new_readonly(validator, true),
@@ -231,6 +239,24 @@ fn callback_executor_ix(
         },
         account_metas,
     )
+}
+
+/// Derives the ACL permission PDA guarding the given group receipt.
+fn derive_group_receipt_permission(group_receipt: Pubkey) -> Pubkey {
+    Pubkey::find_program_address(
+        &[b"permission:", group_receipt.as_ref()],
+        &utils::permission_program_id(),
+    )
+    .0
+}
+
+/// Extends a 13-account callback instruction to the 15-account shape that also
+/// closes the group receipt's ACL permission.
+fn append_permission_accounts(mut ix: Instruction, permission: Pubkey) -> Instruction {
+    ix.accounts.push(AccountMeta::new(permission, false)); // 13: group_receipt_permission
+    ix.accounts
+        .push(AccountMeta::new_readonly(utils::permission_program_id(), false)); // 14: permission_program
+    ix
 }
 
 fn callback_ix(
@@ -367,6 +393,136 @@ async fn execute_callback_closes_receipt_when_last_transfer_with_pre_initialized
     assert!(creates.is_empty(), "expected no CreateEphemeralAccount CPI");
 
     // CloseEphemeralAccount must have been called once — this was the last transfer.
+    let closes = take_captured_ephemeral_closes(MAGIC_PROGRAM_ID);
+    assert_eq!(closes.len(), 1, "expected exactly one CloseEphemeralAccount CPI");
+}
+
+// ── group receipt permission ──────────────────────────────────────────────────
+
+/// Injects a non-empty ACL-owned permission account for the receipt, as
+/// created by the 14-account deposit shape.
+fn pre_create_receipt_permission(ctx: &mut solana_program_test::ProgramTestContext, permission: Pubkey) {
+    let data = vec![1u8; 71];
+    ctx.set_account(
+        &permission,
+        &SolanaAccount {
+            lamports: Rent::default().minimum_balance(data.len()),
+            data,
+            owner: utils::permission_program_id(),
+            executable: false,
+            rent_epoch: 0,
+        }
+        .into(),
+    );
+}
+
+/// 15-account shape, last transfer: the receipt's ACL permission is closed
+/// (rent refunded to the queue) alongside the receipt itself.
+#[tokio::test]
+#[serial]
+async fn execute_callback_closes_receipt_permission_when_last_transfer() {
+    let group_id: u32 = 1;
+    let splits: u32 = 1;
+
+    let receipt_data = receipt_account_data(group_id, splits, 0);
+    let (mut ctx, validator, mint, queue, receipt, vault, vault_token, source) =
+        setup_context(receipt_data, group_id).await;
+
+    // The permission close signs with the receipt PDA seeds, so the header
+    // must carry the real bump (the shared fixture stores 0).
+    let (_, receipt_bump) = utils::derive_group_receipt(queue, source, group_id);
+    ctx.set_account(
+        &receipt,
+        &SolanaAccount {
+            lamports: Rent::default().minimum_balance(GroupReceipt::required_size(splits as usize)),
+            data: receipt_account_data(group_id, splits, receipt_bump),
+            owner: PROGRAM,
+            executable: false,
+            rent_epoch: 0,
+        }
+        .into(),
+    );
+
+    let permission = derive_group_receipt_permission(receipt);
+    pre_create_receipt_permission(&mut ctx, permission);
+
+    let inner = append_permission_accounts(
+        callback_ix(
+            receipt,
+            queue,
+            vault,
+            mint,
+            vault_token,
+            source,
+            magic_fee_vault_pubkey(validator.pubkey()),
+            MAGIC_CONTEXT_ID,
+            true,
+            200,
+            group_id,
+        ),
+        permission,
+    );
+    let ix = callback_executor_ix_from(validator.pubkey(), inner);
+
+    let tx = Transaction::new_signed_with_payer(&[ix], Some(&validator.pubkey()), &[&validator], ctx.last_blockhash);
+    let res = ctx.banks_client.process_transaction_with_metadata(tx).await.unwrap();
+    res.result.unwrap();
+
+    let permission_closes = acl_mock::take_captured_ephemeral_permission_closes();
+    assert_eq!(
+        permission_closes.len(),
+        1,
+        "expected exactly one CloseEphemeralPermission CPI"
+    );
+    let close = &permission_closes[0];
+    assert_eq!(close.payer, queue, "rent must refund to the queue");
+    assert_eq!(close.permissioned_account, receipt);
+    assert_eq!(close.permission, permission);
+
+    // The receipt itself must still be closed.
+    let closes = take_captured_ephemeral_closes(MAGIC_PROGRAM_ID);
+    assert_eq!(closes.len(), 1, "expected exactly one CloseEphemeralAccount CPI");
+}
+
+/// 15-account shape, legacy receipt (created without a permission): the close
+/// is skipped and the callback still completes.
+#[tokio::test]
+#[serial]
+async fn execute_callback_skips_permission_close_for_legacy_receipt() {
+    let group_id: u32 = 1;
+    let splits: u32 = 1;
+
+    let receipt_data = receipt_account_data(group_id, splits, 0);
+    let (ctx, validator, mint, queue, receipt, vault, vault_token, source) =
+        setup_context(receipt_data, group_id).await;
+    // Permission account intentionally not created (data_len == 0).
+    let permission = derive_group_receipt_permission(receipt);
+
+    let inner = append_permission_accounts(
+        callback_ix(
+            receipt,
+            queue,
+            vault,
+            mint,
+            vault_token,
+            source,
+            magic_fee_vault_pubkey(validator.pubkey()),
+            MAGIC_CONTEXT_ID,
+            true,
+            200,
+            group_id,
+        ),
+        permission,
+    );
+    let ix = callback_executor_ix_from(validator.pubkey(), inner);
+
+    let tx = Transaction::new_signed_with_payer(&[ix], Some(&validator.pubkey()), &[&validator], ctx.last_blockhash);
+    let res = ctx.banks_client.process_transaction_with_metadata(tx).await.unwrap();
+    res.result.unwrap();
+
+    let permission_closes = acl_mock::take_captured_ephemeral_permission_closes();
+    assert!(permission_closes.is_empty(), "expected no CloseEphemeralPermission CPI");
+
     let closes = take_captured_ephemeral_closes(MAGIC_PROGRAM_ID);
     assert_eq!(closes.len(), 1, "expected exactly one CloseEphemeralAccount CPI");
 }

--- a/e-token/tests/execute_transfer_callback.rs
+++ b/e-token/tests/execute_transfer_callback.rs
@@ -240,15 +240,6 @@ fn callback_executor_ix_from(validator: Pubkey, callback_ix: Instruction) -> Ins
     )
 }
 
-/// Derives the ACL permission PDA guarding the given group receipt.
-fn derive_group_receipt_permission(group_receipt: Pubkey) -> Pubkey {
-    Pubkey::find_program_address(
-        &[b"permission:", group_receipt.as_ref()],
-        &utils::permission_program_id(),
-    )
-    .0
-}
-
 /// Extends a 13-account callback instruction to the 15-account shape that also
 /// closes the group receipt's ACL permission.
 fn append_permission_accounts(mut ix: Instruction, permission: Pubkey) -> Instruction {
@@ -398,23 +389,6 @@ async fn execute_callback_closes_receipt_when_last_transfer_with_pre_initialized
 
 // ── group receipt permission ──────────────────────────────────────────────────
 
-/// Injects a non-empty ACL-owned permission account for the receipt, as
-/// created by the 14-account deposit shape.
-fn pre_create_receipt_permission(ctx: &mut solana_program_test::ProgramTestContext, permission: Pubkey) {
-    let data = vec![1u8; 71];
-    ctx.set_account(
-        &permission,
-        &SolanaAccount {
-            lamports: Rent::default().minimum_balance(data.len()),
-            data,
-            owner: utils::permission_program_id(),
-            executable: false,
-            rent_epoch: 0,
-        }
-        .into(),
-    );
-}
-
 /// 15-account shape, last transfer: the receipt's ACL permission is closed
 /// (rent refunded to the queue) alongside the receipt itself.
 #[tokio::test]
@@ -443,8 +417,8 @@ async fn execute_callback_closes_receipt_permission_when_last_transfer() {
         .into(),
     );
 
-    let permission = derive_group_receipt_permission(receipt);
-    pre_create_receipt_permission(&mut ctx, permission);
+    let permission = utils::derive_group_receipt_permission(receipt);
+    utils::pre_create_receipt_permission(&mut ctx, permission);
 
     let inner = append_permission_accounts(
         callback_ix(
@@ -497,7 +471,7 @@ async fn execute_callback_skips_permission_close_for_legacy_receipt() {
         setup_context(receipt_data, group_id).await;
     acl_mock::clear_all_captured();
     // Permission account intentionally not created (data_len == 0).
-    let permission = derive_group_receipt_permission(receipt);
+    let permission = utils::derive_group_receipt_permission(receipt);
 
     let inner = append_permission_accounts(
         callback_ix(

--- a/e-token/tests/execute_transfer_callback.rs
+++ b/e-token/tests/execute_transfer_callback.rs
@@ -176,7 +176,6 @@ async fn setup_context(
     let ctx = pt.start_with_context().await;
 
     magic_mock::clear_all_captured(MAGIC_PROGRAM_ID);
-    acl_mock::clear_all_captured();
     let _ = take_execute_callbacks();
 
     (ctx, validator, mint, queue, receipt, vault, vault_token, source)
@@ -427,6 +426,7 @@ async fn execute_callback_closes_receipt_permission_when_last_transfer() {
     let receipt_data = receipt_account_data(group_id, splits, 0);
     let (mut ctx, validator, mint, queue, receipt, vault, vault_token, source) =
         setup_context(receipt_data, group_id).await;
+    acl_mock::clear_all_captured();
 
     // The permission close signs with the receipt PDA seeds, so the header
     // must carry the real bump (the shared fixture stores 0).
@@ -495,6 +495,7 @@ async fn execute_callback_skips_permission_close_for_legacy_receipt() {
     let receipt_data = receipt_account_data(group_id, splits, 0);
     let (ctx, validator, mint, queue, receipt, vault, vault_token, source) =
         setup_context(receipt_data, group_id).await;
+    acl_mock::clear_all_captured();
     // Permission account intentionally not created (data_len == 0).
     let permission = derive_group_receipt_permission(receipt);
 

--- a/e-token/tests/execute_transfer_callback.rs
+++ b/e-token/tests/execute_transfer_callback.rs
@@ -87,9 +87,9 @@ fn queue_account_data(mint: Pubkey, validator: Pubkey, bump: u8) -> Vec<u8> {
 }
 
 /// Build a pre-initialised group receipt buffer.
-fn receipt_account_data(group_id: u32, splits: u32, bump: u8) -> Vec<u8> {
+fn receipt_account_data(group_id: u32, splits: u32, receipt_bump: u8) -> Vec<u8> {
     let mut data = vec![0u8; GroupReceipt::required_size(splits as usize)];
-    let header = GroupReceiptHeader::new(group_id, bump, splits);
+    let header = GroupReceiptHeader::new(group_id, receipt_bump, splits);
     data[..GroupReceiptHeader::SIZE].copy_from_slice(bytemuck::bytes_of(&header));
     data
 }
@@ -97,8 +97,8 @@ fn receipt_account_data(group_id: u32, splits: u32, bump: u8) -> Vec<u8> {
 /// Common fixture: a ProgramTest context with queue and receipt accounts
 /// pre-populated. Returns (context, validator keypair, mint, queue, receipt, vault, vault_token, source).
 async fn setup_context(
-    receipt_data: Vec<u8>,
     group_id: u32,
+    splits: u32,
 ) -> (
     solana_program_test::ProgramTestContext,
     Keypair,
@@ -113,7 +113,8 @@ async fn setup_context(
     let mint = Keypair::new().pubkey();
     let source = Keypair::new().pubkey();
     let (queue, queue_bump) = derive_queue(mint, validator.pubkey());
-    let (receipt, _) = utils::derive_group_receipt(queue, source, group_id);
+    let (receipt, receipt_bump) = utils::derive_group_receipt(queue, source, group_id);
+    let receipt_data = receipt_account_data(group_id, splits, receipt_bump);
     let vault = Keypair::new().pubkey();
     let vault_token = utils::derive_associated_token_address(vault, mint);
 
@@ -296,9 +297,7 @@ async fn execute_callback_with_pre_initialized_receipt_no_magic_cpi() {
 
     // Pre-create receipt as if magic program already created it and
     // process_initialize_group_receipt ran.
-    let receipt_data = receipt_account_data(group_id, splits, 0);
-    let (ctx, validator, mint, queue, receipt, vault, vault_token, source) =
-        setup_context(receipt_data, group_id).await;
+    let (ctx, validator, mint, queue, receipt, vault, vault_token, source) = setup_context(group_id, splits).await;
 
     // Simulate deposit_and_queue_transfer having already run (receipt is owned
     // by PROGRAM with splits set). Now shoot the callback directly.
@@ -353,9 +352,7 @@ async fn execute_callback_closes_receipt_when_last_transfer_with_pre_initialized
     let group_id: u32 = 1;
     let splits: u32 = 1;
 
-    let receipt_data = receipt_account_data(group_id, splits, 0);
-    let (ctx, validator, mint, queue, receipt, vault, vault_token, source) =
-        setup_context(receipt_data, group_id).await;
+    let (ctx, validator, mint, queue, receipt, vault, vault_token, source) = setup_context(group_id, splits).await;
 
     let ix = callback_executor_ix(
         validator.pubkey(),
@@ -397,25 +394,8 @@ async fn execute_callback_closes_receipt_permission_when_last_transfer() {
     let group_id: u32 = 1;
     let splits: u32 = 1;
 
-    let receipt_data = receipt_account_data(group_id, splits, 0);
-    let (mut ctx, validator, mint, queue, receipt, vault, vault_token, source) =
-        setup_context(receipt_data, group_id).await;
+    let (mut ctx, validator, mint, queue, receipt, vault, vault_token, source) = setup_context(group_id, splits).await;
     acl_mock::clear_all_captured();
-
-    // The permission close signs with the receipt PDA seeds, so the header
-    // must carry the real bump (the shared fixture stores 0).
-    let (_, receipt_bump) = utils::derive_group_receipt(queue, source, group_id);
-    ctx.set_account(
-        &receipt,
-        &SolanaAccount {
-            lamports: Rent::default().minimum_balance(GroupReceipt::required_size(splits as usize)),
-            data: receipt_account_data(group_id, splits, receipt_bump),
-            owner: PROGRAM,
-            executable: false,
-            rent_epoch: 0,
-        }
-        .into(),
-    );
 
     let permission = utils::derive_group_receipt_permission(receipt);
     utils::pre_create_receipt_permission(&mut ctx, permission);
@@ -466,9 +446,7 @@ async fn execute_callback_skips_permission_close_for_legacy_receipt() {
     let group_id: u32 = 1;
     let splits: u32 = 1;
 
-    let receipt_data = receipt_account_data(group_id, splits, 0);
-    let (ctx, validator, mint, queue, receipt, vault, vault_token, source) =
-        setup_context(receipt_data, group_id).await;
+    let (ctx, validator, mint, queue, receipt, vault, vault_token, source) = setup_context(group_id, splits).await;
     acl_mock::clear_all_captured();
     // Permission account intentionally not created (data_len == 0).
     let permission = utils::derive_group_receipt_permission(receipt);

--- a/e-token/tests/utils.rs
+++ b/e-token/tests/utils.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 
 use ephemeral_rollups_pinocchio::{
-    acl::permission_pda_from_permissioned_account,
+    acl::{permission_pda_from_permissioned_account, EphemeralPermission},
     pda::{
         delegate_buffer_pda_from_delegated_account_and_owner_program, delegation_metadata_pda_from_delegated_account,
         delegation_record_pda_from_delegated_account,
@@ -136,6 +136,28 @@ pub fn permission_program_id() -> Pubkey {
         .try_into()
         .expect("PERMISSION_PROGRAM_ID must be 32 bytes");
     Pubkey::new_from_array(bytes)
+}
+
+/// Derives the ACL permission PDA guarding the given group receipt.
+pub fn derive_group_receipt_permission(group_receipt: Pubkey) -> Pubkey {
+    permission_pda_from_permissioned_account(&group_receipt)
+}
+
+/// Injects a non-empty ACL-owned receipt permission account into the test context.
+pub fn pre_create_receipt_permission(context: &mut ProgramTestContext, permission: Pubkey) {
+    let data = vec![1u8; EphemeralPermission::size_of(0)];
+    let rent = Rent::default();
+    context.set_account(
+        &permission,
+        &Account {
+            lamports: rent.minimum_balance(data.len()),
+            data,
+            owner: permission_program_id(),
+            executable: false,
+            rent_epoch: 0,
+        }
+        .into(),
+    );
 }
 
 /// Load a BPF `.so` from `tests/fixtures` (or `BPF_OUT_DIR`) as an executable account.

--- a/e-token/tests/utils.rs
+++ b/e-token/tests/utils.rs
@@ -156,10 +156,19 @@ pub fn add_executable_bpf_fixture(pt: &mut ProgramTest, program_address: Pubkey,
 
 /// Prefer BPF, fund [`fixed_payer_keypair`] at genesis, add the SPL ATA mock, and load `acl.so` / `dlp.so`.
 pub fn configure_standard_program_test(pt: &mut ProgramTest) {
+    configure_standard_program_test_with_acl(pt, true);
+}
+
+/// Same as [`configure_standard_program_test`] with `acl.so` optional, for test
+/// binaries that register a native ACL mock at the same address instead (the
+/// fixture binary predates ephemeral permissions).
+pub fn configure_standard_program_test_with_acl(pt: &mut ProgramTest, include_acl_fixture: bool) {
     pt.prefer_bpf(true);
     fund_fixed_payer_genesis(pt);
     add_associated_token_program(pt);
-    add_executable_bpf_fixture(pt, permission_program_id(), "tests/fixtures/acl.so");
+    if include_acl_fixture {
+        add_executable_bpf_fixture(pt, permission_program_id(), "tests/fixtures/acl.so");
+    }
     add_executable_bpf_fixture(pt, ephemeral_rollups_pinocchio::ID, "tests/fixtures/dlp.so");
 }
 
@@ -176,12 +185,22 @@ pub async fn start_program_test_with<F: FnOnce(&mut ProgramTest)>(
     program_id: Pubkey,
     configure: F,
 ) -> ProgramTestContext {
+    start_program_test_with_acl_and(program_id, true, configure).await
+}
+
+/// Same as [`start_program_test_with`] with `acl.so` optional; pass `false` and
+/// register a native ACL mock in `configure` to test ephemeral permissions.
+pub async fn start_program_test_with_acl_and<F: FnOnce(&mut ProgramTest)>(
+    program_id: Pubkey,
+    include_acl_fixture: bool,
+    configure: F,
+) -> ProgramTestContext {
     // `ProgramTest::new` calls `add_program` before any `prefer_bpf` override; default `prefer_bpf`
     // is false unless BPF_OUT_DIR is set, so the main program would hit "processor not available".
     let mut pt = ProgramTest::default();
     pt.prefer_bpf(true);
     pt.add_program("ephemeral_token_program", program_id, None);
-    configure_standard_program_test(&mut pt);
+    configure_standard_program_test_with_acl(&mut pt, include_acl_fixture);
     configure(&mut pt);
     pt.start_with_context().await
 }

--- a/idl/ephemeral_spl_token.json
+++ b/idl/ephemeral_spl_token.json
@@ -698,8 +698,9 @@
         16
       ],
       "docs": [
-        "Deposits into the global vault and enqueues one or more delayed transfers.",
-        "Instruction data: [0..8] amount, [8..16] min_delay_ms, [16..24] max_delay_ms, [24..28] split, optionally [28] flags."
+        "Deposits into the vault and enqueues one or more delayed transfers.",
+        "Instruction data: [0..8] amount, [8..16] min_delay_ms, [16..24] max_delay_ms, [24..28] split, optionally [28] flags.",
+        "groupReceiptPermission + permissionProgram create a private ACL permission on the group receipt; legacy clients may omit both trailing accounts (12-account shape)."
       ],
       "accounts": [
         {
@@ -721,7 +722,7 @@
           "writable": true
         },
         {
-          "name": "destinationTokenOrOwner"
+          "name": "destinationOwner"
         },
         {
           "name": "userAuthority",
@@ -731,8 +732,26 @@
           "name": "tokenProgram"
         },
         {
-          "name": "shuttleWalletAta",
+          "name": "reimbursementToken",
           "writable": true
+        },
+        {
+          "name": "groupReceipt",
+          "writable": true
+        },
+        {
+          "name": "magicVault",
+          "writable": true
+        },
+        {
+          "name": "magicProgram"
+        },
+        {
+          "name": "groupReceiptPermission",
+          "writable": true
+        },
+        {
+          "name": "permissionProgram"
         }
       ],
       "args": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Private and queued transfer flows now support group-receipt ACL permissions.
  - Deposit and callback processing were extended to accept an expanded permission account shape and correctly create/reuse/close permissions as needed.

- **Bug Fixes**
  - Improved validation for missing, partial, or mismatched permission account pairs (fails early with clearer errors).
  - Legacy (shorter) receipt formats remain supported.

- **Documentation**
  - Updated `depositAndQueueTransfer` instruction ABI and account list, including renamed fields and new permission-related accounts.

- **Tests**
  - Added ACL-mock coverage for deposit permission behavior and transaction permission wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->